### PR TITLE
feat: syntax highlighting for python & java docs

### DIFF
--- a/java/docusaurus.config.js
+++ b/java/docusaurus.config.js
@@ -39,6 +39,10 @@ module.exports = {
     colorMode: {
       defaultMode: "dark",
     },
+    prism: {
+      theme: require('prism-react-renderer/themes/dracula'),
+      additionalLanguages: ['java'],
+    },
     navbar: {
       title: "Playwright for Java",
       logo: {

--- a/python/docusaurus.config.js
+++ b/python/docusaurus.config.js
@@ -39,6 +39,10 @@ module.exports = {
     colorMode: {
       defaultMode: "dark",
     },
+    prism: {
+      theme: require('prism-react-renderer/themes/dracula'),
+      additionalLanguages: ['python'],
+    },
     navbar: {
       title: "Playwright for Python",
       logo: {


### PR DESCRIPTION
Fixes syntax highlighting for python & java docs @pavelfeldman @mxschmitt 
<img width="846" alt="main" src="https://user-images.githubusercontent.com/59607654/113264251-6210b300-92f0-11eb-89e3-53c0dffeff28.png">
