### PR TITLE
devops: remove pushing over Arjuns PAT

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - uses: actions/setup-node@v2
         with:
           node-version: '14'


### PR DESCRIPTION
Since its now the same repo, it should work with the access token provided by GitHub automatically.

This won't require the custom PAT anymore -> won't create these notifications too.


![image](https://user-images.githubusercontent.com/17984549/115999212-36c96d00-a5eb-11eb-82bb-51addc4bed6d.png)
