### PR TITLE
fix: remove versions dropdown for java

### DIFF
--- a/java/docusaurus.config.js
+++ b/java/docusaurus.config.js
@@ -64,15 +64,6 @@ module.exports = {
           className: "header-github-link",
           "aria-label": "GitHub repository",
         },
-        {
-          type: "docsVersionDropdown",
-          position: "left",
-          // Add additional dropdown items at the beginning/end of the dropdown.
-          dropdownItemsBefore: [],
-          dropdownItemsAfter: [{ to: "/versions", label: "All versions" }],
-          // Do not add the link active class when browsing docs.
-          dropdownActiveClassDisabled: true,
-        },
       ],
     },
     footer: {


### PR DESCRIPTION
We don't wanna have any versions before going stable.

![image](https://user-images.githubusercontent.com/9798949/110368451-e62b8f80-7ffd-11eb-8609-ce5770bab684.png)
