### PR TITLE
fix: type names for collections such as List<FilePayload>

### DIFF
--- a/java/docs/api/class-accessibility.mdx
+++ b/java/docs/api/class-accessibility.mdx
@@ -17,7 +17,7 @@ Most of the accessibility tree gets filtered out when converting from internal b
 - [Accessibility.snapshot([options])](./api/class-accessibility.mdx#accessibilitysnapshotoptions)
 
 ## Accessibility.snapshot([options])
-- `options` `new Accessibility.SnapshotOptions()`
+- `options` <`Accessibility.SnapshotOptions`>
   - `interestingOnly` <[boolean]> Prune uninteresting nodes from the tree. Defaults to `true`.
   - `root` <[ElementHandle]> The root DOM element for the snapshot. Defaults to the whole page.
 - returns: <[null]|[String]>

--- a/java/docs/api/class-browser.mdx
+++ b/java/docs/api/class-browser.mdx
@@ -42,18 +42,18 @@ Returns an array of all open browser contexts. In a newly created browser, this 
 Indicates that the browser is connected.
 
 ## Browser.newContext([options])
-- `options` `new Browser.NewContextOptions()`
+- `options` <`Browser.NewContextOptions`>
   - `acceptDownloads` <[boolean]> Whether to automatically download all the attachments. Defaults to `false` where all the downloads are canceled.
   - `bypassCSP` <[boolean]> Toggles bypassing page's Content-Security-Policy.
   - `colorScheme` <"light"|"dark"|"no-preference"> Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. See [Page.emulateMedia([options])](./api/class-page.mdx#pageemulatemediaoptions) for more details. Defaults to '`light`'.
   - `deviceScaleFactor` <[double]> Specify device scale factor (can be thought of as dpr). Defaults to `1`.
   - `extraHTTPHeaders` <[Map]<[String], [String]>> An object containing additional HTTP headers to be sent with every request. All header values must be strings.
-  - `geolocation` `new Geolocation()`
+  - `geolocation` <`Geolocation`>
     - `latitude` <[double]> Latitude between -90 and 90.
     - `longitude` <[double]> Longitude between -180 and 180.
     - `accuracy` <[double]> Non-negative accuracy value. Defaults to `0`.
   - `hasTouch` <[boolean]> Specifies if viewport supports touch events. Defaults to false.
-  - `httpCredentials` `new HttpCredentials()` Credentials for [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
+  - `httpCredentials` <`HttpCredentials`> Credentials for [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
     - `username` <[String]>
     - `password` <[String]>
   - `ignoreHTTPSErrors` <[boolean]> Whether to ignore HTTPS errors during navigation. Defaults to `false`.
@@ -62,7 +62,7 @@ Indicates that the browser is connected.
   - `locale` <[String]> Specify user locale, for example `en-GB`, `de-DE`, etc. Locale will affect `navigator.language` value, `Accept-Language` request header value as well as number and date formatting rules.
   - `offline` <[boolean]> Whether to emulate network being offline. Defaults to `false`.
   - `permissions` <[List]<[String]>> A list of permissions to grant to all pages in this context. See [BrowserContext.grantPermissions(permissions[, options])](./api/class-browsercontext.mdx#browsercontextgrantpermissionspermissions-options) for more details.
-  - `proxy` `new Proxy()` Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
+  - `proxy` <`Proxy`> Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
     - `server` <[String]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
     - `bypass` <[String]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
     - `username` <[String]> Optional username to use if HTTP proxy requires authentication.
@@ -70,14 +70,14 @@ Indicates that the browser is connected.
   - `recordHarOmitContent` <[boolean]> Optional setting to control whether to omit request content from the HAR. Defaults to `false`.
   - `recordHarPath` <[Path]> Path on the filesystem to write the HAR file to.
   - `recordVideoDir` <[Path]> Path to the directory to put videos into.
-  - `recordVideoSize` `new RecordVideoSize()` Dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of each page will be scaled down if necessary to fit the specified size.
+  - `recordVideoSize` <`RecordVideoSize`> Dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of each page will be scaled down if necessary to fit the specified size.
     - `width` <[int]> Video frame width.
     - `height` <[int]> Video frame height.
   - `storageState` <[String]> Populates context with given storage state. This option can be used to initialize context with logged-in information obtained via [BrowserContext.storageState([options])](./api/class-browsercontext.mdx#browsercontextstoragestateoptions).
   - `storageStatePath` <[Path]> Populates context with given storage state. This option can be used to initialize context with logged-in information obtained via [BrowserContext.storageState([options])](./api/class-browsercontext.mdx#browsercontextstoragestateoptions). Path to the file with saved storage state.
   - `timezoneId` <[String]> Changes the timezone of the context. See [ICU's metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs.
   - `userAgent` <[String]> Specific user agent to use in this context.
-  - `viewportSize` <[null]|[Map]> Sets a consistent viewport for each page. Defaults to an 1280x720 viewport. `null` disables the default viewport.
+  - `viewportSize` <[null]|`ViewportSize`> Sets a consistent viewport for each page. Defaults to an 1280x720 viewport. `null` disables the default viewport.
     - `width` <[int]> page width in pixels.
     - `height` <[int]> page height in pixels.
 - returns: <[BrowserContext]>
@@ -85,18 +85,18 @@ Indicates that the browser is connected.
 Creates a new browser context. It won't share cookies/cache with other browser contexts.
 
 ## Browser.newPage([options])
-- `options` `new Browser.NewPageOptions()`
+- `options` <`Browser.NewPageOptions`>
   - `acceptDownloads` <[boolean]> Whether to automatically download all the attachments. Defaults to `false` where all the downloads are canceled.
   - `bypassCSP` <[boolean]> Toggles bypassing page's Content-Security-Policy.
   - `colorScheme` <"light"|"dark"|"no-preference"> Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. See [Page.emulateMedia([options])](./api/class-page.mdx#pageemulatemediaoptions) for more details. Defaults to '`light`'.
   - `deviceScaleFactor` <[double]> Specify device scale factor (can be thought of as dpr). Defaults to `1`.
   - `extraHTTPHeaders` <[Map]<[String], [String]>> An object containing additional HTTP headers to be sent with every request. All header values must be strings.
-  - `geolocation` `new Geolocation()`
+  - `geolocation` <`Geolocation`>
     - `latitude` <[double]> Latitude between -90 and 90.
     - `longitude` <[double]> Longitude between -180 and 180.
     - `accuracy` <[double]> Non-negative accuracy value. Defaults to `0`.
   - `hasTouch` <[boolean]> Specifies if viewport supports touch events. Defaults to false.
-  - `httpCredentials` `new HttpCredentials()` Credentials for [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
+  - `httpCredentials` <`HttpCredentials`> Credentials for [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
     - `username` <[String]>
     - `password` <[String]>
   - `ignoreHTTPSErrors` <[boolean]> Whether to ignore HTTPS errors during navigation. Defaults to `false`.
@@ -105,7 +105,7 @@ Creates a new browser context. It won't share cookies/cache with other browser c
   - `locale` <[String]> Specify user locale, for example `en-GB`, `de-DE`, etc. Locale will affect `navigator.language` value, `Accept-Language` request header value as well as number and date formatting rules.
   - `offline` <[boolean]> Whether to emulate network being offline. Defaults to `false`.
   - `permissions` <[List]<[String]>> A list of permissions to grant to all pages in this context. See [BrowserContext.grantPermissions(permissions[, options])](./api/class-browsercontext.mdx#browsercontextgrantpermissionspermissions-options) for more details.
-  - `proxy` `new Proxy()` Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
+  - `proxy` <`Proxy`> Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
     - `server` <[String]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
     - `bypass` <[String]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
     - `username` <[String]> Optional username to use if HTTP proxy requires authentication.
@@ -113,14 +113,14 @@ Creates a new browser context. It won't share cookies/cache with other browser c
   - `recordHarOmitContent` <[boolean]> Optional setting to control whether to omit request content from the HAR. Defaults to `false`.
   - `recordHarPath` <[Path]> Path on the filesystem to write the HAR file to.
   - `recordVideoDir` <[Path]> Path to the directory to put videos into.
-  - `recordVideoSize` `new RecordVideoSize()` Dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of each page will be scaled down if necessary to fit the specified size.
+  - `recordVideoSize` <`RecordVideoSize`> Dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of each page will be scaled down if necessary to fit the specified size.
     - `width` <[int]> Video frame width.
     - `height` <[int]> Video frame height.
   - `storageState` <[String]> Populates context with given storage state. This option can be used to initialize context with logged-in information obtained via [BrowserContext.storageState([options])](./api/class-browsercontext.mdx#browsercontextstoragestateoptions).
   - `storageStatePath` <[Path]> Populates context with given storage state. This option can be used to initialize context with logged-in information obtained via [BrowserContext.storageState([options])](./api/class-browsercontext.mdx#browsercontextstoragestateoptions). Path to the file with saved storage state.
   - `timezoneId` <[String]> Changes the timezone of the context. See [ICU's metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs.
   - `userAgent` <[String]> Specific user agent to use in this context.
-  - `viewportSize` <[null]|[Map]> Sets a consistent viewport for each page. Defaults to an 1280x720 viewport. `null` disables the default viewport.
+  - `viewportSize` <[null]|`ViewportSize`> Sets a consistent viewport for each page. Defaults to an 1280x720 viewport. `null` disables the default viewport.
     - `width` <[int]> page width in pixels.
     - `height` <[int]> page height in pixels.
 - returns: <[Page]>

--- a/java/docs/api/class-browsercontext.mdx
+++ b/java/docs/api/class-browsercontext.mdx
@@ -56,7 +56,7 @@ Use [Page.waitForLoadState([state, options])](./api/class-page.mdx#pagewaitforlo
 :::
 
 ## BrowserContext.addCookies(cookies)
-- `cookies` <[List]<[Map]>>
+- `cookies` <[List]<`Cookie`>>
   - `name` <[String]>
   - `value` <[String]>
   - `url` <[String]> either url or domain / path are required. Optional.
@@ -112,7 +112,7 @@ The default browser context cannot be closed.
 
 ## BrowserContext.cookies([urls])
 - `urls` <[String]|[List]<[String]>> Optional list of URLs.
-- returns: <[List]<[Map]>>
+- returns: <[List]<`Cookie`>>
   - `name` <[String]>
   - `value` <[String]>
   - `domain` <[String]>
@@ -127,7 +127,7 @@ If no URLs are specified, this method returns all cookies. If URLs are specified
 ## BrowserContext.exposeBinding(name, callback[, options])
 - `name` <[String]> Name of the function on the window object.
 - `callback` <[Predicate]> Callback function that will be called in the Playwright's context.
-- `options` `new BrowserContext.ExposeBindingOptions()`
+- `options` <`BrowserContext.ExposeBindingOptions`>
   - `handle` <[boolean]> Whether to pass the argument as a handle, instead of passing by value. When passing a handle, only one argument is supported. When passing by value, multiple arguments are supported.
 
 The method adds a function called `name` on the `window` object of every frame in every page in the context. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`. If the `callback` returns a [Promise], it will be awaited.
@@ -170,7 +170,7 @@ An example of adding an `md5` function to all pages in the context:
   * `'clipboard-read'`
   * `'clipboard-write'`
   * `'payment-handler'`
-- `options` `new BrowserContext.GrantPermissionsOptions()`
+- `options` <`BrowserContext.GrantPermissionsOptions`>
   - `origin` <[String]> The [origin] to grant permissions to, e.g. "https://example.com".
 
 Grants specified permissions to the browser context. Only grants corresponding permissions to the given origin if specified.
@@ -235,7 +235,7 @@ The extra HTTP headers will be sent with every request initiated by any page in 
 :::
 
 ## BrowserContext.setGeolocation(geolocation)
-- `geolocation` <[null]|[Map]>
+- `geolocation` <[null]|`Geolocation`>
   - `latitude` <[double]> Latitude between -90 and 90.
   - `longitude` <[double]> Longitude between -180 and 180.
   - `accuracy` <[double]> Non-negative accuracy value. Defaults to `0`.
@@ -250,7 +250,7 @@ Consider using [BrowserContext.grantPermissions(permissions[, options])](./api/c
 - `offline` <[boolean]> Whether to emulate network being offline for the browser context.
 
 ## BrowserContext.storageState([options])
-- `options` `new BrowserContext.StorageStateOptions()`
+- `options` <`BrowserContext.StorageStateOptions`>
   - `path` <[Path]> The file path to save the storage state to. If `path` is a relative path, then it is resolved relative to current working directory. If no path is provided, storage state is still returned, but won't be saved to the disk.
 - returns: <[String]>
 
@@ -263,7 +263,7 @@ Returns storage state for this browser context, contains current cookies and loc
 Removes a route created with [BrowserContext.route(url, handler)](./api/class-browsercontext.mdx#browsercontextrouteurl-handler). When `handler` is not specified, removes all routes for the `url`.
 
 ## BrowserContext.waitForPage([options, callback])
-- `options` `new BrowserContext.WaitForPageOptions()`
+- `options` <`BrowserContext.WaitForPageOptions`>
   - `predicate` <[function]\([Page]\):[boolean]> Receives the [Page] object and resolves to truthy value when the waiting should resolve.
   - `timeout` <[double]> Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - `callback` <[Runnable]> Callback that performs the action triggering the event.

--- a/java/docs/api/class-browsertype.mdx
+++ b/java/docs/api/class-browsertype.mdx
@@ -19,7 +19,7 @@ BrowserType provides methods to launch a specific browser instance or connect to
 A path where Playwright expects to find a bundled browser executable.
 
 ## BrowserType.launch([options])
-- `options` `new BrowserType.LaunchOptions()`
+- `options` <`BrowserType.LaunchOptions`>
   - `args` <[List]<[String]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
   - `chromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `false`.
   - `devtools` <[boolean]> **Chromium-only** Whether to auto-open a Developer Tools panel for each tab. If this option is `true`, the `headless` option will be set `false`.
@@ -33,7 +33,7 @@ A path where Playwright expects to find a bundled browser executable.
   - `headless` <[boolean]> Whether to run browser in headless mode. More details for [Chromium](https://developers.google.com/web/updates/2017/04/headless-chrome) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode). Defaults to `true` unless the `devtools` option is `true`.
   - `ignoreAllDefaultArgs` <[boolean]> If `true`, Playwright does not pass its own configurations args and only uses the ones from `args`. Dangerous option; use with care. Defaults to `false`.
   - `ignoreDefaultArgs` <[List]<[String]>> If `true`, Playwright does not pass its own configurations args and only uses the ones from `args`. Dangerous option; use with care.
-  - `proxy` `new Proxy()` Network proxy settings.
+  - `proxy` <`Proxy`> Network proxy settings.
     - `server` <[String]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
     - `bypass` <[String]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
     - `username` <[String]> Optional username to use if HTTP proxy requires authentication.
@@ -54,7 +54,7 @@ You can use `ignoreDefaultArgs` to filter out `--mute-audio` from default argume
 
 ## BrowserType.launchPersistentContext(userDataDir[, options])
 - `userDataDir` <[Path]> Path to a User Data Directory, which stores browser session data like cookies and local storage. More details for [Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md#introduction) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options#User_Profile). Note that Chromium's user data directory is the **parent** directory of the "Profile Path" seen at `chrome://version`.
-- `options` `new BrowserType.LaunchPersistentContextOptions()`
+- `options` <`BrowserType.LaunchPersistentContextOptions`>
   - `acceptDownloads` <[boolean]> Whether to automatically download all the attachments. Defaults to `false` where all the downloads are canceled.
   - `args` <[List]<[String]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
   - `bypassCSP` <[boolean]> Toggles bypassing page's Content-Security-Policy.
@@ -66,7 +66,7 @@ You can use `ignoreDefaultArgs` to filter out `--mute-audio` from default argume
   - `env` <[Map]<[String], [String]>> Specify environment variables that will be visible to the browser. Defaults to `process.env`.
   - `executablePath` <[Path]> Path to a browser executable to run instead of the bundled one. If `executablePath` is a relative path, then it is resolved relative to the current working directory. **BEWARE**: Playwright is only guaranteed to work with the bundled Chromium, Firefox or WebKit, use at your own risk.
   - `extraHTTPHeaders` <[Map]<[String], [String]>> An object containing additional HTTP headers to be sent with every request. All header values must be strings.
-  - `geolocation` `new Geolocation()`
+  - `geolocation` <`Geolocation`>
     - `latitude` <[double]> Latitude between -90 and 90.
     - `longitude` <[double]> Longitude between -180 and 180.
     - `accuracy` <[double]> Non-negative accuracy value. Defaults to `0`.
@@ -75,7 +75,7 @@ You can use `ignoreDefaultArgs` to filter out `--mute-audio` from default argume
   - `handleSIGTERM` <[boolean]> Close the browser process on SIGTERM. Defaults to `true`.
   - `hasTouch` <[boolean]> Specifies if viewport supports touch events. Defaults to false.
   - `headless` <[boolean]> Whether to run browser in headless mode. More details for [Chromium](https://developers.google.com/web/updates/2017/04/headless-chrome) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode). Defaults to `true` unless the `devtools` option is `true`.
-  - `httpCredentials` `new HttpCredentials()` Credentials for [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
+  - `httpCredentials` <`HttpCredentials`> Credentials for [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication).
     - `username` <[String]>
     - `password` <[String]>
   - `ignoreAllDefaultArgs` <[boolean]> If `true`, Playwright does not pass its own configurations args and only uses the ones from `args`. Dangerous option; use with care. Defaults to `false`.
@@ -86,7 +86,7 @@ You can use `ignoreDefaultArgs` to filter out `--mute-audio` from default argume
   - `locale` <[String]> Specify user locale, for example `en-GB`, `de-DE`, etc. Locale will affect `navigator.language` value, `Accept-Language` request header value as well as number and date formatting rules.
   - `offline` <[boolean]> Whether to emulate network being offline. Defaults to `false`.
   - `permissions` <[List]<[String]>> A list of permissions to grant to all pages in this context. See [BrowserContext.grantPermissions(permissions[, options])](./api/class-browsercontext.mdx#browsercontextgrantpermissionspermissions-options) for more details.
-  - `proxy` `new Proxy()` Network proxy settings.
+  - `proxy` <`Proxy`> Network proxy settings.
     - `server` <[String]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
     - `bypass` <[String]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
     - `username` <[String]> Optional username to use if HTTP proxy requires authentication.
@@ -94,14 +94,14 @@ You can use `ignoreDefaultArgs` to filter out `--mute-audio` from default argume
   - `recordHarOmitContent` <[boolean]> Optional setting to control whether to omit request content from the HAR. Defaults to `false`.
   - `recordHarPath` <[Path]> Path on the filesystem to write the HAR file to.
   - `recordVideoDir` <[Path]> Path to the directory to put videos into.
-  - `recordVideoSize` `new RecordVideoSize()` Dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of each page will be scaled down if necessary to fit the specified size.
+  - `recordVideoSize` <`RecordVideoSize`> Dimensions of the recorded videos. If not specified the size will be equal to `viewport` scaled down to fit into 800x800. If `viewport` is not configured explicitly the video size defaults to 800x450. Actual picture of each page will be scaled down if necessary to fit the specified size.
     - `width` <[int]> Video frame width.
     - `height` <[int]> Video frame height.
   - `slowMo` <[double]> Slows down Playwright operations by the specified amount of milliseconds. Useful so that you can see what is going on. Defaults to 0.
   - `timeout` <[double]> Maximum time in milliseconds to wait for the browser instance to start. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
   - `timezoneId` <[String]> Changes the timezone of the context. See [ICU's metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs.
   - `userAgent` <[String]> Specific user agent to use in this context.
-  - `viewportSize` <[null]|[Map]> Sets a consistent viewport for each page. Defaults to an 1280x720 viewport. `null` disables the default viewport.
+  - `viewportSize` <[null]|`ViewportSize`> Sets a consistent viewport for each page. Defaults to an 1280x720 viewport. `null` disables the default viewport.
     - `width` <[int]> page width in pixels.
     - `height` <[int]> page height in pixels.
 - returns: <[BrowserContext]>

--- a/java/docs/api/class-elementhandle.mdx
+++ b/java/docs/api/class-elementhandle.mdx
@@ -73,7 +73,7 @@ Elements from child frames return the bounding box relative to the main frame, u
 Assuming the page is static, it is safe to use bounding box coordinates to perform input. For example, the following snippet should click the center of the element.
 
 ## ElementHandle.check([options])
-- `options` `new ElementHandle.CheckOptions()`
+- `options` <`ElementHandle.CheckOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -91,14 +91,14 @@ If the element is detached from the DOM at any moment during the action, this me
 When all steps combined have not finished during the specified `timeout`, this method rejects with a [TimeoutError]. Passing zero timeout disables this.
 
 ## ElementHandle.click([options])
-- `options` `new ElementHandle.ClickOptions()`
+- `options` <`ElementHandle.ClickOptions`>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `clickCount` <[int]> defaults to 1. See [UIEvent.detail].
   - `delay` <[double]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -119,13 +119,13 @@ When all steps combined have not finished during the specified `timeout`, this m
 Returns the content frame for element handles referencing iframe nodes, or `null` otherwise
 
 ## ElementHandle.dblclick([options])
-- `options` `new ElementHandle.DblclickOptions()`
+- `options` <`ElementHandle.DblclickOptions`>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `delay` <[double]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -200,7 +200,7 @@ Examples:
 
 ## ElementHandle.fill(value[, options])
 - `value` <[String]> Value to set for the `<input>`, `<textarea>` or `[contenteditable]` element.
-- `options` `new ElementHandle.FillOptions()`
+- `options` <`ElementHandle.FillOptions`>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
@@ -217,10 +217,10 @@ Calls [focus](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
 Returns element attribute value.
 
 ## ElementHandle.hover([options])
-- `options` `new ElementHandle.HoverOptions()`
+- `options` <`ElementHandle.HoverOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -282,7 +282,7 @@ Returns the frame containing the given element.
 
 ## ElementHandle.press(key[, options])
 - `key` <[String]> Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
-- `options` `new ElementHandle.PressOptions()`
+- `options` <`ElementHandle.PressOptions`>
   - `delay` <[double]> Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -314,7 +314,7 @@ The method finds an element matching the specified selector in the `ElementHandl
 The method finds all elements matching the specified selector in the `ElementHandle`s subtree. See [Working with selectors](./selectors.mdx) for more details. If no elements match the selector, returns empty array.
 
 ## ElementHandle.screenshot([options])
-- `options` `new ElementHandle.ScreenshotOptions()`
+- `options` <`ElementHandle.ScreenshotOptions`>
   - `omitBackground` <[boolean]> Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images. Defaults to `false`.
   - `path` <[Path]> The file path to save the image to. The screenshot type will be inferred from file extension. If `path` is a relative path, then it is resolved relative to the current working directory. If no path is provided, the image won't be saved to the disk.
   - `quality` <[int]> The quality of the image, between 0-100. Not applicable to `png` images.
@@ -327,7 +327,7 @@ Returns the buffer with the captured screenshot.
 This method waits for the [actionability](./actionability.mdx) checks, then scrolls element into view before taking a screenshot. If the element is detached from DOM, the method throws an error.
 
 ## ElementHandle.scrollIntoViewIfNeeded([options])
-- `options` `new ElementHandle.ScrollIntoViewIfNeededOptions()`
+- `options` <`ElementHandle.ScrollIntoViewIfNeededOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
 This method waits for [actionability](./actionability.mdx) checks, then tries to scroll element into view, unless it is completely visible as defined by [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)'s `ratio`.
@@ -335,11 +335,11 @@ This method waits for [actionability](./actionability.mdx) checks, then tries to
 Throws when `elementHandle` does not point to an element [connected](https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected) to a Document or a ShadowRoot.
 
 ## ElementHandle.selectOption(values[, options])
-- `values` <[null]|[String]|[ElementHandle]|[List]<[String]>|[Map]|[List]<[ElementHandle]>|[List]<[Map]>> Options to select. If the `<select>` has the `multiple` attribute, all matching options are selected, otherwise only the first option matching one of the passed options is selected. String values are equivalent to `{value:'string'}`. Option is considered matching if all specified properties match.
+- `values` <[null]|[String]|[ElementHandle]|[List]<[String]>|`SelectOption`|[List]<[ElementHandle]>|[List]<`SelectOption`>> Options to select. If the `<select>` has the `multiple` attribute, all matching options are selected, otherwise only the first option matching one of the passed options is selected. String values are equivalent to `{value:'string'}`. Option is considered matching if all specified properties match.
   - `value` <[String]> Matches by `option.value`. Optional.
   - `label` <[String]> Matches by `option.label`. Optional.
   - `index` <[int]> Matches by the index. Optional.
-- `options` `new ElementHandle.SelectOptionOptions()`
+- `options` <`ElementHandle.SelectOptionOptions`>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[List]<[String]>>
@@ -351,17 +351,17 @@ Triggers a `change` and `input` event once all the provided options have been se
 Will wait until all specified options are present in the `<select>` element.
 
 ## ElementHandle.selectText([options])
-- `options` `new ElementHandle.SelectTextOptions()`
+- `options` <`ElementHandle.SelectTextOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
 This method waits for [actionability](./actionability.mdx) checks, then focuses the element and selects all its text content.
 
 ## ElementHandle.setInputFiles(files[, options])
-- `files` <[Path]|[List]<[Path]>|[Map]|[List]<[Map]>>
-  - `name` <[String]> [File] name
-  - `mimeType` <[String]> [File] type
+- `files` <[Path]|[List]<[Path]>|`FilePayload`|[List]<`FilePayload`>>
+  - `name` <[String]> File name
+  - `mimeType` <[String]> File type
   - `buffer` <[byte&#91;&#93;]> File content
-- `options` `new ElementHandle.SetInputFilesOptions()`
+- `options` <`ElementHandle.SetInputFilesOptions`>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
@@ -370,11 +370,11 @@ This method expects `elementHandle` to point to an [input element](https://devel
 Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then they are resolved relative to the the current working directory. For empty array, clears the selected files.
 
 ## ElementHandle.tap([options])
-- `options` `new ElementHandle.TapOptions()`
+- `options` <`ElementHandle.TapOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -400,7 +400,7 @@ Returns the `node.textContent`.
 
 ## ElementHandle.type(text[, options])
 - `text` <[String]> A text to type into a focused element.
-- `options` `new ElementHandle.TypeOptions()`
+- `options` <`ElementHandle.TypeOptions`>
   - `delay` <[double]> Time to wait between key presses in milliseconds. Defaults to 0.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -412,7 +412,7 @@ To press a special key, like `Control` or `ArrowDown`, use [ElementHandle.press(
 An example of typing into a text field and then submitting the form:
 
 ## ElementHandle.uncheck([options])
-- `options` `new ElementHandle.UncheckOptions()`
+- `options` <`ElementHandle.UncheckOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -431,7 +431,7 @@ When all steps combined have not finished during the specified `timeout`, this m
 
 ## ElementHandle.waitForElementState(state[, options])
 - `state` <"visible"|"hidden"|"stable"|"enabled"|"disabled"|"editable"> A state to wait for, see below for more details.
-- `options` `new ElementHandle.WaitForElementStateOptions()`
+- `options` <`ElementHandle.WaitForElementStateOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
 Returns when the element satisfies the `state`.
@@ -448,7 +448,7 @@ If the element does not satisfy the condition for the `timeout` milliseconds, th
 
 ## ElementHandle.waitForSelector(selector[, options])
 - `selector` <[String]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new ElementHandle.WaitForSelectorOptions()`
+- `options` <`ElementHandle.WaitForSelectorOptions`>
   - `state` <"attached"|"detached"|"visible"|"hidden"> Defaults to `'visible'`. Can be either:
     * `'attached'` - wait for element to be present in DOM.
     * `'detached'` - wait for element to not be present in DOM.

--- a/java/docs/api/class-filechooser.mdx
+++ b/java/docs/api/class-filechooser.mdx
@@ -29,11 +29,11 @@ Returns whether this file chooser accepts multiple files.
 Returns page this file chooser belongs to.
 
 ## FileChooser.setFiles(files[, options])
-- `files` <[Path]|[List]<[Path]>|[Map]|[List]<[Map]>>
-  - `name` <[String]> [File] name
-  - `mimeType` <[String]> [File] type
+- `files` <[Path]|[List]<[Path]>|`FilePayload`|[List]<`FilePayload`>>
+  - `name` <[String]> File name
+  - `mimeType` <[String]> File type
   - `buffer` <[byte&#91;&#93;]> File content
-- `options` `new FileChooser.SetFilesOptions()`
+- `options` <`FileChooser.SetFilesOptions`>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 

--- a/java/docs/api/class-frame.mdx
+++ b/java/docs/api/class-frame.mdx
@@ -64,7 +64,7 @@ An example of dumping frame tree:
 - [Frame.waitForTimeout(timeout)](./api/class-frame.mdx#framewaitfortimeouttimeout)
 
 ## Frame.addScriptTag([options])
-- `options` `new Frame.AddScriptTagOptions()`
+- `options` <`Frame.AddScriptTagOptions`>
   - `content` <[String]> Raw JavaScript content to be injected into frame.
   - `path` <[Path]> Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to the current working directory.
   - `type` <[String]> Script type. Use 'module' in order to load a Javascript ES6 module. See [script](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script) for more details.
@@ -76,7 +76,7 @@ Returns the added tag when the script's onload fires or when the script content 
 Adds a `<script>` tag into the page with the desired url or content.
 
 ## Frame.addStyleTag([options])
-- `options` `new Frame.AddStyleTagOptions()`
+- `options` <`Frame.AddStyleTagOptions`>
   - `content` <[String]> Raw CSS content to be injected into frame.
   - `path` <[Path]> Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to the current working directory.
   - `url` <[String]> URL of the `<link>` tag.
@@ -88,7 +88,7 @@ Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<s
 
 ## Frame.check(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.CheckOptions()`
+- `options` <`Frame.CheckOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -109,14 +109,14 @@ When all steps combined have not finished during the specified `timeout`, this m
 
 ## Frame.click(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.ClickOptions()`
+- `options` <`Frame.ClickOptions`>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `clickCount` <[int]> defaults to 1. See [UIEvent.detail].
   - `delay` <[double]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -137,13 +137,13 @@ Gets the full HTML contents of the frame, including the doctype.
 
 ## Frame.dblclick(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.DblclickOptions()`
+- `options` <`Frame.DblclickOptions`>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `delay` <[double]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -165,7 +165,7 @@ When all steps combined have not finished during the specified `timeout`, this m
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `type` <[String]> DOM event type: `"click"`, `"dragstart"`, etc.
 - `eventInit` <[Object]> Optional event-specific initialization properties.
-- `options` `new Frame.DispatchEventOptions()`
+- `options` <`Frame.DispatchEventOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
 The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the elment, `click` is dispatched. This is equivalend to calling [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
@@ -244,7 +244,7 @@ A string can also be passed in instead of a function.
 ## Frame.fill(selector, value[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `value` <[String]> Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
-- `options` `new Frame.FillOptions()`
+- `options` <`Frame.FillOptions`>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
@@ -254,7 +254,7 @@ To send fine-grained keyboard events, use [Frame.type(selector, text[, options])
 
 ## Frame.focus(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.FocusOptions()`
+- `options` <`Frame.FocusOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
 This method fetches an element with `selector` and focuses it. If there's no element matching `selector`, the method waits until a matching element appears in the DOM.
@@ -271,7 +271,7 @@ This method throws an error if the frame has been detached before `frameElement(
 ## Frame.getAttribute(selector, name[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `name` <[String]> Attribute name to get the value for.
-- `options` `new Frame.GetAttributeOptions()`
+- `options` <`Frame.GetAttributeOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[null]|[String]>
 
@@ -279,10 +279,10 @@ Returns element attribute value.
 
 ## Frame.hover(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.HoverOptions()`
+- `options` <`Frame.HoverOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -298,7 +298,7 @@ When all steps combined have not finished during the specified `timeout`, this m
 
 ## Frame.innerHTML(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.InnerHTMLOptions()`
+- `options` <`Frame.InnerHTMLOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[String]>
 
@@ -306,7 +306,7 @@ Returns `element.innerHTML`.
 
 ## Frame.innerText(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.InnerTextOptions()`
+- `options` <`Frame.InnerTextOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[String]>
 
@@ -314,7 +314,7 @@ Returns `element.innerText`.
 
 ## Frame.isChecked(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.IsCheckedOptions()`
+- `options` <`Frame.IsCheckedOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -327,7 +327,7 @@ Returns `true` if the frame has been detached, or `false` otherwise.
 
 ## Frame.isDisabled(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.IsDisabledOptions()`
+- `options` <`Frame.IsDisabledOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -335,7 +335,7 @@ Returns whether the element is disabled, the opposite of [enabled](./actionabili
 
 ## Frame.isEditable(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.IsEditableOptions()`
+- `options` <`Frame.IsEditableOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -343,7 +343,7 @@ Returns whether the element is [editable](./actionability.mdx#editable).
 
 ## Frame.isEnabled(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.IsEnabledOptions()`
+- `options` <`Frame.IsEnabledOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -351,7 +351,7 @@ Returns whether the element is [enabled](./actionability.mdx#enabled).
 
 ## Frame.isHidden(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.IsHiddenOptions()`
+- `options` <`Frame.IsHiddenOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -359,7 +359,7 @@ Returns whether the element is hidden, the opposite of [visible](./actionability
 
 ## Frame.isVisible(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.IsVisibleOptions()`
+- `options` <`Frame.IsVisibleOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -378,7 +378,7 @@ This value is calculated once when the frame is created, and will not update if 
 
 ## Frame.navigate(url[, options])
 - `url` <[String]> URL to navigate frame to. The url should include scheme, e.g. `https://`.
-- `options` `new Frame.NavigateOptions()`
+- `options` <`Frame.NavigateOptions`>
   - `referer` <[String]> Referer header value. If provided it will take preference over the referer header value set by [Page.setExtraHTTPHeaders(headers)](./api/class-page.mdx#pagesetextrahttpheadersheaders).
   - `timeout` <[double]> Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultNavigationTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaultnavigationtimeouttimeout), [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout), [Page.setDefaultNavigationTimeout(timeout)](./api/class-page.mdx#pagesetdefaultnavigationtimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
   - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider operation succeeded, defaults to `load`. Events can be either:
@@ -419,7 +419,7 @@ Parent frame, if any. Detached frames and main frames return `null`.
 ## Frame.press(selector, key[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `key` <[String]> Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
-- `options` `new Frame.PressOptions()`
+- `options` <`Frame.PressOptions`>
   - `delay` <[double]> Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -454,11 +454,11 @@ The method finds all elements matching the specified selector within the frame. 
 
 ## Frame.selectOption(selector, values[, options])
 - `selector` <[String]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
-- `values` <[null]|[String]|[ElementHandle]|[List]<[String]>|[Map]|[List]<[ElementHandle]>|[List]<[Map]>> Options to select. If the `<select>` has the `multiple` attribute, all matching options are selected, otherwise only the first option matching one of the passed options is selected. String values are equivalent to `{value:'string'}`. Option is considered matching if all specified properties match.
+- `values` <[null]|[String]|[ElementHandle]|[List]<[String]>|`SelectOption`|[List]<[ElementHandle]>|[List]<`SelectOption`>> Options to select. If the `<select>` has the `multiple` attribute, all matching options are selected, otherwise only the first option matching one of the passed options is selected. String values are equivalent to `{value:'string'}`. Option is considered matching if all specified properties match.
   - `value` <[String]> Matches by `option.value`. Optional.
   - `label` <[String]> Matches by `option.label`. Optional.
   - `index` <[int]> Matches by the index. Optional.
-- `options` `new Frame.SelectOptionOptions()`
+- `options` <`Frame.SelectOptionOptions`>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[List]<[String]>>
@@ -471,7 +471,7 @@ Will wait until all specified options are present in the `<select>` element.
 
 ## Frame.setContent(html[, options])
 - `html` <[String]> HTML markup to assign to the page.
-- `options` `new Frame.SetContentOptions()`
+- `options` <`Frame.SetContentOptions`>
   - `timeout` <[double]> Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultNavigationTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaultnavigationtimeouttimeout), [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout), [Page.setDefaultNavigationTimeout(timeout)](./api/class-page.mdx#pagesetdefaultnavigationtimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
   - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider operation succeeded, defaults to `load`. Events can be either:
     * `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
@@ -480,11 +480,11 @@ Will wait until all specified options are present in the `<select>` element.
 
 ## Frame.setInputFiles(selector, files[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `files` <[Path]|[List]<[Path]>|[Map]|[List]<[Map]>>
-  - `name` <[String]> [File] name
-  - `mimeType` <[String]> [File] type
+- `files` <[Path]|[List]<[Path]>|`FilePayload`|[List]<`FilePayload`>>
+  - `name` <[String]> File name
+  - `mimeType` <[String]> File type
   - `buffer` <[byte&#91;&#93;]> File content
-- `options` `new Frame.SetInputFilesOptions()`
+- `options` <`Frame.SetInputFilesOptions`>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
@@ -494,11 +494,11 @@ Sets the value of the file input to these file paths or files. If some of the `f
 
 ## Frame.tap(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.TapOptions()`
+- `options` <`Frame.TapOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -518,7 +518,7 @@ When all steps combined have not finished during the specified `timeout`, this m
 
 ## Frame.textContent(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.TextContentOptions()`
+- `options` <`Frame.TextContentOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[null]|[String]>
 
@@ -532,7 +532,7 @@ Returns the page title.
 ## Frame.type(selector, text[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `text` <[String]> A text to type into a focused element.
-- `options` `new Frame.TypeOptions()`
+- `options` <`Frame.TypeOptions`>
   - `delay` <[double]> Time to wait between key presses in milliseconds. Defaults to 0.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -543,7 +543,7 @@ To press a special key, like `Control` or `ArrowDown`, use [Keyboard.press(key[,
 
 ## Frame.uncheck(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.UncheckOptions()`
+- `options` <`Frame.UncheckOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -567,7 +567,7 @@ Returns frame's url.
 ## Frame.waitForFunction(expression[, arg, options])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
 - `arg` <[Object]> Optional argument to pass to `expression`.
-- `options` `new Frame.WaitForFunctionOptions()`
+- `options` <`Frame.WaitForFunctionOptions`>
   - `pollingInterval` <[double]> If specified, then it is treated as an interval in milliseconds at which the function would be executed. By default if the option is not specified `expression` is executed in `requestAnimationFrame` callback.
   - `timeout` <[double]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - returns: <[JSHandle]>
@@ -583,7 +583,7 @@ To pass an argument to the predicate of `frame.waitForFunction` function:
   * `'load'` - wait for the `load` event to be fired.
   * `'domcontentloaded'` - wait for the `DOMContentLoaded` event to be fired.
   * `'networkidle'` - wait until there are no network connections for at least `500` ms.
-- `options` `new Frame.WaitForLoadStateOptions()`
+- `options` <`Frame.WaitForLoadStateOptions`>
   - `timeout` <[double]> Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultNavigationTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaultnavigationtimeouttimeout), [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout), [Page.setDefaultNavigationTimeout(timeout)](./api/class-page.mdx#pagesetdefaultnavigationtimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
 Waits for the required load state to be reached.
@@ -591,7 +591,7 @@ Waits for the required load state to be reached.
 This returns when the frame reaches a required load state, `load` by default. The navigation must have been committed when this method is called. If current document has already reached the required state, resolves immediately.
 
 ## Frame.waitForNavigation([options, callback])
-- `options` `new Frame.WaitForNavigationOptions()`
+- `options` <`Frame.WaitForNavigationOptions`>
   - `timeout` <[double]> Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultNavigationTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaultnavigationtimeouttimeout), [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout), [Page.setDefaultNavigationTimeout(timeout)](./api/class-page.mdx#pagesetdefaultnavigationtimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
   - `url` <[String]|[Pattern]|[function]\([String]\):[boolean]> A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation.
   - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider operation succeeded, defaults to `load`. Events can be either:
@@ -611,7 +611,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 ## Frame.waitForSelector(selector[, options])
 - `selector` <[String]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Frame.WaitForSelectorOptions()`
+- `options` <`Frame.WaitForSelectorOptions`>
   - `state` <"attached"|"detached"|"visible"|"hidden"> Defaults to `'visible'`. Can be either:
     * `'attached'` - wait for element to be present in DOM.
     * `'detached'` - wait for element to not be present in DOM.

--- a/java/docs/api/class-keyboard.mdx
+++ b/java/docs/api/class-keyboard.mdx
@@ -56,7 +56,7 @@ Modifier keys DO NOT effect `keyboard.insertText`. Holding down `Shift` will not
 
 ## Keyboard.press(key[, options])
 - `key` <[String]> Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
-- `options` `new Keyboard.PressOptions()`
+- `options` <`Keyboard.PressOptions`>
   - `delay` <[double]> Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
 
 `key` can specify the intended [keyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) value or a single character to generate the text for. A superset of the `key` values can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values). Examples of the keys are:
@@ -75,7 +75,7 @@ Shortcut for [Keyboard.down(key)](./api/class-keyboard.mdx#keyboarddownkey) and 
 
 ## Keyboard.type(text[, options])
 - `text` <[String]> A text to type into a focused element.
-- `options` `new Keyboard.TypeOptions()`
+- `options` <`Keyboard.TypeOptions`>
   - `delay` <[double]> Time to wait between key presses in milliseconds. Defaults to 0.
 
 Sends a `keydown`, `keypress`/`input`, and `keyup` event for each character in the text.

--- a/java/docs/api/class-mouse.mdx
+++ b/java/docs/api/class-mouse.mdx
@@ -19,7 +19,7 @@ Every `page` object has its own Mouse, accessible with [Page.mouse()](./api/clas
 ## Mouse.click(x, y[, options])
 - `x` <[double]>
 - `y` <[double]>
-- `options` `new Mouse.ClickOptions()`
+- `options` <`Mouse.ClickOptions`>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `clickCount` <[int]> defaults to 1. See [UIEvent.detail].
   - `delay` <[double]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
@@ -29,14 +29,14 @@ Shortcut for [Mouse.move(x, y[, options])](./api/class-mouse.mdx#mousemovex-y-op
 ## Mouse.dblclick(x, y[, options])
 - `x` <[double]>
 - `y` <[double]>
-- `options` `new Mouse.DblclickOptions()`
+- `options` <`Mouse.DblclickOptions`>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `delay` <[double]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
 
 Shortcut for [Mouse.move(x, y[, options])](./api/class-mouse.mdx#mousemovex-y-options), [Mouse.down([options])](./api/class-mouse.mdx#mousedownoptions), [Mouse.up([options])](./api/class-mouse.mdx#mouseupoptions), [Mouse.down([options])](./api/class-mouse.mdx#mousedownoptions) and [Mouse.up([options])](./api/class-mouse.mdx#mouseupoptions).
 
 ## Mouse.down([options])
-- `options` `new Mouse.DownOptions()`
+- `options` <`Mouse.DownOptions`>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `clickCount` <[int]> defaults to 1. See [UIEvent.detail].
 
@@ -45,13 +45,13 @@ Dispatches a `mousedown` event.
 ## Mouse.move(x, y[, options])
 - `x` <[double]>
 - `y` <[double]>
-- `options` `new Mouse.MoveOptions()`
+- `options` <`Mouse.MoveOptions`>
   - `steps` <[int]> defaults to 1. Sends intermediate `mousemove` events.
 
 Dispatches a `mousemove` event.
 
 ## Mouse.up([options])
-- `options` `new Mouse.UpOptions()`
+- `options` <`Mouse.UpOptions`>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `clickCount` <[int]> defaults to 1. See [UIEvent.detail].
 

--- a/java/docs/api/class-page.mdx
+++ b/java/docs/api/class-page.mdx
@@ -258,7 +258,7 @@ The order of evaluation of multiple scripts installed via [BrowserContext.addIni
 :::
 
 ## Page.addScriptTag([options])
-- `options` `new Page.AddScriptTagOptions()`
+- `options` <`Page.AddScriptTagOptions`>
   - `content` <[String]> Raw JavaScript content to be injected into frame.
   - `path` <[Path]> Path to the JavaScript file to be injected into frame. If `path` is a relative path, then it is resolved relative to the current working directory.
   - `type` <[String]> Script type. Use 'module' in order to load a Javascript ES6 module. See [script](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script) for more details.
@@ -270,7 +270,7 @@ Adds a `<script>` tag into the page with the desired url or content. Returns the
 Shortcut for main frame's [Frame.addScriptTag([options])](./api/class-frame.mdx#frameaddscripttagoptions).
 
 ## Page.addStyleTag([options])
-- `options` `new Page.AddStyleTagOptions()`
+- `options` <`Page.AddStyleTagOptions`>
   - `content` <[String]> Raw CSS content to be injected into frame.
   - `path` <[Path]> Path to the CSS file to be injected into frame. If `path` is a relative path, then it is resolved relative to the current working directory.
   - `url` <[String]> URL of the `<link>` tag.
@@ -286,7 +286,7 @@ Brings page to front (activates tab).
 
 ## Page.check(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.CheckOptions()`
+- `options` <`Page.CheckOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -306,14 +306,14 @@ Shortcut for main frame's [Frame.check(selector[, options])](./api/class-frame.m
 
 ## Page.click(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.ClickOptions()`
+- `options` <`Page.ClickOptions`>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `clickCount` <[int]> defaults to 1. See [UIEvent.detail].
   - `delay` <[double]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -330,7 +330,7 @@ When all steps combined have not finished during the specified `timeout`, this m
 Shortcut for main frame's [Frame.click(selector[, options])](./api/class-frame.mdx#frameclickselector-options).
 
 ## Page.close([options])
-- `options` `new Page.CloseOptions()`
+- `options` <`Page.CloseOptions`>
   - `runBeforeUnload` <[boolean]> Defaults to `false`. Whether to run the [before unload](https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload) page handlers.
 
 If `runBeforeUnload` is `false`, does not run any unload handlers and waits for the page to be closed. If `runBeforeUnload` is `true` the method will run unload handlers, but will **not** wait for the page to close.
@@ -353,13 +353,13 @@ Get the browser context that the page belongs to.
 
 ## Page.dblclick(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.DblclickOptions()`
+- `options` <`Page.DblclickOptions`>
   - `button` <"left"|"right"|"middle"> Defaults to `left`.
   - `delay` <[double]> Time to wait between `mousedown` and `mouseup` in milliseconds. Defaults to 0.
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -383,7 +383,7 @@ Shortcut for main frame's [Frame.dblclick(selector[, options])](./api/class-fram
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `type` <[String]> DOM event type: `"click"`, `"dragstart"`, etc.
 - `eventInit` <[Object]> Optional event-specific initialization properties.
-- `options` `new Page.DispatchEventOptions()`
+- `options` <`Page.DispatchEventOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
 The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the elment, `click` is dispatched. This is equivalend to calling [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
@@ -402,7 +402,7 @@ Since `eventInit` is event-specific, please refer to the events documentation fo
 You can also specify `JSHandle` as the property value if you want live objects to be passed into the event:
 
 ## Page.emulateMedia([options])
-- `options` `new Page.EmulateMediaOptions()`
+- `options` <`Page.EmulateMediaOptions`>
   - `colorScheme` <[null]|"light"|"dark"|"no-preference"> Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. Passing `null` disables color scheme emulation.
   - `media` <[null]|"screen"|"print"> Changes the CSS media type of the page. The only allowed values are `'screen'`, `'print'` and `null`. Passing `null` disables CSS media emulation.
 
@@ -469,7 +469,7 @@ A string can also be passed in instead of a function:
 ## Page.exposeBinding(name, callback[, options])
 - `name` <[String]> Name of the function on the window object.
 - `callback` <[Predicate]> Callback function that will be called in the Playwright's context.
-- `options` `new Page.ExposeBindingOptions()`
+- `options` <`Page.ExposeBindingOptions`>
   - `handle` <[boolean]> Whether to pass the argument as a handle, instead of passing by value. When passing a handle, only one argument is supported. When passing by value, multiple arguments are supported.
 
 The method adds a function called `name` on the `window` object of every frame in this page. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`. If the `callback` returns a [Promise], it will be awaited.
@@ -505,7 +505,7 @@ An example of adding an `sha1` function to the page:
 ## Page.fill(selector, value[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `value` <[String]> Value to fill for the `<input>`, `<textarea>` or `[contenteditable]` element.
-- `options` `new Page.FillOptions()`
+- `options` <`Page.FillOptions`>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
@@ -517,7 +517,7 @@ Shortcut for main frame's [Frame.fill(selector, value[, options])](./api/class-f
 
 ## Page.focus(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.FocusOptions()`
+- `options` <`Page.FocusOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
 This method fetches an element with `selector` and focuses it. If there's no element matching `selector`, the method waits until a matching element appears in the DOM.
@@ -544,14 +544,14 @@ An array of all frames attached to the page.
 ## Page.getAttribute(selector, name[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `name` <[String]> Attribute name to get the value for.
-- `options` `new Page.GetAttributeOptions()`
+- `options` <`Page.GetAttributeOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[null]|[String]>
 
 Returns element attribute value.
 
 ## Page.goBack([options])
-- `options` `new Page.GoBackOptions()`
+- `options` <`Page.GoBackOptions`>
   - `timeout` <[double]> Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultNavigationTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaultnavigationtimeouttimeout), [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout), [Page.setDefaultNavigationTimeout(timeout)](./api/class-page.mdx#pagesetdefaultnavigationtimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
   - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider operation succeeded, defaults to `load`. Events can be either:
     * `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
@@ -564,7 +564,7 @@ Returns the main resource response. In case of multiple redirects, the navigatio
 Navigate to the previous page in history.
 
 ## Page.goForward([options])
-- `options` `new Page.GoForwardOptions()`
+- `options` <`Page.GoForwardOptions`>
   - `timeout` <[double]> Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultNavigationTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaultnavigationtimeouttimeout), [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout), [Page.setDefaultNavigationTimeout(timeout)](./api/class-page.mdx#pagesetdefaultnavigationtimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
   - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider operation succeeded, defaults to `load`. Events can be either:
     * `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
@@ -578,10 +578,10 @@ Navigate to the next page in history.
 
 ## Page.hover(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.HoverOptions()`
+- `options` <`Page.HoverOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -599,7 +599,7 @@ Shortcut for main frame's [Frame.hover(selector[, options])](./api/class-frame.m
 
 ## Page.innerHTML(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.InnerHTMLOptions()`
+- `options` <`Page.InnerHTMLOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[String]>
 
@@ -607,7 +607,7 @@ Returns `element.innerHTML`.
 
 ## Page.innerText(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.InnerTextOptions()`
+- `options` <`Page.InnerTextOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[String]>
 
@@ -615,7 +615,7 @@ Returns `element.innerText`.
 
 ## Page.isChecked(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.IsCheckedOptions()`
+- `options` <`Page.IsCheckedOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -628,7 +628,7 @@ Indicates that the page has been closed.
 
 ## Page.isDisabled(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.IsDisabledOptions()`
+- `options` <`Page.IsDisabledOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -636,7 +636,7 @@ Returns whether the element is disabled, the opposite of [enabled](./actionabili
 
 ## Page.isEditable(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.IsEditableOptions()`
+- `options` <`Page.IsEditableOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -644,7 +644,7 @@ Returns whether the element is [editable](./actionability.mdx#editable).
 
 ## Page.isEnabled(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.IsEnabledOptions()`
+- `options` <`Page.IsEnabledOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -652,7 +652,7 @@ Returns whether the element is [enabled](./actionability.mdx#enabled).
 
 ## Page.isHidden(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.IsHiddenOptions()`
+- `options` <`Page.IsHiddenOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -660,7 +660,7 @@ Returns whether the element is hidden, the opposite of [visible](./actionability
 
 ## Page.isVisible(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.IsVisibleOptions()`
+- `options` <`Page.IsVisibleOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[boolean]>
 
@@ -673,7 +673,7 @@ The page's main frame. Page is guaranteed to have a main frame which persists du
 
 ## Page.navigate(url[, options])
 - `url` <[String]> URL to navigate page to. The url should include scheme, e.g. `https://`.
-- `options` `new Page.NavigateOptions()`
+- `options` <`Page.NavigateOptions`>
   - `referer` <[String]> Referer header value. If provided it will take preference over the referer header value set by [Page.setExtraHTTPHeaders(headers)](./api/class-page.mdx#pagesetextrahttpheadersheaders).
   - `timeout` <[double]> Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultNavigationTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaultnavigationtimeouttimeout), [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout), [Page.setDefaultNavigationTimeout(timeout)](./api/class-page.mdx#pagesetdefaultnavigationtimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
   - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider operation succeeded, defaults to `load`. Events can be either:
@@ -719,7 +719,7 @@ This method requires Playwright to be started in a headed mode, with a falsy `he
 :::
 
 ## Page.pdf([options])
-- `options` `new Page.PdfOptions()`
+- `options` <`Page.PdfOptions`>
   - `displayHeaderFooter` <[boolean]> Display header and footer. Defaults to `false`.
   - `footerTemplate` <[String]> HTML template for the print footer. Should use the same format as the `headerTemplate`.
   - `format` <[String]> Paper format. If set, takes priority over `width` or `height` options. Defaults to 'Letter'.
@@ -731,7 +731,7 @@ This method requires Playwright to be started in a headed mode, with a falsy `he
     * `'totalPages'` total pages in the document
   - `height` <[String]> Paper height, accepts values labeled with units.
   - `landscape` <[boolean]> Paper orientation. Defaults to `false`.
-  - `margin` `new Margin()` Paper margins, defaults to none.
+  - `margin` <`Margin`> Paper margins, defaults to none.
     - `top` <[String]> Top margin, accepts values labeled with units. Defaults to `0`.
     - `right` <[String]> Right margin, accepts values labeled with units. Defaults to `0`.
     - `bottom` <[String]> Bottom margin, accepts values labeled with units. Defaults to `0`.
@@ -789,7 +789,7 @@ The `format` options are:
 ## Page.press(selector, key[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `key` <[String]> Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.
-- `options` `new Page.PressOptions()`
+- `options` <`Page.PressOptions`>
   - `delay` <[double]> Time to wait between `keydown` and `keyup` in milliseconds. Defaults to 0.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -825,7 +825,7 @@ The method finds all elements matching the specified selector within the page. I
 Shortcut for main frame's [Frame.querySelectorAll(selector)](./api/class-frame.mdx#framequeryselectorallselector).
 
 ## Page.reload([options])
-- `options` `new Page.ReloadOptions()`
+- `options` <`Page.ReloadOptions`>
   - `timeout` <[double]> Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultNavigationTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaultnavigationtimeouttimeout), [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout), [Page.setDefaultNavigationTimeout(timeout)](./api/class-page.mdx#pagesetdefaultnavigationtimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
   - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider operation succeeded, defaults to `load`. Events can be either:
     * `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
@@ -858,8 +858,8 @@ Enabling routing disables http cache.
 :::
 
 ## Page.screenshot([options])
-- `options` `new Page.ScreenshotOptions()`
-  - `clip` `new Clip()` An object which specifies clipping of the resulting image. Should have the following fields:
+- `options` <`Page.ScreenshotOptions`>
+  - `clip` <`Clip`> An object which specifies clipping of the resulting image. Should have the following fields:
     - `x` <[double]> x-coordinate of top-left corner of clip area
     - `y` <[double]> y-coordinate of top-left corner of clip area
     - `width` <[double]> width of clipping area
@@ -880,11 +880,11 @@ Screenshots take at least 1/6 second on Chromium OS X and Chromium Windows. See 
 
 ## Page.selectOption(selector, values[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `values` <[null]|[String]|[ElementHandle]|[List]<[String]>|[Map]|[List]<[ElementHandle]>|[List]<[Map]>> Options to select. If the `<select>` has the `multiple` attribute, all matching options are selected, otherwise only the first option matching one of the passed options is selected. String values are equivalent to `{value:'string'}`. Option is considered matching if all specified properties match.
+- `values` <[null]|[String]|[ElementHandle]|[List]<[String]>|`SelectOption`|[List]<[ElementHandle]>|[List]<`SelectOption`>> Options to select. If the `<select>` has the `multiple` attribute, all matching options are selected, otherwise only the first option matching one of the passed options is selected. String values are equivalent to `{value:'string'}`. Option is considered matching if all specified properties match.
   - `value` <[String]> Matches by `option.value`. Optional.
   - `label` <[String]> Matches by `option.label`. Optional.
   - `index` <[int]> Matches by the index. Optional.
-- `options` `new Page.SelectOptionOptions()`
+- `options` <`Page.SelectOptionOptions`>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[List]<[String]>>
@@ -899,7 +899,7 @@ Shortcut for main frame's [Frame.selectOption(selector, values[, options])](./ap
 
 ## Page.setContent(html[, options])
 - `html` <[String]> HTML markup to assign to the page.
-- `options` `new Page.SetContentOptions()`
+- `options` <`Page.SetContentOptions`>
   - `timeout` <[double]> Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultNavigationTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaultnavigationtimeouttimeout), [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout), [Page.setDefaultNavigationTimeout(timeout)](./api/class-page.mdx#pagesetdefaultnavigationtimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
   - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider operation succeeded, defaults to `load`. Events can be either:
     * `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
@@ -941,11 +941,11 @@ The extra HTTP headers will be sent with every request the page initiates.
 
 ## Page.setInputFiles(selector, files[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `files` <[Path]|[List]<[Path]>|[Map]|[List]<[Map]>>
-  - `name` <[String]> [File] name
-  - `mimeType` <[String]> [File] type
+- `files` <[Path]|[List]<[Path]>|`FilePayload`|[List]<`FilePayload`>>
+  - `name` <[String]> File name
+  - `mimeType` <[String]> File type
   - `buffer` <[byte&#91;&#93;]> File content
-- `options` `new Page.SetInputFilesOptions()`
+- `options` <`Page.SetInputFilesOptions`>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
@@ -954,7 +954,7 @@ This method expects `selector` to point to an [input element](https://developer.
 Sets the value of the file input to these file paths or files. If some of the `filePaths` are relative paths, then they are resolved relative to the the current working directory. For empty array, clears the selected files.
 
 ## Page.setViewportSize(viewportSize)
-- `viewportSize` `new ViewportSize()`
+- `viewportSize` <`ViewportSize`>
   - `width` <[int]> page width in pixels.
   - `height` <[int]> page height in pixels.
 
@@ -964,11 +964,11 @@ In the case of multiple pages in a single browser, each page can have its own vi
 
 ## Page.tap(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.TapOptions()`
+- `options` <`Page.TapOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `modifiers` <[List]<"Alt"|"Control"|"Meta"|"Shift">> Modifier keys to press. Ensures that only these modifiers are pressed during the operation, and then restores current modifiers back. If not specified, currently pressed modifiers are used.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
-  - `position` `new Position()` A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
+  - `position` <`Position`> A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
     - `x` <[double]>
     - `y` <[double]>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -990,7 +990,7 @@ Shortcut for main frame's [Frame.tap(selector[, options])](./api/class-frame.mdx
 
 ## Page.textContent(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.TextContentOptions()`
+- `options` <`Page.TextContentOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[null]|[String]>
 
@@ -1004,7 +1004,7 @@ Returns the page's title. Shortcut for main frame's [Frame.title()](./api/class-
 ## Page.type(selector, text[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `text` <[String]> A text to type into a focused element.
-- `options` `new Page.TypeOptions()`
+- `options` <`Page.TypeOptions`>
   - `delay` <[double]> Time to wait between key presses in milliseconds. Defaults to 0.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -1017,7 +1017,7 @@ Shortcut for main frame's [Frame.type(selector, text[, options])](./api/class-fr
 
 ## Page.uncheck(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.UncheckOptions()`
+- `options` <`Page.UncheckOptions`>
   - `force` <[boolean]> Whether to bypass the [actionability](./actionability.mdx) checks. Defaults to `false`.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
@@ -1057,7 +1057,7 @@ Video object associated with this page.
   - `height` <[int]> page height in pixels.
 
 ## Page.waitForClose([options, callback])
-- `options` `new Page.WaitForCloseOptions()`
+- `options` <`Page.WaitForCloseOptions`>
   - `timeout` <[double]> Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - `callback` <[Runnable]> Callback that performs the action triggering the event.
 - returns: <[Page]>
@@ -1065,7 +1065,7 @@ Video object associated with this page.
 Performs action and waits for the Page to close.
 
 ## Page.waitForConsoleMessage([options, callback])
-- `options` `new Page.WaitForConsoleMessageOptions()`
+- `options` <`Page.WaitForConsoleMessageOptions`>
   - `predicate` <[function]\([ConsoleMessage]\):[boolean]> Receives the [ConsoleMessage] object and resolves to truthy value when the waiting should resolve.
   - `timeout` <[double]> Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - `callback` <[Runnable]> Callback that performs the action triggering the event.
@@ -1074,7 +1074,7 @@ Performs action and waits for the Page to close.
 Performs action and waits for a [ConoleMessage] to be logged by in the page. If predicate is provided, it passes [ConsoleMessage] value into the `predicate` function and waits for `predicate(message)` to return a truthy value. Will throw an error if the page is closed before the console event is fired.
 
 ## Page.waitForDownload([options, callback])
-- `options` `new Page.WaitForDownloadOptions()`
+- `options` <`Page.WaitForDownloadOptions`>
   - `predicate` <[function]\([Download]\):[boolean]> Receives the [Download] object and resolves to truthy value when the waiting should resolve.
   - `timeout` <[double]> Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - `callback` <[Runnable]> Callback that performs the action triggering the event.
@@ -1083,7 +1083,7 @@ Performs action and waits for a [ConoleMessage] to be logged by in the page. If 
 Performs action and waits for a new [Download]. If predicate is provided, it passes [Download] value into the `predicate` function and waits for `predicate(download)` to return a truthy value. Will throw an error if the page is closed before the download event is fired.
 
 ## Page.waitForFileChooser([options, callback])
-- `options` `new Page.WaitForFileChooserOptions()`
+- `options` <`Page.WaitForFileChooserOptions`>
   - `predicate` <[function]\([FileChooser]\):[boolean]> Receives the [FileChooser] object and resolves to truthy value when the waiting should resolve.
   - `timeout` <[double]> Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - `callback` <[Runnable]> Callback that performs the action triggering the event.
@@ -1094,7 +1094,7 @@ Performs action and waits for a new [FileChooser] to be created. If predicate is
 ## Page.waitForFunction(expression[, arg, options])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
 - `arg` <[Object]> Optional argument to pass to `expression`.
-- `options` `new Page.WaitForFunctionOptions()`
+- `options` <`Page.WaitForFunctionOptions`>
   - `pollingInterval` <[double]> If specified, then it is treated as an interval in milliseconds at which the function would be executed. By default if the option is not specified `expression` is executed in `requestAnimationFrame` callback.
   - `timeout` <[double]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - returns: <[JSHandle]>
@@ -1112,7 +1112,7 @@ Shortcut for main frame's [Frame.waitForFunction(expression[, arg, options])](./
   * `'load'` - wait for the `load` event to be fired.
   * `'domcontentloaded'` - wait for the `DOMContentLoaded` event to be fired.
   * `'networkidle'` - wait until there are no network connections for at least `500` ms.
-- `options` `new Page.WaitForLoadStateOptions()`
+- `options` <`Page.WaitForLoadStateOptions`>
   - `timeout` <[double]> Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultNavigationTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaultnavigationtimeouttimeout), [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout), [Page.setDefaultNavigationTimeout(timeout)](./api/class-page.mdx#pagesetdefaultnavigationtimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
 Returns when the required load state has been reached.
@@ -1122,7 +1122,7 @@ This resolves when the page reaches a required load state, `load` by default. Th
 Shortcut for main frame's [Frame.waitForLoadState([state, options])](./api/class-frame.mdx#framewaitforloadstatestate-options).
 
 ## Page.waitForNavigation([options, callback])
-- `options` `new Page.WaitForNavigationOptions()`
+- `options` <`Page.WaitForNavigationOptions`>
   - `timeout` <[double]> Maximum operation time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultNavigationTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaultnavigationtimeouttimeout), [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout), [Page.setDefaultNavigationTimeout(timeout)](./api/class-page.mdx#pagesetdefaultnavigationtimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
   - `url` <[String]|[Pattern]|[function]\([String]\):[boolean]> A glob pattern, regex pattern or predicate receiving [URL] to match while waiting for the navigation.
   - `waitUntil` <"load"|"domcontentloaded"|"networkidle"> When to consider operation succeeded, defaults to `load`. Events can be either:
@@ -1143,7 +1143,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 Shortcut for main frame's [Frame.waitForNavigation([options, callback])](./api/class-frame.mdx#framewaitfornavigationoptions-callback).
 
 ## Page.waitForPopup([options, callback])
-- `options` `new Page.WaitForPopupOptions()`
+- `options` <`Page.WaitForPopupOptions`>
   - `predicate` <[function]\([Page]\):[boolean]> Receives the [Page] object and resolves to truthy value when the waiting should resolve.
   - `timeout` <[double]> Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - `callback` <[Runnable]> Callback that performs the action triggering the event.
@@ -1153,7 +1153,7 @@ Performs action and waits for a popup [Page]. If predicate is provided, it passe
 
 ## Page.waitForRequest(urlOrPredicate[, options, callback])
 - `urlOrPredicate` <[String]|[Pattern]|[function]\([Request]\):[boolean]> Request URL string, regex or predicate receiving [Request] object.
-- `options` `new Page.WaitForRequestOptions()`
+- `options` <`Page.WaitForRequestOptions`>
   - `timeout` <[double]> Maximum wait time in milliseconds, defaults to 30 seconds, pass `0` to disable the timeout. The default value can be changed by using the [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) method.
 - `callback` <[Runnable]> Callback that performs the action triggering the event.
 - returns: <[Request]>
@@ -1162,7 +1162,7 @@ Waits for the matching request and returns it.
 
 ## Page.waitForResponse(urlOrPredicate[, options, callback])
 - `urlOrPredicate` <[String]|[Pattern]|[function]\([Response]\):[boolean]> Request URL string, regex or predicate receiving [Response] object.
-- `options` `new Page.WaitForResponseOptions()`
+- `options` <`Page.WaitForResponseOptions`>
   - `timeout` <[double]> Maximum wait time in milliseconds, defaults to 30 seconds, pass `0` to disable the timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - `callback` <[Runnable]> Callback that performs the action triggering the event.
 - returns: <[Response]>
@@ -1171,7 +1171,7 @@ Returns the matched response.
 
 ## Page.waitForSelector(selector[, options])
 - `selector` <[String]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
-- `options` `new Page.WaitForSelectorOptions()`
+- `options` <`Page.WaitForSelectorOptions`>
   - `state` <"attached"|"detached"|"visible"|"hidden"> Defaults to `'visible'`. Can be either:
     * `'attached'` - wait for element to be present in DOM.
     * `'detached'` - wait for element to not be present in DOM.
@@ -1196,7 +1196,7 @@ Note that `page.waitForTimeout()` should only be used for debugging. Tests using
 Shortcut for main frame's [Frame.waitForTimeout(timeout)](./api/class-frame.mdx#framewaitfortimeouttimeout).
 
 ## Page.waitForWebSocket([options, callback])
-- `options` `new Page.WaitForWebSocketOptions()`
+- `options` <`Page.WaitForWebSocketOptions`>
   - `predicate` <[function]\([WebSocket]\):[boolean]> Receives the [WebSocket] object and resolves to truthy value when the waiting should resolve.
   - `timeout` <[double]> Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - `callback` <[Runnable]> Callback that performs the action triggering the event.
@@ -1205,7 +1205,7 @@ Shortcut for main frame's [Frame.waitForTimeout(timeout)](./api/class-frame.mdx#
 Performs action and waits for a new [WebSocket]. If predicate is provided, it passes [WebSocket] value into the `predicate` function and waits for `predicate(webSocket)` to return a truthy value. Will throw an error if the page is closed before the WebSocket event is fired.
 
 ## Page.waitForWorker([options, callback])
-- `options` `new Page.WaitForWorkerOptions()`
+- `options` <`Page.WaitForWorkerOptions`>
   - `predicate` <[function]\([Worker]\):[boolean]> Receives the [Worker] object and resolves to truthy value when the waiting should resolve.
   - `timeout` <[double]> Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - `callback` <[Runnable]> Callback that performs the action triggering the event.

--- a/java/docs/api/class-route.mdx
+++ b/java/docs/api/class-route.mdx
@@ -33,7 +33,7 @@ Whenever a network route is set up with [Page.route(url, handler)](./api/class-p
 Aborts the route's request.
 
 ## Route.fulfill([options])
-- `options` `new Route.FulfillOptions()`
+- `options` <`Route.FulfillOptions`>
   - `body` <[String]> Optional response body as text.
   - `bodyBytes` <[byte&#91;&#93;]> Optional response body as raw bytes.
   - `contentType` <[String]> If set, equals to setting `Content-Type` response header.
@@ -53,7 +53,7 @@ An example of serving static file:
 A request to be routed.
 
 ## Route.resume([options])
-- `options` `new Route.ResumeOptions()`
+- `options` <`Route.ResumeOptions`>
   - `headers` <[Map]<[String], [String]>> If set changes the request HTTP headers. Header values will be converted to a string.
   - `method` <[String]> If set changes the request method (e.g. GET or POST)
   - `postData` <[String]|[byte&#91;&#93;]> If set changes the post data of request

--- a/java/docs/api/class-selectors.mdx
+++ b/java/docs/api/class-selectors.mdx
@@ -13,7 +13,7 @@ Selectors can be used to install custom selector engines. See [Working with sele
 ## Selectors.register(name, script[, options])
 - `name` <[String]> Name that is used in selectors as a prefix, e.g. `{name: 'foo'}` enables `foo=myselectorbody` selectors. May only contain `[a-zA-Z0-9_]` characters.
 - `script` <[String]|[Path]> Script that evaluates to a selector engine instance.
-- `options` `new Selectors.RegisterOptions()`
+- `options` <`Selectors.RegisterOptions`>
   - `contentScript` <[boolean]> Whether to run this selector engine in isolated JavaScript environment. This environment has access to the same DOM, but not any JavaScript objects from the frame's scripts. Defaults to `false`. Note that running as a content script is not guaranteed when this engine is used together with other registered engines.
 
 An example of registering selector engine that queries elements based on a tag name:

--- a/java/docs/api/class-websocket.mdx
+++ b/java/docs/api/class-websocket.mdx
@@ -48,7 +48,7 @@ Indicates that the web socket has been closed.
 Contains the URL of the WebSocket.
 
 ## WebSocket.waitForFrameReceived([options, callback])
-- `options` `new WebSocket.WaitForFrameReceivedOptions()`
+- `options` <`WebSocket.WaitForFrameReceivedOptions`>
   - `predicate` <[function]\([WebSocketFrame]\):[boolean]> Receives the [WebSocketFrame] object and resolves to truthy value when the waiting should resolve.
   - `timeout` <[double]> Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - `callback` <[Runnable]> Callback that performs the action triggering the event.
@@ -57,7 +57,7 @@ Contains the URL of the WebSocket.
 Performs action and waits for a frame to be sent. If predicate is provided, it passes [WebSocketFrame] value into the `predicate` function and waits for `predicate(webSocketFrame)` to return a truthy value. Will throw an error if the WebSocket or Page is closed before the frame is received.
 
 ## WebSocket.waitForFrameSent([options, callback])
-- `options` `new WebSocket.WaitForFrameSentOptions()`
+- `options` <`WebSocket.WaitForFrameSentOptions`>
   - `predicate` <[function]\([WebSocketFrame]\):[boolean]> Receives the [WebSocketFrame] object and resolves to truthy value when the waiting should resolve.
   - `timeout` <[double]> Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - `callback` <[Runnable]> Callback that performs the action triggering the event.

--- a/java/docs/api/class-worker.mdx
+++ b/java/docs/api/class-worker.mdx
@@ -45,7 +45,7 @@ If the function passed to the [Worker.evaluateHandle(expression[, arg])](./api/c
 - returns: <[String]>
 
 ## Worker.waitForClose([options, callback])
-- `options` `new Worker.WaitForCloseOptions()`
+- `options` <`Worker.WaitForCloseOptions`>
   - `timeout` <[double]> Maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
 - `callback` <[Runnable]> Callback that performs the action triggering the event.
 - returns: <[Worker]>

--- a/nodejs/docs/api/class-elementhandle.mdx
+++ b/nodejs/docs/api/class-elementhandle.mdx
@@ -408,8 +408,8 @@ This method waits for [actionability](./actionability.mdx) checks, then focuses 
 
 ## elementHandle.setInputFiles(files[, options])
 - `files` <[string]|[Array]<[string]>|[Object]|[Array]<[Object]>>
-  - `name` <[string]> [File] name
-  - `mimeType` <[string]> [File] type
+  - `name` <[string]> File name
+  - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
 - `options` <[Object]>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.

--- a/nodejs/docs/api/class-filechooser.mdx
+++ b/nodejs/docs/api/class-filechooser.mdx
@@ -38,8 +38,8 @@ Returns page this file chooser belongs to.
 
 ## fileChooser.setFiles(files[, options])
 - `files` <[string]|[Array]<[string]>|[Object]|[Array]<[Object]>>
-  - `name` <[string]> [File] name
-  - `mimeType` <[string]> [File] type
+  - `name` <[string]> File name
+  - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
 - `options` <[Object]>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.

--- a/nodejs/docs/api/class-frame.mdx
+++ b/nodejs/docs/api/class-frame.mdx
@@ -570,8 +570,8 @@ frame.selectOption('select#colors', 'red', 'green', 'blue');
 ## frame.setInputFiles(selector, files[, options])
 - `selector` <[string]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `files` <[string]|[Array]<[string]>|[Object]|[Array]<[Object]>>
-  - `name` <[string]> [File] name
-  - `mimeType` <[string]> [File] type
+  - `name` <[string]> File name
+  - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
 - `options` <[Object]>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.

--- a/nodejs/docs/api/class-page.mdx
+++ b/nodejs/docs/api/class-page.mdx
@@ -1192,8 +1192,8 @@ The extra HTTP headers will be sent with every request the page initiates.
 ## page.setInputFiles(selector, files[, options])
 - `selector` <[string]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `files` <[string]|[Array]<[string]>|[Object]|[Array]<[Object]>>
-  - `name` <[string]> [File] name
-  - `mimeType` <[string]> [File] type
+  - `name` <[string]> File name
+  - `mimeType` <[string]> File type
   - `buffer` <[Buffer]> File content
 - `options` <[Object]>
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.

--- a/python/docs/api/class-elementhandle.mdx
+++ b/python/docs/api/class-elementhandle.mdx
@@ -578,8 +578,8 @@ This method waits for [actionability](./actionability.mdx) checks, then focuses 
 
 ## element_handle.set_input_files(files, **kwargs)
 - `files` <[Union]\[[str], [pathlib.Path]\]|[List]\[[Union]\[[str], [pathlib.Path]\]\]|[Dict]|[List]\[[Dict]\]>
-  - `name` <[str]> [File] name
-  - `mimeType` <[str]> [File] type
+  - `name` <[str]> File name
+  - `mimeType` <[str]> File type
   - `buffer` <[Buffer]> File content
 - `no_wait_after` <[bool]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
 - `timeout` <[float]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browser_context.set_default_timeout(timeout)](./api/class-browsercontext.mdx#browser_contextset_default_timeouttimeout) or [page.set_default_timeout(timeout)](./api/class-page.mdx#pageset_default_timeouttimeout) methods.

--- a/python/docs/api/class-filechooser.mdx
+++ b/python/docs/api/class-filechooser.mdx
@@ -60,8 +60,8 @@ Returns page this file chooser belongs to.
 
 ## file_chooser.set_files(files, **kwargs)
 - `files` <[Union]\[[str], [pathlib.Path]\]|[List]\[[Union]\[[str], [pathlib.Path]\]\]|[Dict]|[List]\[[Dict]\]>
-  - `name` <[str]> [File] name
-  - `mimeType` <[str]> [File] type
+  - `name` <[str]> File name
+  - `mimeType` <[str]> File type
   - `buffer` <[Buffer]> File content
 - `no_wait_after` <[bool]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
 - `timeout` <[float]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browser_context.set_default_timeout(timeout)](./api/class-browsercontext.mdx#browser_contextset_default_timeouttimeout) or [page.set_default_timeout(timeout)](./api/class-page.mdx#pageset_default_timeouttimeout) methods.

--- a/python/docs/api/class-frame.mdx
+++ b/python/docs/api/class-frame.mdx
@@ -891,8 +891,8 @@ await frame.select_option("select#colors", value=["red", "green", "blue"])
 ## frame.set_input_files(selector, files, **kwargs)
 - `selector` <[str]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `files` <[Union]\[[str], [pathlib.Path]\]|[List]\[[Union]\[[str], [pathlib.Path]\]\]|[Dict]|[List]\[[Dict]\]>
-  - `name` <[str]> [File] name
-  - `mimeType` <[str]> [File] type
+  - `name` <[str]> File name
+  - `mimeType` <[str]> File type
   - `buffer` <[Buffer]> File content
 - `no_wait_after` <[bool]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
 - `timeout` <[float]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browser_context.set_default_timeout(timeout)](./api/class-browsercontext.mdx#browser_contextset_default_timeouttimeout) or [page.set_default_timeout(timeout)](./api/class-page.mdx#pageset_default_timeouttimeout) methods.

--- a/python/docs/api/class-page.mdx
+++ b/python/docs/api/class-page.mdx
@@ -2013,8 +2013,8 @@ The extra HTTP headers will be sent with every request the page initiates.
 ## page.set_input_files(selector, files, **kwargs)
 - `selector` <[str]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `files` <[Union]\[[str], [pathlib.Path]\]|[List]\[[Union]\[[str], [pathlib.Path]\]\]|[Dict]|[List]\[[Dict]\]>
-  - `name` <[str]> [File] name
-  - `mimeType` <[str]> [File] type
+  - `name` <[str]> File name
+  - `mimeType` <[str]> File type
   - `buffer` <[Buffer]> File content
 - `no_wait_after` <[bool]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
 - `timeout` <[float]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browser_context.set_default_timeout(timeout)](./api/class-browsercontext.mdx#browser_contextset_default_timeouttimeout) or [page.set_default_timeout(timeout)](./api/class-page.mdx#pageset_default_timeouttimeout) methods.


### PR DESCRIPTION
* Custom type names are properly replaced in the template params: List<Cookie> instead of List<Map> etc.
* Fix type names for nested options classes such as geolocation (it's now Geolocation instead of Map) 