### PR TITLE
chore: strip out the search parameter in shared link

### DIFF
--- a/src/theme/Heading/index.js
+++ b/src/theme/Heading/index.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid */
+import React from 'react';
+import clsx from 'clsx';
+import { useThemeConfig } from '@docusaurus/theme-common';
+import './styles.css';
+import styles from './styles.module.css';
+
+// This component was modified to strip out the search parameter in the link
+
+const Heading = Tag => function TargetComponent({
+  id,
+  ...props
+}) {
+  const {
+    navbar: {
+      hideOnScroll
+    }
+  } = useThemeConfig();
+
+  if (!id) {
+    return <Tag {...props} />;
+  }
+
+  const handleOnHeadingClick = (ev) => {
+    ev.preventDefault()
+    const url = new URL(ev.target.href)
+    url.search = ""
+    history.pushState('', document.title, url.toString());
+  }
+
+  return <Tag {...props}>
+        <a aria-hidden="true" tabIndex={-1} className={clsx('anchor', {
+      [styles.enhancedAnchor]: !hideOnScroll
+    })} id={id} />
+        {props.children}
+        <a className="hash-link" href={`#${id}`} onClick={handleOnHeadingClick} title="Direct link to heading">
+          #
+        </a>
+      </Tag>;
+};
+
+export default Heading;

--- a/src/theme/Heading/styles.css
+++ b/src/theme/Heading/styles.css
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.anchor {
+  display: block;
+  position: relative;
+  top: -0.5rem;
+}
+
+.hash-link {
+  opacity: 0;
+  padding-left: 0.5rem;
+  transition: opacity var(--ifm-transition-fast);
+}
+
+.hash-link:focus,
+*:hover > .hash-link {
+  opacity: 1;
+}

--- a/src/theme/Heading/styles.module.css
+++ b/src/theme/Heading/styles.module.css
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.enhancedAnchor {
+  top: calc(var(--ifm-navbar-height) * -1);
+}


### PR DESCRIPTION
Fixes #129

Before: After clicking on the anchor link it ended up in `http://localhost:3000/docs/api/class-page?_highlight=screenshot#pagescreenshotoptions`
After: After clicking on the anchor link it ends up now in `http://localhost:3000/docs/api/class-page#pagescreenshotoptions`

For further reference, see here:
- `npx docusaurus swizzle @docusaurus/theme-classic Heading --danger`
- https://docusaurus.io/docs/2.0.0-alpha.71/using-themes#swizzling-theme-components