### PR TITLE
fix: roll and fix EvaluationArgument

### DIFF
--- a/common/links.md
+++ b/common/links.md
@@ -1,5 +1,5 @@
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.md#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.md#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/actionability.mdx
+++ b/csharp/docs/actionability.mdx
@@ -124,7 +124,7 @@ For example, consider a scenario where Playwright will click `Sign Up` button re
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-accessibility.mdx
+++ b/csharp/docs/api/class-accessibility.mdx
@@ -113,7 +113,7 @@ if(focusedNode != null)
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-browser.mdx
+++ b/csharp/docs/api/class-browser.mdx
@@ -168,7 +168,7 @@ Returns the browser version.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-browser.mdx
+++ b/csharp/docs/api/class-browser.mdx
@@ -64,7 +64,7 @@ Indicates that the browser is connected.
   - `locale` <[string]> Specify user locale, for example `en-GB`, `de-DE`, etc. Locale will affect `navigator.language` value, `Accept-Language` request header value as well as number and date formatting rules.
   - `offline` <[boolean]> Whether to emulate network being offline. Defaults to `false`.
   - `permissions` <[IEnumerable]<[string]>> A list of permissions to grant to all pages in this context. See [BrowserContext.GrantPermissions(permissions[, options])](./api/class-browsercontext.mdx#browsercontextgrantpermissionspermissions-options) for more details.
-  - `proxy` <`Proxy`> Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
+  - `proxy` <`Proxy`> Network proxy settings to use with this context.
     - `server` <[string]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
     - `bypass` <[string]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
     - `username` <[string]> Optional username to use if HTTP proxy requires authentication.
@@ -82,7 +82,7 @@ Indicates that the browser is connected.
   - `storageStatePath` <[string]> Populates context with given storage state. This option can be used to initialize context with logged-in information obtained via [BrowserContext.StorageState([options])](./api/class-browsercontext.mdx#browsercontextstoragestateoptions). Path to the file with saved storage state.
   - `timezoneId` <[string]> Changes the timezone of the context. See [ICU's metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs.
   - `userAgent` <[string]> Specific user agent to use in this context.
-  - `viewportSize` <[null]|`ViewportSize`> Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. `null` disables the default viewport.
+  - `viewportSize` <[null]|`ViewportSize`> Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use `ViewportSize.NoViewport` to disable the default viewport.
     - `width` <[int]> page width in pixels.
     - `height` <[int]> page height in pixels.
 - returns: <[BrowserContext]>
@@ -110,7 +110,7 @@ Creates a new browser context. It won't share cookies/cache with other browser c
   - `locale` <[string]> Specify user locale, for example `en-GB`, `de-DE`, etc. Locale will affect `navigator.language` value, `Accept-Language` request header value as well as number and date formatting rules.
   - `offline` <[boolean]> Whether to emulate network being offline. Defaults to `false`.
   - `permissions` <[IEnumerable]<[string]>> A list of permissions to grant to all pages in this context. See [BrowserContext.GrantPermissions(permissions[, options])](./api/class-browsercontext.mdx#browsercontextgrantpermissionspermissions-options) for more details.
-  - `proxy` <`Proxy`> Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
+  - `proxy` <`Proxy`> Network proxy settings to use with this context.
     - `server` <[string]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
     - `bypass` <[string]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
     - `username` <[string]> Optional username to use if HTTP proxy requires authentication.
@@ -128,7 +128,7 @@ Creates a new browser context. It won't share cookies/cache with other browser c
   - `storageStatePath` <[string]> Populates context with given storage state. This option can be used to initialize context with logged-in information obtained via [BrowserContext.StorageState([options])](./api/class-browsercontext.mdx#browsercontextstoragestateoptions). Path to the file with saved storage state.
   - `timezoneId` <[string]> Changes the timezone of the context. See [ICU's metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs.
   - `userAgent` <[string]> Specific user agent to use in this context.
-  - `viewportSize` <[null]|`ViewportSize`> Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. `null` disables the default viewport.
+  - `viewportSize` <[null]|`ViewportSize`> Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use `ViewportSize.NoViewport` to disable the default viewport.
     - `width` <[int]> page width in pixels.
     - `height` <[int]> page height in pixels.
 - returns: <[Page]>

--- a/csharp/docs/api/class-browsercontext.mdx
+++ b/csharp/docs/api/class-browsercontext.mdx
@@ -311,7 +311,7 @@ Performs action and waits for a new [Page] to be created in the context. If pred
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-browsertype.mdx
+++ b/csharp/docs/api/class-browsertype.mdx
@@ -21,7 +21,7 @@ A path where Playwright expects to find a bundled browser executable.
 ## BrowserType.Launch([options])
 - `options` <`BrowserType.LaunchOptions`>
   - `args` <[IEnumerable]<[string]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
-  - `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
+  - `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"|"firefox-stable"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
   - `chromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `false`.
   - `devtools` <[boolean]> **Chromium-only** Whether to auto-open a Developer Tools panel for each tab. If this option is `true`, the `headless` option will be set `false`.
   - `downloadsPath` <[string]> If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and is deleted when browser is closed.
@@ -59,7 +59,7 @@ You can use `ignoreDefaultArgs` to filter out `--mute-audio` from default argume
   - `acceptDownloads` <[boolean]> Whether to automatically download all the attachments. Defaults to `false` where all the downloads are canceled.
   - `args` <[IEnumerable]<[string]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
   - `bypassCSP` <[boolean]> Toggles bypassing page's Content-Security-Policy.
-  - `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
+  - `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"|"firefox-stable"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
   - `chromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `true`.
   - `colorScheme` <"light"|"dark"|"no-preference"> Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. See [Page.EmulateMedia([options])](./api/class-page.mdx#pageemulatemediaoptions) for more details. Defaults to `'light'`.
   - `deviceScaleFactor` <[double]> Specify device scale factor (can be thought of as dpr). Defaults to `1`.
@@ -106,7 +106,7 @@ You can use `ignoreDefaultArgs` to filter out `--mute-audio` from default argume
   - `timeout` <[double]> Maximum time in milliseconds to wait for the browser instance to start. Defaults to `30000` (30 seconds). Pass `0` to disable timeout.
   - `timezoneId` <[string]> Changes the timezone of the context. See [ICU's metaZones.txt](https://cs.chromium.org/chromium/src/third_party/icu/source/data/misc/metaZones.txt?rcl=faee8bc70570192d82d2978a71e2a615788597d1) for a list of supported timezone IDs.
   - `userAgent` <[string]> Specific user agent to use in this context.
-  - `viewportSize` <[null]|`ViewportSize`> Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. `null` disables the default viewport.
+  - `viewportSize` <[null]|`ViewportSize`> Emulates consistent viewport for each page. Defaults to an 1280x720 viewport. Use `ViewportSize.NoViewport` to disable the default viewport.
     - `width` <[int]> page width in pixels.
     - `height` <[int]> page height in pixels.
 - returns: <[BrowserContext]>

--- a/csharp/docs/api/class-browsertype.mdx
+++ b/csharp/docs/api/class-browsertype.mdx
@@ -146,7 +146,7 @@ Returns browser name. For example: `'chromium'`, `'webkit'` or `'firefox'`.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-consolemessage.mdx
+++ b/csharp/docs/api/class-consolemessage.mdx
@@ -16,6 +16,8 @@ import TabItem from '@theme/TabItem';
 ## ConsoleMessage.Args()
 - returns: <[IEnumerable]<[JSHandle]>>
 
+List of arguments passed to a `console` function call. See also [event Page.Console](./api/class-page.mdx#eventpageconsole).
+
 ## ConsoleMessage.Location()
 - returns: <[string]>
 
@@ -23,6 +25,8 @@ URL of the resource followed by 0-based line and column numbers in the resource 
 
 ## ConsoleMessage.Text()
 - returns: <[string]>
+
+The text of the console message.
 
 ## ConsoleMessage.Type()
 - returns: <[string]>

--- a/csharp/docs/api/class-consolemessage.mdx
+++ b/csharp/docs/api/class-consolemessage.mdx
@@ -59,7 +59,7 @@ One of the following values: `'log'`, `'debug'`, `'info'`, `'error'`, `'warning'
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-dialog.mdx
+++ b/csharp/docs/api/class-dialog.mdx
@@ -70,7 +70,7 @@ Returns dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prom
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-download.mdx
+++ b/csharp/docs/api/class-download.mdx
@@ -84,7 +84,7 @@ Returns downloaded url.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-elementhandle.mdx
+++ b/csharp/docs/api/class-elementhandle.mdx
@@ -152,7 +152,7 @@ When all steps combined have not finished during the specified `timeout`, this m
 
 ## ElementHandle.DispatchEvent(type[, eventInit])
 - `type` <[string]> DOM event type: `"click"`, `"dragstart"`, etc.
-- `eventInit` <[object]> Optional event-specific initialization properties.
+- `eventInit` <[EvaluationArgument]> Optional event-specific initialization properties.
 
 The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element, `click` is dispatched. This is equivalent to calling [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
 
@@ -172,7 +172,7 @@ You can also specify `JSHandle` as the property value if you want live objects t
 ## ElementHandle.EvalOnSelector(selector, expression[, arg])
 - `selector` <[string]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[object]>
 
 Returns the return value of `expression`.
@@ -186,7 +186,7 @@ Examples:
 ## ElementHandle.EvalOnSelectorAll(selector, expression[, arg])
 - `selector` <[string]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[object]>
 
 Returns the return value of `expression`.
@@ -510,7 +510,7 @@ This method does not work across navigations, use [Page.WaitForSelector(selector
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-elementhandle.mdx
+++ b/csharp/docs/api/class-elementhandle.mdx
@@ -210,7 +210,11 @@ Examples:
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.SetDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.SetDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
-This method waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
+
+To send fine-grained keyboard events, use [ElementHandle.Type(text[, options])](./api/class-elementhandle.mdx#elementhandletypetext-options).
 
 ## ElementHandle.Focus()
 
@@ -351,11 +355,13 @@ Throws when `elementHandle` does not point to an element [connected](https://dev
   - `index` <[int]> Matches by the index. Optional.
 - returns: <[IEnumerable]<[string]>>
 
+This method waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If element is not a `<select>` element, the method throws an error.
-
-Will wait until all specified options are present in the `<select>` element.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
 ## ElementHandle.SelectText([options])
 - `options` <`ElementHandle.SelectTextOptions`>

--- a/csharp/docs/api/class-filechooser.mdx
+++ b/csharp/docs/api/class-filechooser.mdx
@@ -65,7 +65,7 @@ Sets the value of the file input this chooser is associated with. If some of the
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-frame.mdx
+++ b/csharp/docs/api/class-frame.mdx
@@ -255,7 +255,9 @@ A string can also be passed in instead of a function.
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.SetDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.SetDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
-This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
 
 To send fine-grained keyboard events, use [Frame.Type(selector, text[, options])](./api/class-frame.mdx#frametypeselector-text-options).
 
@@ -471,11 +473,13 @@ The method finds all elements matching the specified selector within the frame. 
   - `index` <[int]> Matches by the index. Optional.
 - returns: <[IEnumerable]<[string]>>
 
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element matching `selector`, the method throws an error.
-
-Will wait until all specified options are present in the `<select>` element.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
 ## Frame.SetContent(html[, options])
 - `html` <[string]> HTML markup to assign to the page.

--- a/csharp/docs/api/class-frame.mdx
+++ b/csharp/docs/api/class-frame.mdx
@@ -171,7 +171,7 @@ When all steps combined have not finished during the specified `timeout`, this m
 ## Frame.DispatchEvent(selector, type[, eventInit, options])
 - `selector` <[string]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `type` <[string]> DOM event type: `"click"`, `"dragstart"`, etc.
-- `eventInit` <[object]> Optional event-specific initialization properties.
+- `eventInit` <[EvaluationArgument]> Optional event-specific initialization properties.
 - `options` <`Frame.DispatchEventOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.SetDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.SetDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
@@ -193,7 +193,7 @@ You can also specify `JSHandle` as the property value if you want live objects t
 ## Frame.EvalOnSelector(selector, expression[, arg])
 - `selector` <[string]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[object]>
 
 Returns the return value of `expression`.
@@ -207,7 +207,7 @@ Examples:
 ## Frame.EvalOnSelectorAll(selector, expression[, arg])
 - `selector` <[string]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[object]>
 
 Returns the return value of `expression`.
@@ -220,7 +220,7 @@ Examples:
 
 ## Frame.Evaluate(expression[, arg])
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[object]>
 
 Returns the return value of `expression`.
@@ -235,7 +235,7 @@ A string can also be passed in instead of a function.
 
 ## Frame.EvaluateHandle(expression[, arg])
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the return value of `expression` as a [JSHandle].
@@ -583,7 +583,7 @@ Returns frame's url.
 
 ## Frame.WaitForFunction(expression[, arg, options])
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - `options` <`Frame.WaitForFunctionOptions`>
   - `pollingInterval` <[double]> If specified, then it is treated as an interval in milliseconds at which the function would be executed. By default if the option is not specified `expression` is executed in `requestAnimationFrame` callback.
   - `timeout` <[double]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.SetDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
@@ -686,7 +686,7 @@ Waits for the frame to navigate to the given URL.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-jshandle.mdx
+++ b/csharp/docs/api/class-jshandle.mdx
@@ -31,7 +31,7 @@ The `jsHandle.dispose` method stops referencing the element handle.
 
 ## JsHandle.Evaluate(expression[, arg])
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[object]>
 
 Returns the return value of `expression`.
@@ -44,7 +44,7 @@ Examples:
 
 ## JsHandle.EvaluateHandle(expression[, arg])
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the return value of `expression` as a [JSHandle].
@@ -104,7 +104,7 @@ The method will return an empty JSON object if the referenced object is not stri
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-keyboard.mdx
+++ b/csharp/docs/api/class-keyboard.mdx
@@ -121,7 +121,7 @@ Dispatches a `keyup` event.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-mouse.mdx
+++ b/csharp/docs/api/class-mouse.mdx
@@ -93,7 +93,7 @@ Dispatches a `mouseup` event.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-page.mdx
+++ b/csharp/docs/api/class-page.mdx
@@ -392,7 +392,7 @@ Shortcut for main frame's [Frame.DblClickAsync(selector[, options])](./api/class
 ## Page.DispatchEvent(selector, type[, eventInit, options])
 - `selector` <[string]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `type` <[string]> DOM event type: `"click"`, `"dragstart"`, etc.
-- `eventInit` <[object]> Optional event-specific initialization properties.
+- `eventInit` <[EvaluationArgument]> Optional event-specific initialization properties.
 - `options` <`Page.DispatchEventOptions`>
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.SetDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.SetDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
@@ -421,7 +421,7 @@ This method changes the `CSS media type` through the `media` argument, and/or th
 ## Page.EvalOnSelector(selector, expression[, arg])
 - `selector` <[string]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[object]>
 
 The method finds an element matching the specified selector within the page and passes it as a first argument to `expression`. If no elements match the selector, the method throws an error. Returns the value of `expression`.
@@ -435,7 +435,7 @@ Shortcut for main frame's [Frame.EvalOnSelector(selector, expression[, arg])](./
 ## Page.EvalOnSelectorAll(selector, expression[, arg])
 - `selector` <[string]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[object]>
 
 The method finds all elements matching the specified selector within the page and passes an array of matched elements as a first argument to `expression`. Returns the result of `expression` invocation.
@@ -446,7 +446,7 @@ Examples:
 
 ## Page.Evaluate(expression[, arg])
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[object]>
 
 Returns the value of the `expression` invocation.
@@ -465,7 +465,7 @@ Shortcut for main frame's [Frame.Evaluate(expression[, arg])](./api/class-frame.
 
 ## Page.EvaluateHandle(expression[, arg])
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the value of the `expression` invocation as a [JSHandle].
@@ -1119,7 +1119,7 @@ Performs action and waits for a new [FileChooser] to be created. If predicate is
 
 ## Page.WaitForFunction(expression[, arg, options])
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - `options` <`Page.WaitForFunctionOptions`>
   - `pollingInterval` <[double]> If specified, then it is treated as an interval in milliseconds at which the function would be executed. By default if the option is not specified `expression` is executed in `requestAnimationFrame` callback.
   - `timeout` <[double]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.SetDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
@@ -1293,7 +1293,7 @@ This does not contain ServiceWorkers
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-page.mdx
+++ b/csharp/docs/api/class-page.mdx
@@ -416,6 +416,8 @@ You can also specify `JSHandle` as the property value if you want live objects t
   - `colorScheme` <[null]|"light"|"dark"|"no-preference"> Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. Passing `null` disables color scheme emulation.
   - `media` <[null]|"screen"|"print"> Changes the CSS media type of the page. The only allowed values are `'screen'`, `'print'` and `null`. Passing `null` disables CSS media emulation.
 
+This method changes the `CSS media type` through the `media` argument, and/or the `'prefers-colors-scheme'` media feature, using the `colorScheme` argument.
+
 ## Page.EvalOnSelector(selector, expression[, arg])
 - `selector` <[string]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
@@ -519,11 +521,13 @@ An example of adding an `sha1` function to the page:
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.SetDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.SetDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
-This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
 
 To send fine-grained keyboard events, use [Page.Type(selector, text[, options])](./api/class-page.mdx#pagetypeselector-text-options).
 
-Shortcut for main frame's [Frame.Fill(selector, value[, options])](./api/class-frame.mdx#framefillselector-value-options)
+Shortcut for main frame's [Frame.Fill(selector, value[, options])](./api/class-frame.mdx#framefillselector-value-options).
 
 ## Page.Focus(selector[, options])
 - `selector` <[string]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
@@ -900,13 +904,15 @@ Returns the buffer with the captured screenshot.
   - `index` <[int]> Matches by the index. Optional.
 - returns: <[IEnumerable]<[string]>>
 
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element matching `selector`, the method throws an error.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
-Will wait until all specified options are present in the `<select>` element.
-
-Shortcut for main frame's [Frame.SelectOption(selector[, options], values)](./api/class-frame.mdx#frameselectoptionselector-options-values)
+Shortcut for main frame's [Frame.SelectOption(selector[, options], values)](./api/class-frame.mdx#frameselectoptionselector-options-values).
 
 ## Page.SetContent(html[, options])
 - `html` <[string]> HTML markup to assign to the page.

--- a/csharp/docs/api/class-playwright.mdx
+++ b/csharp/docs/api/class-playwright.mdx
@@ -59,7 +59,7 @@ This object can be used to launch or connect to WebKit, returning instances of [
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-request.mdx
+++ b/csharp/docs/api/class-request.mdx
@@ -151,7 +151,7 @@ URL of the request.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-response.mdx
+++ b/csharp/docs/api/class-response.mdx
@@ -109,7 +109,7 @@ Contains the URL of the response.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-route.mdx
+++ b/csharp/docs/api/class-route.mdx
@@ -87,7 +87,7 @@ Continues route's request with optional overrides.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-selectors.mdx
+++ b/csharp/docs/api/class-selectors.mdx
@@ -44,7 +44,7 @@ An example of registering selector engine that queries elements based on a tag n
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-timeouterror.mdx
+++ b/csharp/docs/api/class-timeouterror.mdx
@@ -37,7 +37,7 @@ TimeoutError is emitted whenever certain operations are terminated due to timeou
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-touchscreen.mdx
+++ b/csharp/docs/api/class-touchscreen.mdx
@@ -42,7 +42,7 @@ Dispatches a `touchstart` and `touchend` event with a single touch at the positi
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-video.mdx
+++ b/csharp/docs/api/class-video.mdx
@@ -52,7 +52,7 @@ Saves the video to a user-specified path. It is safe to call this method while t
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-websocket.mdx
+++ b/csharp/docs/api/class-websocket.mdx
@@ -98,7 +98,7 @@ Performs action and waits for a frame to be sent. If predicate is provided, it p
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-websocketframe.mdx
+++ b/csharp/docs/api/class-websocketframe.mdx
@@ -47,7 +47,7 @@ Returns text payload.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/api/class-worker.mdx
+++ b/csharp/docs/api/class-worker.mdx
@@ -35,7 +35,7 @@ Emitted when this dedicated [WebWorker](https://developer.mozilla.org/en-US/docs
 
 ## Worker.Evaluate(expression[, arg])
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[object]>
 
 Returns the return value of `expression`.
@@ -46,7 +46,7 @@ If the function passed to the [Worker.Evaluate(expression[, arg])](./api/class-w
 
 ## Worker.EvaluateHandle(expression[, arg])
 - `expression` <[string]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the return value of `expression` as a [JSHandle].
@@ -91,7 +91,7 @@ Performs action and waits for the Worker to close.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/assertions.mdx
+++ b/csharp/docs/assertions.mdx
@@ -102,7 +102,7 @@ With Playwright, you can also write custom JavaScript to run in the context of t
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/auth.mdx
+++ b/csharp/docs/auth.mdx
@@ -97,7 +97,7 @@ User data directories can be used with the [BrowserType.LaunchPersistentContext(
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/browsers.mdx
+++ b/csharp/docs/browsers.mdx
@@ -22,6 +22,15 @@ There is also a way to opt into using Google Chrome's or Microsoft Edge's brande
 
 Playwright's Firefox version matches the recent [Firefox Beta](https://www.mozilla.org/en-US/firefox/channel/desktop/) build.
 
+### Firefox-Stable
+
+Playwright team maintains a Playwright Firefox version that matches the latest Firefox Stable, a.k.a. `firefox-stable`.
+
+Using `firefox-stable` is a 2-steps process:
+1. Installing `firefox-stable` with Playwright CLI.
+
+2. Using `firefox-stable` channel when launching browser.
+
 ## WebKit
 
 Playwright's WebKit version matches the recent WebKit trunk build, before it is used in Apple Safari and other WebKit-based browsers. This gives a lot of lead time to react on the potential browser update issues. We are also working on a dedicated support for builds that would match Apple Safari Technology Preview.

--- a/csharp/docs/browsers.mdx
+++ b/csharp/docs/browsers.mdx
@@ -87,7 +87,7 @@ Google Chrome and Microsoft Edge respect enterprise policies, which include limi
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/ci.mdx
+++ b/csharp/docs/ci.mdx
@@ -236,7 +236,7 @@ On Linux agents, headed execution requires [Xvfb](https://en.wikipedia.org/wiki/
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/cli.mdx
+++ b/csharp/docs/cli.mdx
@@ -108,7 +108,7 @@ Opening WebKit Web Inspector will disconnect Playwright from the browser. In suc
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/cli.mdx
+++ b/csharp/docs/cli.mdx
@@ -13,6 +13,7 @@ Playwright comes with the command line tools that run via `npx` or as a part of 
 - [Inspect selectors](#inspect-selectors)
 - [Take screenshot](#take-screenshot)
 - [Generate PDF](#generate-pdf)
+- [Install system dependencies](#install-system-dependencies)
 - [Known limitations](#known-limitations)
 
 ## Usage
@@ -72,6 +73,10 @@ Generates selector for the given element.
 ## Generate PDF
 
 PDF generation only works in Headless Chromium.
+
+## Install system dependencies
+
+Ubuntu 18.04 and Ubuntu 20.04 system dependencies can get installed automatically. This is useful for CI environments.
 
 ## Known limitations
 

--- a/csharp/docs/core-concepts.mdx
+++ b/csharp/docs/core-concepts.mdx
@@ -145,7 +145,7 @@ Wrong:
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/debug.mdx
+++ b/csharp/docs/debug.mdx
@@ -112,7 +112,7 @@ Playwright supports verbose logging with the `DEBUG` environment variable.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/dialogs.mdx
+++ b/csharp/docs/dialogs.mdx
@@ -65,7 +65,7 @@ You can register a dialog handler to handle the beforeunload dialog yourself:
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/docker.mdx
+++ b/csharp/docs/docker.mdx
@@ -110,7 +110,7 @@ Browser builds for Firefox and WebKit are built for the [glibc](https://en.wikip
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/downloads.mdx
+++ b/csharp/docs/downloads.mdx
@@ -55,7 +55,7 @@ Note that handling the event forks the control flow and makes script harder to f
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/emulation.mdx
+++ b/csharp/docs/emulation.mdx
@@ -113,7 +113,7 @@ Create a context with dark or light mode. Pages created in this context will fol
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/events.mdx
+++ b/csharp/docs/events.mdx
@@ -59,7 +59,7 @@ If certain event needs to be handled once, there is a convenience API for that:
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/extensibility.mdx
+++ b/csharp/docs/extensibility.mdx
@@ -46,7 +46,7 @@ An example of registering selector engine that queries elements based on a tag n
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/handles.mdx
+++ b/csharp/docs/handles.mdx
@@ -74,7 +74,7 @@ Handles can be acquired using the page methods such as [Page.EvaluateHandle(expr
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/input.mdx
+++ b/csharp/docs/input.mdx
@@ -182,7 +182,7 @@ For the dynamic pages that handle focus events, you can focus the given element.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/inspector.mdx
+++ b/csharp/docs/inspector.mdx
@@ -99,7 +99,7 @@ You can copy entire generated script or clear it using toolbar actions.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/installation.mdx
+++ b/csharp/docs/installation.mdx
@@ -93,7 +93,7 @@ To opt-out from the unused browser removal, you can set the `PLAYWRIGHT_SKIP_BRO
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/intro.mdx
+++ b/csharp/docs/intro.mdx
@@ -55,11 +55,24 @@ Command Line Interface [CLI](./cli.mdx) can be used to record user interactions 
 ## System requirements
 
 The browser binaries for Chromium, Firefox and WebKit work across the 3 platforms (Windows, macOS, Linux):
-* **Windows**: Works with Windows and Windows Subsystem for Linux (WSL).
-* **macOS**: Requires 10.14 or above.
-* **Linux**: Depending on your Linux distribution, you might need to install additional dependencies to run the browsers.
-  * Firefox requires Ubuntu 18.04+
-  * For Ubuntu 20.04, the additional dependencies are defined in [our Docker image](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.focal), which is based on Ubuntu.
+
+### Windows
+
+Works with Windows and Windows Subsystem for Linux (WSL).
+
+### macOS
+
+Requires 10.14 (Mojave) or above.
+
+### Linux
+
+Depending on your Linux distribution, you might need to install additional dependencies to run the browsers.
+
+:::note
+Only Ubuntu 18.04 and Ubuntu 20.04 are officially supported.
+:::
+
+See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) which has a command to install all necessary dependencies automatically for Ubuntu LTS releases.
 
 [Accessibility]: ./api/class-accessibility.mdx "Accessibility"
 [Browser]: ./api/class-browser.mdx "Browser"

--- a/csharp/docs/intro.mdx
+++ b/csharp/docs/intro.mdx
@@ -100,7 +100,7 @@ See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) 
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/languages.mdx
+++ b/csharp/docs/languages.mdx
@@ -73,7 +73,7 @@ dotnet add package PlaywrightSharp
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/mobile.mdx
+++ b/csharp/docs/mobile.mdx
@@ -56,7 +56,7 @@ See [Android] for documentation.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/multi-pages.mdx
+++ b/csharp/docs/multi-pages.mdx
@@ -78,7 +78,7 @@ If the action that triggers the popup is unknown, the following pattern can be u
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/navigations.mdx
+++ b/csharp/docs/navigations.mdx
@@ -121,7 +121,7 @@ For pages that have complicated loading patterns, [Page.WaitForFunction(expressi
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/network.mdx
+++ b/csharp/docs/network.mdx
@@ -117,7 +117,7 @@ Playwright supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/AP
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/pom.mdx
+++ b/csharp/docs/pom.mdx
@@ -53,7 +53,7 @@ Page objects can then be used inside a test.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/release-notes.mdx
+++ b/csharp/docs/release-notes.mdx
@@ -114,7 +114,7 @@ This version of Playwright was also tested against the following stable channels
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/screenshots.mdx
+++ b/csharp/docs/screenshots.mdx
@@ -55,7 +55,7 @@ Sometimes it is useful to take a screenshot of a single element.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/selectors.mdx
+++ b/csharp/docs/selectors.mdx
@@ -265,7 +265,7 @@ When user-facing attributes change frequently, it is recommended to use explicit
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/showcase.mdx
+++ b/csharp/docs/showcase.mdx
@@ -92,7 +92,7 @@ Did we miss something in this list? Send us a PR!
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/troubleshooting.mdx
+++ b/csharp/docs/troubleshooting.mdx
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 
 Playwright does self-inspection every time it runs to make sure the browsers can be launched successfully. If there are missing dependencies, playwright will print instructions to acquire them.
 
-We also provide [Ubuntu 18.04 dockerfile](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.bionic) and [Ubuntu 20.04 dockerfile](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.focal) with the list of Debian dependencies.
+See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) which has a command to install all necessary dependencies automatically for Ubuntu LTS releases.
 
 ## Code transpilation issues
 
@@ -26,7 +26,7 @@ Some workarounds to this problem would be to instruct the transpiler not to mess
 
 ### ReferenceError: URL is not defined
 
-Playwright requires Node.js 10 or higher. Node.js 8 is not supported, and will cause you to receive this error.
+Playwright requires Node.js 12 or higher. Node.js 8 is not supported, and will cause you to receive this error.
 
 # Please file an issue
 

--- a/csharp/docs/troubleshooting.mdx
+++ b/csharp/docs/troubleshooting.mdx
@@ -58,7 +58,7 @@ Playwright is a new project, and we are watching the issues very closely. As we 
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/verification.mdx
+++ b/csharp/docs/verification.mdx
@@ -70,7 +70,7 @@ Listen for uncaught exceptions in the page with the `pagerror` event.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/videos.mdx
+++ b/csharp/docs/videos.mdx
@@ -48,7 +48,7 @@ Note that the video is only available after the page or browser context is close
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/csharp/docs/why-playwright.mdx
+++ b/csharp/docs/why-playwright.mdx
@@ -69,7 +69,7 @@ Playwright enables fast, reliable and capable automation across all modern brows
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/actionability.mdx
+++ b/java/docs/actionability.mdx
@@ -124,7 +124,7 @@ For example, consider a scenario where Playwright will click `Sign Up` button re
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-browser.mdx
+++ b/java/docs/api/class-browser.mdx
@@ -229,7 +229,7 @@ Returns the browser version.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-browser.mdx
+++ b/java/docs/api/class-browser.mdx
@@ -30,6 +30,8 @@ public class Example {
 - [Browser.isConnected()](./api/class-browser.mdx#browserisconnected)
 - [Browser.newContext([options])](./api/class-browser.mdx#browsernewcontextoptions)
 - [Browser.newPage([options])](./api/class-browser.mdx#browsernewpageoptions)
+- [Browser.startTracing([page, options])](./api/class-browser.mdx#browserstarttracingpage-options)
+- [Browser.stopTracing()](./api/class-browser.mdx#browserstoptracing)
 - [Browser.version()](./api/class-browser.mdx#browserversion)
 
 ## Browser.onDisconnected(handler)
@@ -85,7 +87,7 @@ Indicates that the browser is connected.
   - `setLocale` <[String]> Specify user locale, for example `en-GB`, `de-DE`, etc. Locale will affect `navigator.language` value, `Accept-Language` request header value as well as number and date formatting rules.
   - `setOffline` <[boolean]> Whether to emulate network being offline. Defaults to `false`.
   - `setPermissions` <[List]<[String]>> A list of permissions to grant to all pages in this context. See [BrowserContext.grantPermissions(permissions[, options])](./api/class-browsercontext.mdx#browsercontextgrantpermissionspermissions-options) for more details.
-  - `setProxy` <`Proxy`> Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
+  - `setProxy` <`Proxy`> Network proxy settings to use with this context.
     - `setServer` <[String]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
     - `setBypass` <[String]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
     - `setUsername` <[String]> Optional username to use if HTTP proxy requires authentication.
@@ -140,7 +142,7 @@ page.navigate('https://example.com');
   - `setLocale` <[String]> Specify user locale, for example `en-GB`, `de-DE`, etc. Locale will affect `navigator.language` value, `Accept-Language` request header value as well as number and date formatting rules.
   - `setOffline` <[boolean]> Whether to emulate network being offline. Defaults to `false`.
   - `setPermissions` <[List]<[String]>> A list of permissions to grant to all pages in this context. See [BrowserContext.grantPermissions(permissions[, options])](./api/class-browsercontext.mdx#browsercontextgrantpermissionspermissions-options) for more details.
-  - `setProxy` <`Proxy`> Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
+  - `setProxy` <`Proxy`> Network proxy settings to use with this context.
     - `setServer` <[String]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
     - `setBypass` <[String]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
     - `setUsername` <[String]> Optional username to use if HTTP proxy requires authentication.
@@ -166,6 +168,35 @@ page.navigate('https://example.com');
 Creates a new page in a new browser context. Closing this page will close the context as well.
 
 This is a convenience API that should only be used for the single-page scenarios and short snippets. Production code and testing frameworks should explicitly create [Browser.newContext([options])](./api/class-browser.mdx#browsernewcontextoptions) followed by the [BrowserContext.newPage()](./api/class-browsercontext.mdx#browsercontextnewpage) to control their exact life times.
+
+## Browser.startTracing([page, options])
+- `page` <[Page]> Optional, if specified, tracing includes screenshots of the given page.
+- `options` <`Browser.StartTracingOptions`>
+  - `setCategories` <[List]<[String]>> specify custom categories to use instead of default.
+  - `setPath` <[Path]> A path to write the trace file to.
+  - `setScreenshots` <[boolean]> captures screenshots in the trace.
+
+:::note
+Tracing is only supported on Chromium-based browsers.
+:::
+
+You can use [Browser.startTracing([page, options])](./api/class-browser.mdx#browserstarttracingpage-options) and [Browser.stopTracing()](./api/class-browser.mdx#browserstoptracing) to create a trace file that can be opened in Chrome DevTools performance panel.
+
+```java
+browser.startTracing(page, new Browser.StartTracingOptions()
+  .setPath(Paths.get("trace.json")));
+page.goto('https://www.google.com');
+browser.stopTracing();
+```
+
+## Browser.stopTracing()
+- returns: <[byte&#91;&#93;]>
+
+:::note
+Tracing is only supported on Chromium-based browsers.
+:::
+
+Returns the buffer with trace data.
 
 ## Browser.version()
 - returns: <[String]>

--- a/java/docs/api/class-browsercontext.mdx
+++ b/java/docs/api/class-browsercontext.mdx
@@ -439,7 +439,7 @@ Performs action and waits for a new [Page] to be created in the context. If pred
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-browsertype.mdx
+++ b/java/docs/api/class-browsertype.mdx
@@ -197,7 +197,7 @@ Returns browser name. For example: `'chromium'`, `'webkit'` or `'firefox'`.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-browsertype.mdx
+++ b/java/docs/api/class-browsertype.mdx
@@ -66,7 +66,7 @@ A path where Playwright expects to find a bundled browser executable.
 ## BrowserType.launch([options])
 - `options` <`BrowserType.LaunchOptions`>
   - `setArgs` <[List]<[String]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
-  - `setChannel` <`enum BrowserChannel { CHROME, CHROME_BETA, CHROME_DEV, CHROME_CANARY, MSEDGE, MSEDGE_BETA, MSEDGE_DEV, MSEDGE_CANARY }`> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
+  - `setChannel` <`enum BrowserChannel { CHROME, CHROME_BETA, CHROME_DEV, CHROME_CANARY, MSEDGE, MSEDGE_BETA, MSEDGE_DEV, MSEDGE_CANARY, FIREFOX_STABLE }`> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
   - `setChromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `false`.
   - `setDevtools` <[boolean]> **Chromium-only** Whether to auto-open a Developer Tools panel for each tab. If this option is `true`, the `headless` option will be set `false`.
   - `setDownloadsPath` <[Path]> If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and is deleted when browser is closed.
@@ -110,7 +110,7 @@ Browser browser = chromium.launch(new BrowserType.LaunchOptions()
   - `setAcceptDownloads` <[boolean]> Whether to automatically download all the attachments. Defaults to `false` where all the downloads are canceled.
   - `setArgs` <[List]<[String]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
   - `setBypassCSP` <[boolean]> Toggles bypassing page's Content-Security-Policy.
-  - `setChannel` <`enum BrowserChannel { CHROME, CHROME_BETA, CHROME_DEV, CHROME_CANARY, MSEDGE, MSEDGE_BETA, MSEDGE_DEV, MSEDGE_CANARY }`> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
+  - `setChannel` <`enum BrowserChannel { CHROME, CHROME_BETA, CHROME_DEV, CHROME_CANARY, MSEDGE, MSEDGE_BETA, MSEDGE_DEV, MSEDGE_CANARY, FIREFOX_STABLE }`> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
   - `setChromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `true`.
   - `setColorScheme` <`enum ColorScheme { LIGHT, DARK, NO_PREFERENCE }`> Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. See [Page.emulateMedia([options])](./api/class-page.mdx#pageemulatemediaoptions) for more details. Defaults to `'light'`.
   - `setDeviceScaleFactor` <[double]> Specify device scale factor (can be thought of as dpr). Defaults to `1`.

--- a/java/docs/api/class-consolemessage.mdx
+++ b/java/docs/api/class-consolemessage.mdx
@@ -59,7 +59,7 @@ One of the following values: `'log'`, `'debug'`, `'info'`, `'error'`, `'warning'
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-consolemessage.mdx
+++ b/java/docs/api/class-consolemessage.mdx
@@ -16,6 +16,8 @@ import TabItem from '@theme/TabItem';
 ## ConsoleMessage.args()
 - returns: <[List]<[JSHandle]>>
 
+List of arguments passed to a `console` function call. See also [Page.onConsoleMessage(handler)](./api/class-page.mdx#pageonconsolemessagehandler).
+
 ## ConsoleMessage.location()
 - returns: <[String]>
 
@@ -23,6 +25,8 @@ URL of the resource followed by 0-based line and column numbers in the resource 
 
 ## ConsoleMessage.text()
 - returns: <[String]>
+
+The text of the console message.
 
 ## ConsoleMessage.type()
 - returns: <[String]>

--- a/java/docs/api/class-dialog.mdx
+++ b/java/docs/api/class-dialog.mdx
@@ -90,7 +90,7 @@ Returns dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prom
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-download.mdx
+++ b/java/docs/api/class-download.mdx
@@ -100,7 +100,7 @@ Returns downloaded url.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-elementhandle.mdx
+++ b/java/docs/api/class-elementhandle.mdx
@@ -175,7 +175,7 @@ When all steps combined have not finished during the specified `timeout`, this m
 
 ## ElementHandle.dispatchEvent(type[, eventInit])
 - `type` <[String]> DOM event type: `"click"`, `"dragstart"`, etc.
-- `eventInit` <[Object]> Optional event-specific initialization properties.
+- `eventInit` <[EvaluationArgument]> Optional event-specific initialization properties.
 
 The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element, `click` is dispatched. This is equivalent to calling [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
 
@@ -207,7 +207,7 @@ elementHandle.dispatchEvent("dragstart", arg);
 ## ElementHandle.evalOnSelector(selector, expression[, arg])
 - `selector` <[String]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Object]>
 
 Returns the return value of `expression`.
@@ -227,7 +227,7 @@ assertEquals("10", tweetHandle.evalOnSelector(".retweets", "node => node.innerTe
 ## ElementHandle.evalOnSelectorAll(selector, expression[, arg])
 - `selector` <[String]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Object]>
 
 Returns the return value of `expression`.
@@ -584,7 +584,7 @@ This method does not work across navigations, use [Page.waitForSelector(selector
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-elementhandle.mdx
+++ b/java/docs/api/class-elementhandle.mdx
@@ -256,7 +256,11 @@ assertEquals(Arrays.asList("Hello!", "Hi!"), feedHandle.evalOnSelectorAll(".twee
   - `setNoWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `setTimeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
-This method waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
+
+To send fine-grained keyboard events, use [ElementHandle.type(text[, options])](./api/class-elementhandle.mdx#elementhandletypetext-options).
 
 ## ElementHandle.focus()
 
@@ -397,11 +401,13 @@ Throws when `elementHandle` does not point to an element [connected](https://dev
   - `setTimeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[List]<[String]>>
 
+This method waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If element is not a `<select>` element, the method throws an error.
-
-Will wait until all specified options are present in the `<select>` element.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
 ```java
 // single selection matching the value

--- a/java/docs/api/class-filechooser.mdx
+++ b/java/docs/api/class-filechooser.mdx
@@ -70,7 +70,7 @@ Sets the value of the file input this chooser is associated with. If some of the
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-frame.mdx
+++ b/java/docs/api/class-frame.mdx
@@ -194,7 +194,7 @@ When all steps combined have not finished during the specified `timeout`, this m
 ## Frame.dispatchEvent(selector, type[, eventInit, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `type` <[String]> DOM event type: `"click"`, `"dragstart"`, etc.
-- `eventInit` <[Object]> Optional event-specific initialization properties.
+- `eventInit` <[EvaluationArgument]> Optional event-specific initialization properties.
 - `options` <`Frame.DispatchEventOptions`>
   - `setTimeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
@@ -228,7 +228,7 @@ frame.dispatchEvent("#source", "dragstart", arg);
 ## Frame.evalOnSelector(selector, expression[, arg])
 - `selector` <[String]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Object]>
 
 Returns the return value of `expression`.
@@ -248,7 +248,7 @@ String html = (String) frame.evalOnSelector(".main-container", "(e, suffix) => e
 ## Frame.evalOnSelectorAll(selector, expression[, arg])
 - `selector` <[String]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Object]>
 
 Returns the return value of `expression`.
@@ -265,7 +265,7 @@ boolean divsCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => div
 
 ## Frame.evaluate(expression[, arg])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Object]>
 
 Returns the return value of `expression`.
@@ -297,7 +297,7 @@ bodyHandle.dispose();
 
 ## Frame.evaluateHandle(expression[, arg])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the return value of `expression` as a [JSHandle].
@@ -683,7 +683,7 @@ Returns frame's url.
 
 ## Frame.waitForFunction(expression[, arg, options])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - `options` <`Frame.WaitForFunctionOptions`>
   - `setPollingInterval` <[double]> If specified, then it is treated as an interval in milliseconds at which the function would be executed. By default if the option is not specified `expression` is executed in `requestAnimationFrame` callback.
   - `setTimeout` <[double]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
@@ -848,7 +848,7 @@ frame.waitForURL("**/target.html");
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-frame.mdx
+++ b/java/docs/api/class-frame.mdx
@@ -333,7 +333,9 @@ resultHandle.dispose();
   - `setNoWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `setTimeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
-This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
 
 To send fine-grained keyboard events, use [Frame.type(selector, text[, options])](./api/class-frame.mdx#frametypeselector-text-options).
 
@@ -555,11 +557,13 @@ The method finds all elements matching the specified selector within the frame. 
   - `setTimeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[List]<[String]>>
 
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element matching `selector`, the method throws an error.
-
-Will wait until all specified options are present in the `<select>` element.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
 ```java
 // single selection matching the value

--- a/java/docs/api/class-jshandle.mdx
+++ b/java/docs/api/class-jshandle.mdx
@@ -36,7 +36,7 @@ The `jsHandle.dispose` method stops referencing the element handle.
 
 ## JsHandle.evaluate(expression[, arg])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Object]>
 
 Returns the return value of `expression`.
@@ -54,7 +54,7 @@ assertEquals("10 retweets", tweetHandle.evaluate("node => node.innerText"));
 
 ## JsHandle.evaluateHandle(expression[, arg])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the return value of `expression` as a [JSHandle].
@@ -122,7 +122,7 @@ The method will return an empty JSON object if the referenced object is not stri
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-keyboard.mdx
+++ b/java/docs/api/class-keyboard.mdx
@@ -168,7 +168,7 @@ Dispatches a `keyup` event.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-mouse.mdx
+++ b/java/docs/api/class-mouse.mdx
@@ -94,7 +94,7 @@ Dispatches a `mouseup` event.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-page.mdx
+++ b/java/docs/api/class-page.mdx
@@ -457,7 +457,7 @@ Shortcut for main frame's [Frame.dblclick(selector[, options])](./api/class-fram
 ## Page.dispatchEvent(selector, type[, eventInit, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `type` <[String]> DOM event type: `"click"`, `"dragstart"`, etc.
-- `eventInit` <[Object]> Optional event-specific initialization properties.
+- `eventInit` <[EvaluationArgument]> Optional event-specific initialization properties.
 - `options` <`Page.DispatchEventOptions`>
   - `setTimeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
@@ -527,7 +527,7 @@ page.evaluate("() => matchMedia('(prefers-color-scheme: no-preference)').matches
 ## Page.evalOnSelector(selector, expression[, arg])
 - `selector` <[String]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Object]>
 
 The method finds an element matching the specified selector within the page and passes it as a first argument to `expression`. If no elements match the selector, the method throws an error. Returns the value of `expression`.
@@ -547,7 +547,7 @@ Shortcut for main frame's [Frame.evalOnSelector(selector, expression[, arg])](./
 ## Page.evalOnSelectorAll(selector, expression[, arg])
 - `selector` <[String]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Object]>
 
 The method finds all elements matching the specified selector within the page and passes an array of matched elements as a first argument to `expression`. Returns the result of `expression` invocation.
@@ -562,7 +562,7 @@ boolean divCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs
 
 ## Page.evaluate(expression[, arg])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Object]>
 
 Returns the value of the `expression` invocation.
@@ -598,7 +598,7 @@ Shortcut for main frame's [Frame.evaluate(expression[, arg])](./api/class-frame.
 
 ## Page.evaluateHandle(expression[, arg])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the value of the `expression` invocation as a [JSHandle].
@@ -1446,7 +1446,7 @@ Performs action and waits for a new [FileChooser] to be created. If predicate is
 
 ## Page.waitForFunction(expression[, arg, options])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - `options` <`Page.WaitForFunctionOptions`>
   - `setPollingInterval` <[double]> If specified, then it is treated as an interval in milliseconds at which the function would be executed. By default if the option is not specified `expression` is executed in `requestAnimationFrame` callback.
   - `setTimeout` <[double]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout).
@@ -1723,7 +1723,7 @@ This does not contain ServiceWorkers
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-page.mdx
+++ b/java/docs/api/class-page.mdx
@@ -165,7 +165,7 @@ The arguments passed into `console.log` appear as arguments on the event handler
 An example of handling `console` event:
 
 ```java
-page.onConsole(msg -> {
+page.onConsoleMessage(msg -> {
   for (int i = 0; i < msg.args().size(); ++i)
     System.out.println(i + ": " + msg.args().get(i).jsonValue());
 });
@@ -493,6 +493,8 @@ page.dispatchEvent("#source", "dragstart", arg);
   - `setColorScheme` <[null]|`enum ColorScheme { LIGHT, DARK, NO_PREFERENCE }`> Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. Passing `null` disables color scheme emulation.
   - `setMedia` <[null]|`enum Media { SCREEN, PRINT }`> Changes the CSS media type of the page. The only allowed values are `'screen'`, `'print'` and `null`. Passing `null` disables CSS media emulation.
 
+This method changes the `CSS media type` through the `media` argument, and/or the `'prefers-colors-scheme'` media feature, using the `colorScheme` argument.
+
 ```java
 page.evaluate("() => matchMedia('screen').matches");
 // → true
@@ -744,11 +746,13 @@ public class Example {
   - `setNoWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `setTimeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
-This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
 
 To send fine-grained keyboard events, use [Page.type(selector, text[, options])](./api/class-page.mdx#pagetypeselector-text-options).
 
-Shortcut for main frame's [Frame.fill(selector, value[, options])](./api/class-frame.mdx#framefillselector-value-options)
+Shortcut for main frame's [Frame.fill(selector, value[, options])](./api/class-frame.mdx#framefillselector-value-options).
 
 ## Page.focus(selector[, options])
 - `selector` <[String]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
@@ -1209,11 +1213,13 @@ Returns the buffer with the captured screenshot.
   - `setTimeout` <[double]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [BrowserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [Page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[List]<[String]>>
 
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element matching `selector`, the method throws an error.
-
-Will wait until all specified options are present in the `<select>` element.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
 ```java
 // single selection matching the value
@@ -1224,7 +1230,7 @@ page.selectOption("select#colors", new SelectOption().setLabel("Blue"));
 page.selectOption("select#colors", new String[] {"red", "green", "blue"});
 ```
 
-Shortcut for main frame's [Frame.selectOption(selector, values[, options])](./api/class-frame.mdx#frameselectoptionselector-values-options)
+Shortcut for main frame's [Frame.selectOption(selector, values[, options])](./api/class-frame.mdx#frameselectoptionselector-values-options).
 
 ## Page.setContent(html[, options])
 - `html` <[String]> HTML markup to assign to the page.

--- a/java/docs/api/class-playwright.mdx
+++ b/java/docs/api/class-playwright.mdx
@@ -95,7 +95,7 @@ This object can be used to launch or connect to WebKit, returning instances of [
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-playwrightexception.mdx
+++ b/java/docs/api/class-playwrightexception.mdx
@@ -37,7 +37,7 @@ PlaywrightException is thrown whenever certain operations are terminated abnorma
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-request.mdx
+++ b/java/docs/api/class-request.mdx
@@ -171,7 +171,7 @@ URL of the request.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-response.mdx
+++ b/java/docs/api/class-response.mdx
@@ -95,7 +95,7 @@ Contains the URL of the response.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-route.mdx
+++ b/java/docs/api/class-route.mdx
@@ -112,7 +112,7 @@ page.route("**/*", route -> {
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-selectors.mdx
+++ b/java/docs/api/class-selectors.mdx
@@ -71,7 +71,7 @@ browser.close();
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-timeouterror.mdx
+++ b/java/docs/api/class-timeouterror.mdx
@@ -37,7 +37,7 @@ TimeoutError is emitted whenever certain operations are terminated due to timeou
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-touchscreen.mdx
+++ b/java/docs/api/class-touchscreen.mdx
@@ -42,7 +42,7 @@ Dispatches a `touchstart` and `touchend` event with a single touch at the positi
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-video.mdx
+++ b/java/docs/api/class-video.mdx
@@ -56,7 +56,7 @@ Saves the video to a user-specified path. It is safe to call this method while t
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-websocket.mdx
+++ b/java/docs/api/class-websocket.mdx
@@ -91,7 +91,7 @@ Performs action and waits for a frame to be sent. If predicate is provided, it p
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-websocketframe.mdx
+++ b/java/docs/api/class-websocketframe.mdx
@@ -47,7 +47,7 @@ Returns text payload.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/api/class-worker.mdx
+++ b/java/docs/api/class-worker.mdx
@@ -31,7 +31,7 @@ Emitted when this dedicated [WebWorker](https://developer.mozilla.org/en-US/docs
 
 ## Worker.evaluate(expression[, arg])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Object]>
 
 Returns the return value of `expression`.
@@ -42,7 +42,7 @@ If the function passed to the [Worker.evaluate(expression[, arg])](./api/class-w
 
 ## Worker.evaluateHandle(expression[, arg])
 - `expression` <[String]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Object]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the return value of `expression` as a [JSHandle].
@@ -88,7 +88,7 @@ Performs action and waits for the Worker to close.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/assertions.mdx
+++ b/java/docs/assertions.mdx
@@ -161,7 +161,7 @@ assertEquals(3, length);
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/auth.mdx
+++ b/java/docs/auth.mdx
@@ -151,7 +151,7 @@ public class Example {
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/browsers.mdx
+++ b/java/docs/browsers.mdx
@@ -22,6 +22,32 @@ There is also a way to opt into using Google Chrome's or Microsoft Edge's brande
 
 Playwright's Firefox version matches the recent [Firefox Beta](https://www.mozilla.org/en-US/firefox/channel/desktop/) build.
 
+### Firefox-Stable
+
+Playwright team maintains a Playwright Firefox version that matches the latest Firefox Stable, a.k.a. `firefox-stable`.
+
+Using `firefox-stable` is a 2-steps process:
+1. Installing `firefox-stable` with Playwright CLI.
+
+   ```sh
+   $ mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install firefox-stable"
+   ```
+
+2. Using `firefox-stable` channel when launching browser.
+
+```java
+import com.microsoft.playwright.*;
+
+public class Example {
+  public static void main(String[] args) {
+    try (Playwright playwright = Playwright.create()) {
+      BrowserType firefox = playwright.firefox();
+      Browser browser = firefox.launch(new BrowserType.LaunchOptions().setChannel("firefox-stable"));
+    }
+  }
+}
+```
+
 ## WebKit
 
 Playwright's WebKit version matches the recent WebKit trunk build, before it is used in Apple Safari and other WebKit-based browsers. This gives a lot of lead time to react on the potential browser update issues. We are also working on a dedicated support for builds that would match Apple Safari Technology Preview.

--- a/java/docs/browsers.mdx
+++ b/java/docs/browsers.mdx
@@ -118,7 +118,7 @@ Google Chrome and Microsoft Edge respect enterprise policies, which include limi
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/ci.mdx
+++ b/java/docs/ci.mdx
@@ -268,7 +268,7 @@ On Linux agents, headed execution requires [Xvfb](https://en.wikipedia.org/wiki/
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/cli.mdx
+++ b/java/docs/cli.mdx
@@ -13,6 +13,7 @@ Playwright comes with the command line tools that run via `npx` or as a part of 
 - [Inspect selectors](#inspect-selectors)
 - [Take screenshot](#take-screenshot)
 - [Generate PDF](#generate-pdf)
+- [Install system dependencies](#install-system-dependencies)
 - [Known limitations](#known-limitations)
 
 ## Usage
@@ -159,6 +160,15 @@ PDF generation only works in Headless Chromium.
 ```sh
 # See command help
 $ mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="pdf https://en.wikipedia.org/wiki/PDF wiki.pdf"
+```
+
+## Install system dependencies
+
+Ubuntu 18.04 and Ubuntu 20.04 system dependencies can get installed automatically. This is useful for CI environments.
+
+```sh
+# See command help
+$ mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install-deps"
 ```
 
 ## Known limitations

--- a/java/docs/cli.mdx
+++ b/java/docs/cli.mdx
@@ -201,7 +201,7 @@ Opening WebKit Web Inspector will disconnect Playwright from the browser. In suc
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/core-concepts.mdx
+++ b/java/docs/core-concepts.mdx
@@ -367,7 +367,7 @@ Object result = page.evaluate("() => {\n" +
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/debug.mdx
+++ b/java/docs/debug.mdx
@@ -137,7 +137,7 @@ $ mvn test
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/dialogs.mdx
+++ b/java/docs/dialogs.mdx
@@ -84,7 +84,7 @@ page.close(new Page.CloseOptions().setRunBeforeUnload(true));
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/docker.mdx
+++ b/java/docs/docker.mdx
@@ -126,7 +126,7 @@ Browser builds for Firefox and WebKit are built for the [glibc](https://en.wikip
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/downloads.mdx
+++ b/java/docs/downloads.mdx
@@ -59,7 +59,7 @@ Note that handling the event forks the control flow and makes script harder to f
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/emulation.mdx
+++ b/java/docs/emulation.mdx
@@ -183,7 +183,7 @@ page.emulateMedia(new Page.EmulateMediaOptions().setMedia(Media.PRINT));
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/events.mdx
+++ b/java/docs/events.mdx
@@ -93,7 +93,7 @@ page.evaluate("prompt('Enter a number:')");
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/extensibility.mdx
+++ b/java/docs/extensibility.mdx
@@ -74,7 +74,7 @@ int buttonCount = (int) page.evalOnSelectorAll("tag=button", "buttons => buttons
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/handles.mdx
+++ b/java/docs/handles.mdx
@@ -118,7 +118,7 @@ Handles can be acquired using the page methods such as [Page.evaluateHandle(expr
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/input.mdx
+++ b/java/docs/input.mdx
@@ -306,7 +306,7 @@ page.focus("input#name");
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/inspector.mdx
+++ b/java/docs/inspector.mdx
@@ -119,7 +119,7 @@ You can copy entire generated script or clear it using toolbar actions.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/installation.mdx
+++ b/java/docs/installation.mdx
@@ -136,7 +136,7 @@ To opt-out from the unused browser removal, you can set the `PLAYWRIGHT_SKIP_BRO
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/intro.mdx
+++ b/java/docs/intro.mdx
@@ -129,11 +129,24 @@ $ mvn exec:java -e -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="co
 ## System requirements
 
 Playwright requires **Java 8** or newer. The browser binaries for Chromium, Firefox and WebKit work across the 3 platforms (Windows, macOS, Linux):
-* **Windows**: Works with Windows and Windows Subsystem for Linux (WSL).
-* **macOS**: Requires 10.14 or above.
-* **Linux**: Depending on your Linux distribution, you might need to install additional dependencies to run the browsers.
-  * Firefox requires Ubuntu 18.04+
-  * For Ubuntu 20.04, the additional dependencies are defined in [our Docker image](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.focal), which is based on Ubuntu.
+
+### Windows
+
+Works with Windows and Windows Subsystem for Linux (WSL).
+
+### macOS
+
+Requires 10.14 (Mojave) or above.
+
+### Linux
+
+Depending on your Linux distribution, you might need to install additional dependencies to run the browsers.
+
+:::note
+Only Ubuntu 18.04 and Ubuntu 20.04 are officially supported.
+:::
+
+See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) which has a command to install all necessary dependencies automatically for Ubuntu LTS releases.
 
 [Browser]: ./api/class-browser.mdx "Browser"
 [BrowserContext]: ./api/class-browsercontext.mdx "BrowserContext"

--- a/java/docs/intro.mdx
+++ b/java/docs/intro.mdx
@@ -174,7 +174,7 @@ See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) 
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/languages.mdx
+++ b/java/docs/languages.mdx
@@ -73,7 +73,7 @@ dotnet add package PlaywrightSharp
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/mobile.mdx
+++ b/java/docs/mobile.mdx
@@ -56,7 +56,7 @@ See [Android] for documentation.
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/multi-pages.mdx
+++ b/java/docs/multi-pages.mdx
@@ -142,7 +142,7 @@ page.onPopup(popup -> {
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/navigations.mdx
+++ b/java/docs/navigations.mdx
@@ -198,7 +198,7 @@ page.screenshot();
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/network.mdx
+++ b/java/docs/network.mdx
@@ -222,7 +222,7 @@ page.onWebSocket(ws -> {
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/pom.mdx
+++ b/java/docs/pom.mdx
@@ -89,7 +89,7 @@ searchPage.search("search query");
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/release-notes.mdx
+++ b/java/docs/release-notes.mdx
@@ -114,7 +114,7 @@ This version of Playwright was also tested against the following stable channels
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/screenshots.mdx
+++ b/java/docs/screenshots.mdx
@@ -71,7 +71,7 @@ elementHandle.screenshot(new ElementHandle.ScreenshotOptions().setPath(Paths.get
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/selectors.mdx
+++ b/java/docs/selectors.mdx
@@ -433,7 +433,7 @@ page.click("//*[@id='tsf']/div[2]/div[1]/div[1]/div/div[2]/input");
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/showcase.mdx
+++ b/java/docs/showcase.mdx
@@ -92,7 +92,7 @@ Did we miss something in this list? Send us a PR!
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/troubleshooting.mdx
+++ b/java/docs/troubleshooting.mdx
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 
 Playwright does self-inspection every time it runs to make sure the browsers can be launched successfully. If there are missing dependencies, playwright will print instructions to acquire them.
 
-We also provide [Ubuntu 18.04 dockerfile](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.bionic) and [Ubuntu 20.04 dockerfile](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.focal) with the list of Debian dependencies.
+See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) which has a command to install all necessary dependencies automatically for Ubuntu LTS releases.
 
 ## Code transpilation issues
 
@@ -26,7 +26,7 @@ Some workarounds to this problem would be to instruct the transpiler not to mess
 
 ### ReferenceError: URL is not defined
 
-Playwright requires Node.js 10 or higher. Node.js 8 is not supported, and will cause you to receive this error.
+Playwright requires Node.js 12 or higher. Node.js 8 is not supported, and will cause you to receive this error.
 
 # Please file an issue
 

--- a/java/docs/troubleshooting.mdx
+++ b/java/docs/troubleshooting.mdx
@@ -58,7 +58,7 @@ Playwright is a new project, and we are watching the issues very closely. As we 
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/verification.mdx
+++ b/java/docs/verification.mdx
@@ -15,10 +15,10 @@ Console messages logged in the page can be brought into the Playwright context.
 
 ```java
 // Listen for all System.out.printlns
-page.onConsole(msg -> System.out.println(msg.text()));
+page.onConsoleMessage(msg -> System.out.println(msg.text()));
 
 // Listen for all console events and handle errors
-page.onConsole(msg -> {
+page.onConsoleMessage(msg -> {
   if ("error".equals(msg.type()))
     System.out.println("Error text: " + msg.text());
 });

--- a/java/docs/verification.mdx
+++ b/java/docs/verification.mdx
@@ -119,7 +119,7 @@ Page popup = page.waitForPopup(() -> {
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/videos.mdx
+++ b/java/docs/videos.mdx
@@ -64,7 +64,7 @@ Note that the video is only available after the page or browser context is close
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/java/docs/why-playwright.mdx
+++ b/java/docs/why-playwright.mdx
@@ -69,7 +69,7 @@ Playwright enables fast, reliable and capable automation across all modern brows
 [WebSocketFrame]: ./api/class-websocketframe.mdx "WebSocketFrame"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/actionability.mdx
+++ b/nodejs/docs/actionability.mdx
@@ -134,7 +134,7 @@ For example, consider a scenario where Playwright will click `Sign Up` button re
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-accessibility.mdx
+++ b/nodejs/docs/api/class-accessibility.mdx
@@ -116,7 +116,7 @@ function findFocusedNode(node) {
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-android.mdx
+++ b/nodejs/docs/api/class-android.mdx
@@ -120,7 +120,7 @@ This setting will change the default maximum time for all the methods accepting 
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-androiddevice.mdx
+++ b/nodejs/docs/api/class-androiddevice.mdx
@@ -308,7 +308,7 @@ Currently open WebViews.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-androidinput.mdx
+++ b/nodejs/docs/api/class-androidinput.mdx
@@ -87,7 +87,7 @@ Types `text` into currently focused widget.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-androidsocket.mdx
+++ b/nodejs/docs/api/class-androidsocket.mdx
@@ -67,7 +67,7 @@ Writes some `data` to the socket.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-androidwebview.mdx
+++ b/nodejs/docs/api/class-androidwebview.mdx
@@ -68,7 +68,7 @@ WebView package identifier.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-browser.mdx
+++ b/nodejs/docs/api/class-browser.mdx
@@ -96,7 +96,7 @@ Returns the newly created browser session.
   - `logger` <[Logger]> Logger sink for Playwright logging.
   - `offline` <[boolean]> Whether to emulate network being offline. Defaults to `false`.
   - `permissions` <[Array]<[string]>> A list of permissions to grant to all pages in this context. See [browserContext.grantPermissions(permissions[, options])](./api/class-browsercontext.mdx#browsercontextgrantpermissionspermissions-options) for more details.
-  - `proxy` <[Object]> Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
+  - `proxy` <[Object]> Network proxy settings to use with this context.
     - `server` <[string]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
     - `bypass` <[string]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
     - `username` <[string]> Optional username to use if HTTP proxy requires authentication.
@@ -174,7 +174,7 @@ Creates a new browser context. It won't share cookies/cache with other browser c
   - `logger` <[Logger]> Logger sink for Playwright logging.
   - `offline` <[boolean]> Whether to emulate network being offline. Defaults to `false`.
   - `permissions` <[Array]<[string]>> A list of permissions to grant to all pages in this context. See [browserContext.grantPermissions(permissions[, options])](./api/class-browsercontext.mdx#browsercontextgrantpermissionspermissions-options) for more details.
-  - `proxy` <[Object]> Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
+  - `proxy` <[Object]> Network proxy settings to use with this context.
     - `server` <[string]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
     - `bypass` <[string]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
     - `username` <[string]> Optional username to use if HTTP proxy requires authentication.

--- a/nodejs/docs/api/class-browser.mdx
+++ b/nodejs/docs/api/class-browser.mdx
@@ -290,7 +290,7 @@ Returns the browser version.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-browsercontext.mdx
+++ b/nodejs/docs/api/class-browsercontext.mdx
@@ -522,7 +522,7 @@ const [page, _] = await Promise.all([
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-browserserver.mdx
+++ b/nodejs/docs/api/class-browserserver.mdx
@@ -72,7 +72,7 @@ Browser websocket endpoint which can be used as an argument to [browserType.conn
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-browsertype.mdx
+++ b/nodejs/docs/api/class-browsertype.mdx
@@ -64,7 +64,7 @@ A path where Playwright expects to find a bundled browser executable.
 ## browserType.launch([options])
 - `options` <[Object]>
   - `args` <[Array]<[string]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
-  - `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
+  - `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"|"firefox-stable"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
   - `chromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `false`.
   - `devtools` <[boolean]> **Chromium-only** Whether to auto-open a Developer Tools panel for each tab. If this option is `true`, the `headless` option will be set `false`.
   - `downloadsPath` <[string]> If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and is deleted when browser is closed.
@@ -108,7 +108,7 @@ const browser = await chromium.launch({  // Or 'firefox' or 'webkit'.
   - `acceptDownloads` <[boolean]> Whether to automatically download all the attachments. Defaults to `false` where all the downloads are canceled.
   - `args` <[Array]<[string]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
   - `bypassCSP` <[boolean]> Toggles bypassing page's Content-Security-Policy.
-  - `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
+  - `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"|"firefox-stable"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
   - `chromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `true`.
   - `colorScheme` <"light"|"dark"|"no-preference"> Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. See [page.emulateMedia([options])](./api/class-page.mdx#pageemulatemediaoptions) for more details. Defaults to `'light'`.
   - `deviceScaleFactor` <[number]> Specify device scale factor (can be thought of as dpr). Defaults to `1`.
@@ -173,7 +173,7 @@ Launches browser that uses persistent storage located at `userDataDir` and retur
 ## browserType.launchServer([options])
 - `options` <[Object]>
   - `args` <[Array]<[string]>> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
-  - `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
+  - `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"|"firefox-stable"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
   - `chromiumSandbox` <[boolean]> Enable Chromium sandboxing. Defaults to `true`.
   - `devtools` <[boolean]> **Chromium-only** Whether to auto-open a Developer Tools panel for each tab. If this option is `true`, the `headless` option will be set `false`.
   - `downloadsPath` <[string]> If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and is deleted when browser is closed.

--- a/nodejs/docs/api/class-browsertype.mdx
+++ b/nodejs/docs/api/class-browsertype.mdx
@@ -253,7 +253,7 @@ Returns browser name. For example: `'chromium'`, `'webkit'` or `'firefox'`.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-cdpsession.mdx
+++ b/nodejs/docs/api/class-cdpsession.mdx
@@ -75,7 +75,7 @@ Detaches the CDPSession from the target. Once detached, the CDPSession object wo
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-consolemessage.mdx
+++ b/nodejs/docs/api/class-consolemessage.mdx
@@ -16,6 +16,8 @@ import TabItem from '@theme/TabItem';
 ## consoleMessage.args()
 - returns: <[Array]<[JSHandle]>>
 
+List of arguments passed to a `console` function call. See also [page.on('console')](./api/class-page.mdx#pageonconsole).
+
 ## consoleMessage.location()
 - returns: <[Object]>
   - `url` <[string]> URL of the resource.
@@ -24,6 +26,8 @@ import TabItem from '@theme/TabItem';
 
 ## consoleMessage.text()
 - returns: <[string]>
+
+The text of the console message.
 
 ## consoleMessage.type()
 - returns: <[string]>

--- a/nodejs/docs/api/class-consolemessage.mdx
+++ b/nodejs/docs/api/class-consolemessage.mdx
@@ -70,7 +70,7 @@ One of the following values: `'log'`, `'debug'`, `'info'`, `'error'`, `'warning'
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-coverage.mdx
+++ b/nodejs/docs/api/class-coverage.mdx
@@ -126,7 +126,7 @@ JavaScript Coverage doesn't include anonymous scripts by default. However, scrip
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-dialog.mdx
+++ b/nodejs/docs/api/class-dialog.mdx
@@ -95,7 +95,7 @@ Returns dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prom
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-download.mdx
+++ b/nodejs/docs/api/class-download.mdx
@@ -103,7 +103,7 @@ Returns downloaded url.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-electron.mdx
+++ b/nodejs/docs/api/class-electron.mdx
@@ -98,7 +98,7 @@ Launches electron application specified with the `executablePath`.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-electronapplication.mdx
+++ b/nodejs/docs/api/class-electronapplication.mdx
@@ -40,6 +40,7 @@ const { _electron: electron } = require('playwright');
 
 - [electronApplication.on('close')](./api/class-electronapplication.mdx#electronapplicationonclose)
 - [electronApplication.on('window')](./api/class-electronapplication.mdx#electronapplicationonwindow)
+- [electronApplication.browserWindow(page)](./api/class-electronapplication.mdx#electronapplicationbrowserwindowpage)
 - [electronApplication.close()](./api/class-electronapplication.mdx#electronapplicationclose)
 - [electronApplication.context()](./api/class-electronapplication.mdx#electronapplicationcontext)
 - [electronApplication.evaluate(pageFunction[, arg])](./api/class-electronapplication.mdx#electronapplicationevaluatepagefunction-arg)
@@ -56,6 +57,12 @@ This event is issued when the application closes.
 - type: <[Page]>
 
 This event is issued for every window that is created **and loaded** in Electron. It contains a [Page] that can be used for Playwright automation.
+
+## electronApplication.browserWindow(page)
+- `page` <[Page]> Page to retrieve the window for.
+- returns: <[Promise]<[JSHandle]>>
+
+Returns the BrowserWindow object that corresponds to the given Playwright page.
 
 ## electronApplication.close()
 

--- a/nodejs/docs/api/class-electronapplication.mdx
+++ b/nodejs/docs/api/class-electronapplication.mdx
@@ -165,7 +165,7 @@ Convenience method that returns all the opened windows.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-elementhandle.mdx
+++ b/nodejs/docs/api/class-elementhandle.mdx
@@ -261,7 +261,11 @@ await elementHandle.dispatchEvent('dragstart', { dataTransfer });
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
-This method waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
+
+To send fine-grained keyboard events, use [elementHandle.type(text[, options])](./api/class-elementhandle.mdx#elementhandletypetext-options).
 
 ## elementHandle.focus()
 
@@ -390,11 +394,13 @@ Throws when `elementHandle` does not point to an element [connected](https://dev
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[Promise]<[Array]<[string]>>>
 
+This method waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If element is not a `<select>` element, the method throws an error.
-
-Will wait until all specified options are present in the `<select>` element.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
 ```js
 // single selection matching the value

--- a/nodejs/docs/api/class-elementhandle.mdx
+++ b/nodejs/docs/api/class-elementhandle.mdx
@@ -588,7 +588,7 @@ This method does not work across navigations, use [page.waitForSelector(selector
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-filechooser.mdx
+++ b/nodejs/docs/api/class-filechooser.mdx
@@ -83,7 +83,7 @@ Sets the value of the file input this chooser is associated with. If some of the
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-frame.mdx
+++ b/nodejs/docs/api/class-frame.mdx
@@ -343,7 +343,9 @@ await resultHandle.dispose();
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
-This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
 
 To send fine-grained keyboard events, use [frame.type(selector, text[, options])](./api/class-frame.mdx#frametypeselector-text-options).
 
@@ -549,11 +551,13 @@ Shortcuts such as `key: "Control+o"` or `key: "Control+Shift+T"` are supported a
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[Promise]<[Array]<[string]>>>
 
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element matching `selector`, the method throws an error.
-
-Will wait until all specified options are present in the `<select>` element.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
 ```js
 // single selection matching the value

--- a/nodejs/docs/api/class-frame.mdx
+++ b/nodejs/docs/api/class-frame.mdx
@@ -841,7 +841,7 @@ await frame.waitForURL('**/target.html');
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-jshandle.mdx
+++ b/nodejs/docs/api/class-jshandle.mdx
@@ -132,7 +132,7 @@ The method will return an empty JSON object if the referenced object is not stri
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-keyboard.mdx
+++ b/nodejs/docs/api/class-keyboard.mdx
@@ -178,7 +178,7 @@ Dispatches a `keyup` event.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-logger.mdx
+++ b/nodejs/docs/api/class-logger.mdx
@@ -76,7 +76,7 @@ Determines whether sink is interested in the logger with the given name and seve
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-mouse.mdx
+++ b/nodejs/docs/api/class-mouse.mdx
@@ -104,7 +104,7 @@ Dispatches a `mouseup` event.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-page.mdx
+++ b/nodejs/docs/api/class-page.mdx
@@ -156,11 +156,11 @@ The arguments passed into `console.log` appear as arguments on the event handler
 An example of handling `console` event:
 
 ```js
-page.on('console', msg => {
+page.on('console', async msg => {
   for (let i = 0; i < msg.args().length; ++i)
     console.log(`${i}: ${await msg.args()[i].jsonValue()}`);
 });
-page.evaluate(() => console.log('hello', 5, {foo: 'bar'}));
+await page.evaluate(() => console.log('hello', 5, {foo: 'bar'}));
 ```
 
 ## page.on('crash')
@@ -538,6 +538,8 @@ await page.dispatchEvent('#source', 'dragstart', { dataTransfer });
   - `colorScheme` <[null]|"light"|"dark"|"no-preference"> Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. Passing `null` disables color scheme emulation.
   - `media` <[null]|"screen"|"print"> Changes the CSS media type of the page. The only allowed values are `'screen'`, `'print'` and `null`. Passing `null` disables CSS media emulation.
 
+This method changes the `CSS media type` through the `media` argument, and/or the `'prefers-colors-scheme'` media feature, using the `colorScheme` argument.
+
 ```js
 await page.evaluate(() => matchMedia('screen').matches);
 // → true
@@ -734,11 +736,13 @@ const crypto = require('crypto');
   - `noWaitAfter` <[boolean]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 
-This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
 
 To send fine-grained keyboard events, use [page.type(selector, text[, options])](./api/class-page.mdx#pagetypeselector-text-options).
 
-Shortcut for main frame's [frame.fill(selector, value[, options])](./api/class-frame.mdx#framefillselector-value-options)
+Shortcut for main frame's [frame.fill(selector, value[, options])](./api/class-frame.mdx#framefillselector-value-options).
 
 ## page.focus(selector[, options])
 - `selector` <[string]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
@@ -1144,11 +1148,13 @@ Returns the buffer with the captured screenshot.
   - `timeout` <[number]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout(timeout)](./api/class-browsercontext.mdx#browsercontextsetdefaulttimeouttimeout) or [page.setDefaultTimeout(timeout)](./api/class-page.mdx#pagesetdefaulttimeouttimeout) methods.
 - returns: <[Promise]<[Array]<[string]>>>
 
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element matching `selector`, the method throws an error.
-
-Will wait until all specified options are present in the `<select>` element.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
 ```js
 // single selection matching the value
@@ -1162,7 +1168,7 @@ page.selectOption('select#colors', ['red', 'green', 'blue']);
 
 ```
 
-Shortcut for main frame's [frame.selectOption(selector, values[, options])](./api/class-frame.mdx#frameselectoptionselector-values-options)
+Shortcut for main frame's [frame.selectOption(selector, values[, options])](./api/class-frame.mdx#frameselectoptionselector-values-options).
 
 ## page.setContent(html[, options])
 - `html` <[string]> HTML markup to assign to the page.

--- a/nodejs/docs/api/class-page.mdx
+++ b/nodejs/docs/api/class-page.mdx
@@ -1642,7 +1642,7 @@ Browser-specific Coverage implementation. See [Coverage](#class-coverage) for mo
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-playwright.mdx
+++ b/nodejs/docs/api/class-playwright.mdx
@@ -124,7 +124,7 @@ This object can be used to launch or connect to WebKit, returning instances of [
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-request.mdx
+++ b/nodejs/docs/api/class-request.mdx
@@ -190,7 +190,7 @@ URL of the request.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-response.mdx
+++ b/nodejs/docs/api/class-response.mdx
@@ -113,7 +113,7 @@ Contains the URL of the response.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-route.mdx
+++ b/nodejs/docs/api/class-route.mdx
@@ -122,7 +122,7 @@ A request to be routed.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-selectors.mdx
+++ b/nodejs/docs/api/class-selectors.mdx
@@ -92,7 +92,7 @@ const { selectors, firefox } = require('playwright');  // Or 'chromium' or 'webk
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-timeouterror.mdx
+++ b/nodejs/docs/api/class-timeouterror.mdx
@@ -47,7 +47,7 @@ TimeoutError is emitted whenever certain operations are terminated due to timeou
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-touchscreen.mdx
+++ b/nodejs/docs/api/class-touchscreen.mdx
@@ -52,7 +52,7 @@ Dispatches a `touchstart` and `touchend` event with a single touch at the positi
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-video.mdx
+++ b/nodejs/docs/api/class-video.mdx
@@ -66,7 +66,7 @@ Saves the video to a user-specified path. It is safe to call this method while t
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-websocket.mdx
+++ b/nodejs/docs/api/class-websocket.mdx
@@ -93,7 +93,7 @@ Waits for event to fire and passes its value into the predicate function. Return
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/api/class-worker.mdx
+++ b/nodejs/docs/api/class-worker.mdx
@@ -90,7 +90,7 @@ If the function passed to the [worker.evaluateHandle(pageFunction[, arg])](./api
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/assertions.mdx
+++ b/nodejs/docs/assertions.mdx
@@ -171,7 +171,7 @@ expect(length === 3).toBeTruthy();
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/auth.mdx
+++ b/nodejs/docs/auth.mdx
@@ -154,7 +154,7 @@ const context = await chromium.launchPersistentContext(userDataDir, { headless: 
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/browsers.mdx
+++ b/nodejs/docs/browsers.mdx
@@ -22,6 +22,26 @@ There is also a way to opt into using Google Chrome's or Microsoft Edge's brande
 
 Playwright's Firefox version matches the recent [Firefox Beta](https://www.mozilla.org/en-US/firefox/channel/desktop/) build.
 
+### Firefox-Stable
+
+Playwright team maintains a Playwright Firefox version that matches the latest Firefox Stable, a.k.a. `firefox-stable`.
+
+Using `firefox-stable` is a 2-steps process:
+1. Installing `firefox-stable` with Playwright CLI.
+
+   ```sh
+   $ npx playwright install firefox-stable
+   ```
+
+2. Using `firefox-stable` channel when launching browser.
+
+```js
+const { firefox } = require('playwright');
+const browser = await firefox.launch({
+  channel: 'firefox-stable'
+});
+```
+
 ## WebKit
 
 Playwright's WebKit version matches the recent WebKit trunk build, before it is used in Apple Safari and other WebKit-based browsers. This gives a lot of lead time to react on the potential browser update issues. We are also working on a dedicated support for builds that would match Apple Safari Technology Preview.

--- a/nodejs/docs/browsers.mdx
+++ b/nodejs/docs/browsers.mdx
@@ -115,7 +115,7 @@ Google Chrome and Microsoft Edge respect enterprise policies, which include limi
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/ci.mdx
+++ b/nodejs/docs/ci.mdx
@@ -290,7 +290,7 @@ xvfb-run node index.js
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/cli.mdx
+++ b/nodejs/docs/cli.mdx
@@ -13,6 +13,7 @@ Playwright comes with the command line tools that run via `npx` or as a part of 
 - [Inspect selectors](#inspect-selectors)
 - [Take screenshot](#take-screenshot)
 - [Generate PDF](#generate-pdf)
+- [Install system dependencies](#install-system-dependencies)
 - [Known limitations](#known-limitations)
 
 ## Usage
@@ -189,6 +190,15 @@ PDF generation only works in Headless Chromium.
 ```sh
 # See command help
 $ npx playwright pdf https://en.wikipedia.org/wiki/PDF wiki.pdf
+```
+
+## Install system dependencies
+
+Ubuntu 18.04 and Ubuntu 20.04 system dependencies can get installed automatically. This is useful for CI environments.
+
+```sh
+# See command help
+$ npx playwright install-deps
 ```
 
 ## Known limitations

--- a/nodejs/docs/cli.mdx
+++ b/nodejs/docs/cli.mdx
@@ -241,7 +241,7 @@ Opening WebKit Web Inspector will disconnect Playwright from the browser. In suc
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/core-concepts.mdx
+++ b/nodejs/docs/core-concepts.mdx
@@ -345,7 +345,7 @@ const result = await page.evaluate(() => {
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/debug.mdx
+++ b/nodejs/docs/debug.mdx
@@ -145,7 +145,7 @@ $ npm run test
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/dialogs.mdx
+++ b/nodejs/docs/dialogs.mdx
@@ -94,7 +94,7 @@ await page.close({runBeforeUnload: true});
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/docker.mdx
+++ b/nodejs/docs/docker.mdx
@@ -154,7 +154,7 @@ $ docker run --rm -it playwright:localbuild /bin/bash
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/downloads.mdx
+++ b/nodejs/docs/downloads.mdx
@@ -80,7 +80,7 @@ Note that handling the event forks the control flow and makes script harder to f
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/emulation.mdx
+++ b/nodejs/docs/emulation.mdx
@@ -223,7 +223,7 @@ await page.emulateMedia({ media: 'print' });
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/events.mdx
+++ b/nodejs/docs/events.mdx
@@ -106,7 +106,7 @@ await page.evaluate("prompt('Enter a number:')");
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/extensibility.mdx
+++ b/nodejs/docs/extensibility.mdx
@@ -84,7 +84,7 @@ const buttonCount = await page.$$eval('tag=button', buttons => buttons.length);
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/handles.mdx
+++ b/nodejs/docs/handles.mdx
@@ -127,7 +127,7 @@ Handles can be acquired using the page methods such as [page.evaluateHandle(page
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/input.mdx
+++ b/nodejs/docs/input.mdx
@@ -320,7 +320,7 @@ await page.focus('input#name');
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/inspector.mdx
+++ b/nodejs/docs/inspector.mdx
@@ -128,7 +128,7 @@ You can copy entire generated script or clear it using toolbar actions.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/installation.mdx
+++ b/nodejs/docs/installation.mdx
@@ -200,7 +200,7 @@ To opt-out from the unused browser removal, you can set the `PLAYWRIGHT_SKIP_BRO
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/intro.mdx
+++ b/nodejs/docs/intro.mdx
@@ -162,7 +162,7 @@ See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) 
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/intro.mdx
+++ b/nodejs/docs/intro.mdx
@@ -106,12 +106,25 @@ let page: import('playwright').Page;
 
 ## System requirements
 
-Playwright requires Node.js version 10.17 or above. The browser binaries for Chromium, Firefox and WebKit work across the 3 platforms (Windows, macOS, Linux):
-* **Windows**: Works with Windows and Windows Subsystem for Linux (WSL).
-* **macOS**: Requires 10.14 or above.
-* **Linux**: Depending on your Linux distribution, you might need to install additional dependencies to run the browsers.
-  * Firefox requires Ubuntu 18.04+
-  * For Ubuntu 20.04, the additional dependencies are defined in [our Docker image](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.focal), which is based on Ubuntu.
+Playwright requires Node.js version 12 or above. The browser binaries for Chromium, Firefox and WebKit work across the 3 platforms (Windows, macOS, Linux):
+
+### Windows
+
+Works with Windows and Windows Subsystem for Linux (WSL).
+
+### macOS
+
+Requires 10.14 (Mojave) or above.
+
+### Linux
+
+Depending on your Linux distribution, you might need to install additional dependencies to run the browsers.
+
+:::note
+Only Ubuntu 18.04 and Ubuntu 20.04 are officially supported.
+:::
+
+See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) which has a command to install all necessary dependencies automatically for Ubuntu LTS releases.
 
 [Accessibility]: ./api/class-accessibility.mdx "Accessibility"
 [Android]: ./api/class-android.mdx "Android"

--- a/nodejs/docs/languages.mdx
+++ b/nodejs/docs/languages.mdx
@@ -83,7 +83,7 @@ dotnet add package PlaywrightSharp
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/mobile.mdx
+++ b/nodejs/docs/mobile.mdx
@@ -117,7 +117,7 @@ const { _android } = require('playwright');
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/multi-pages.mdx
+++ b/nodejs/docs/multi-pages.mdx
@@ -148,7 +148,7 @@ page.on('popup', async popup => {
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/navigations.mdx
+++ b/nodejs/docs/navigations.mdx
@@ -210,7 +210,7 @@ await page.screenshot();
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/network.mdx
+++ b/nodejs/docs/network.mdx
@@ -247,7 +247,7 @@ page.on('websocket', ws => {
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/pom.mdx
+++ b/nodejs/docs/pom.mdx
@@ -91,7 +91,7 @@ await searchPage.search('search query');
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/release-notes.mdx
+++ b/nodejs/docs/release-notes.mdx
@@ -129,7 +129,7 @@ This version of Playwright was also tested against the following stable channels
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/screenshots.mdx
+++ b/nodejs/docs/screenshots.mdx
@@ -83,7 +83,7 @@ await elementHandle.screenshot({ path: 'screenshot.png' });
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/selectors.mdx
+++ b/nodejs/docs/selectors.mdx
@@ -450,7 +450,7 @@ await page.click('//*[@id="tsf"]/div[2]/div[1]/div[1]/div/div[2]/input');
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/showcase.mdx
+++ b/nodejs/docs/showcase.mdx
@@ -102,7 +102,7 @@ Did we miss something in this list? Send us a PR!
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/test-runners.mdx
+++ b/nodejs/docs/test-runners.mdx
@@ -144,7 +144,7 @@ Then set `BROWSER=firefox` to run your tests with firefox, or any other browser.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/troubleshooting.mdx
+++ b/nodejs/docs/troubleshooting.mdx
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 
 Playwright does self-inspection every time it runs to make sure the browsers can be launched successfully. If there are missing dependencies, playwright will print instructions to acquire them.
 
-We also provide [Ubuntu 18.04 dockerfile](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.bionic) and [Ubuntu 20.04 dockerfile](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.focal) with the list of Debian dependencies.
+See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) which has a command to install all necessary dependencies automatically for Ubuntu LTS releases.
 
 ## Code transpilation issues
 
@@ -32,7 +32,7 @@ await page.evaluate(`(async() => {
 
 ### ReferenceError: URL is not defined
 
-Playwright requires Node.js 10 or higher. Node.js 8 is not supported, and will cause you to receive this error.
+Playwright requires Node.js 12 or higher. Node.js 8 is not supported, and will cause you to receive this error.
 
 # Please file an issue
 

--- a/nodejs/docs/troubleshooting.mdx
+++ b/nodejs/docs/troubleshooting.mdx
@@ -74,7 +74,7 @@ Playwright is a new project, and we are watching the issues very closely. As we 
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/verification.mdx
+++ b/nodejs/docs/verification.mdx
@@ -133,7 +133,7 @@ const [popup] = await Promise.all([
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/videos.mdx
+++ b/nodejs/docs/videos.mdx
@@ -77,7 +77,7 @@ Note that the video is only available after the page or browser context is close
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/nodejs/docs/why-playwright.mdx
+++ b/nodejs/docs/why-playwright.mdx
@@ -84,7 +84,7 @@ Playwright enables fast, reliable and capable automation across all modern brows
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/actionability.mdx
+++ b/python/docs/actionability.mdx
@@ -125,7 +125,7 @@ For example, consider a scenario where Playwright will click `Sign Up` button re
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-accessibility.mdx
+++ b/python/docs/api/class-accessibility.mdx
@@ -156,7 +156,7 @@ if node:
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-browser.mdx
+++ b/python/docs/api/class-browser.mdx
@@ -369,7 +369,7 @@ Returns the browser version.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-browser.mdx
+++ b/python/docs/api/class-browser.mdx
@@ -153,7 +153,7 @@ Returns the newly created browser session.
 - `no_viewport` <[bool]> Does not enforce fixed viewport, allows resizing window in the headed mode.
 - `offline` <[bool]> Whether to emulate network being offline. Defaults to `false`.
 - `permissions` <[List]\[[str]\]> A list of permissions to grant to all pages in this context. See [browser_context.grant_permissions(permissions, **kwargs)](./api/class-browsercontext.mdx#browser_contextgrant_permissionspermissions-kwargs) for more details.
-- `proxy` <[Dict]> Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
+- `proxy` <[Dict]> Network proxy settings to use with this context.
   - `server` <[str]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
   - `bypass` <[str]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
   - `username` <[str]> Optional username to use if HTTP proxy requires authentication.
@@ -247,7 +247,7 @@ await page.goto("https://example.com")
 - `no_viewport` <[bool]> Does not enforce fixed viewport, allows resizing window in the headed mode.
 - `offline` <[bool]> Whether to emulate network being offline. Defaults to `false`.
 - `permissions` <[List]\[[str]\]> A list of permissions to grant to all pages in this context. See [browser_context.grant_permissions(permissions, **kwargs)](./api/class-browsercontext.mdx#browser_contextgrant_permissionspermissions-kwargs) for more details.
-- `proxy` <[Dict]> Network proxy settings to use with this context. Note that browser needs to be launched with the global proxy for this option to work. If all contexts override the proxy, global proxy will be never used and can be any string, for example `launch({ proxy: { server: 'per-context' } })`.
+- `proxy` <[Dict]> Network proxy settings to use with this context.
   - `server` <[str]> Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
   - `bypass` <[str]> Optional coma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
   - `username` <[str]> Optional username to use if HTTP proxy requires authentication.

--- a/python/docs/api/class-browsercontext.mdx
+++ b/python/docs/api/class-browsercontext.mdx
@@ -903,7 +903,7 @@ Waits for given `event` to fire. If predicate is provided, it passes event's val
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-browsertype.mdx
+++ b/python/docs/api/class-browsertype.mdx
@@ -247,7 +247,7 @@ Returns browser name. For example: `'chromium'`, `'webkit'` or `'firefox'`.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-browsertype.mdx
+++ b/python/docs/api/class-browsertype.mdx
@@ -95,7 +95,7 @@ A path where Playwright expects to find a bundled browser executable.
 
 ## browser_type.launch(**kwargs)
 - `args` <[List]\[[str]\]> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
-- `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
+- `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"|"firefox-stable"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
 - `chromium_sandbox` <[bool]> Enable Chromium sandboxing. Defaults to `false`.
 - `devtools` <[bool]> **Chromium-only** Whether to auto-open a Developer Tools panel for each tab. If this option is `true`, the `headless` option will be set `false`.
 - `downloads_path` <[Union]\[[str], [pathlib.Path]\]> If specified, accepted downloads are downloaded into this directory. Otherwise, temporary directory is created and is deleted when browser is closed.
@@ -159,7 +159,7 @@ browser = await playwright.chromium.launch( # or "firefox" or "webkit".
 - `accept_downloads` <[bool]> Whether to automatically download all the attachments. Defaults to `false` where all the downloads are canceled.
 - `args` <[List]\[[str]\]> Additional arguments to pass to the browser instance. The list of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
 - `bypass_csp` <[bool]> Toggles bypassing page's Content-Security-Policy.
-- `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
+- `channel` <"chrome"|"chrome-beta"|"chrome-dev"|"chrome-canary"|"msedge"|"msedge-beta"|"msedge-dev"|"msedge-canary"|"firefox-stable"> Browser distribution channel. Read more about using [Google Chrome and Microsoft Edge](./browsers.mdx#google-chrome--microsoft-edge).
 - `chromium_sandbox` <[bool]> Enable Chromium sandboxing. Defaults to `true`.
 - `color_scheme` <"light"|"dark"|"no-preference"> Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. See [page.emulate_media(**kwargs)](./api/class-page.mdx#pageemulate_mediakwargs) for more details. Defaults to `'light'`.
 - `device_scale_factor` <[float]> Specify device scale factor (can be thought of as dpr). Defaults to `1`.

--- a/python/docs/api/class-cdpsession.mdx
+++ b/python/docs/api/class-cdpsession.mdx
@@ -93,7 +93,7 @@ Detaches the CDPSession from the target. Once detached, the CDPSession object wo
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-consolemessage.mdx
+++ b/python/docs/api/class-consolemessage.mdx
@@ -61,7 +61,7 @@ One of the following values: `'log'`, `'debug'`, `'info'`, `'error'`, `'warning'
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-consolemessage.mdx
+++ b/python/docs/api/class-consolemessage.mdx
@@ -16,6 +16,8 @@ import TabItem from '@theme/TabItem';
 ## console_message.args
 - returns: <[List]\[[JSHandle]\]>
 
+List of arguments passed to a `console` function call. See also [page.on("console")](./api/class-page.mdx#pageonconsole).
+
 ## console_message.location
 - returns: <[Dict]>
   - `url` <[str]> URL of the resource.
@@ -24,6 +26,8 @@ import TabItem from '@theme/TabItem';
 
 ## console_message.text
 - returns: <[str]>
+
+The text of the console message.
 
 ## console_message.type
 - returns: <[str]>

--- a/python/docs/api/class-dialog.mdx
+++ b/python/docs/api/class-dialog.mdx
@@ -128,7 +128,7 @@ Returns dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prom
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-download.mdx
+++ b/python/docs/api/class-download.mdx
@@ -111,7 +111,7 @@ Returns downloaded url.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-elementhandle.mdx
+++ b/python/docs/api/class-elementhandle.mdx
@@ -389,7 +389,11 @@ assert await feed_handle.eval_on_selector_all(".tweet", "nodes => nodes.map(n =>
 - `no_wait_after` <[bool]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
 - `timeout` <[float]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browser_context.set_default_timeout(timeout)](./api/class-browsercontext.mdx#browser_contextset_default_timeouttimeout) or [page.set_default_timeout(timeout)](./api/class-page.mdx#pageset_default_timeouttimeout) methods.
 
-This method waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
+
+To send fine-grained keyboard events, use [element_handle.type(text, **kwargs)](./api/class-elementhandle.mdx#element_handletypetext-kwargs).
 
 ## element_handle.focus()
 
@@ -525,11 +529,13 @@ Throws when `elementHandle` does not point to an element [connected](https://dev
 - `label` <[str]|[List]\[[str]\]> Options to select by label. If the `<select>` has the `multiple` attribute, all given options are selected, otherwise only the first option matching one of the passed options is selected. Optional.
 - returns: <[List]\[[str]\]>
 
+This method waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If element is not a `<select>` element, the method throws an error.
-
-Will wait until all specified options are present in the `<select>` element.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
 <Tabs
   groupId="python-flavor"

--- a/python/docs/api/class-elementhandle.mdx
+++ b/python/docs/api/class-elementhandle.mdx
@@ -226,7 +226,7 @@ When all steps combined have not finished during the specified `timeout`, this m
 
 ## element_handle.dispatch_event(type, **kwargs)
 - `type` <[str]> DOM event type: `"click"`, `"dragstart"`, etc.
-- `event_init` <[Dict]> Optional event-specific initialization properties.
+- `event_init` <[EvaluationArgument]> Optional event-specific initialization properties.
 
 The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element, `click` is dispatched. This is equivalent to calling [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
 
@@ -298,7 +298,7 @@ await element_handle.dispatch_event("#source", "dragstart", {"dataTransfer": dat
 ## element_handle.eval_on_selector(selector, expression, **kwargs)
 - `selector` <[str]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Serializable]>
 
 Returns the return value of `expression`.
@@ -340,7 +340,7 @@ assert await tweet_handle.eval_on_selector(".retweets", "node => node.innerText"
 ## element_handle.eval_on_selector_all(selector, expression, **kwargs)
 - `selector` <[str]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Serializable]>
 
 Returns the return value of `expression`.
@@ -809,7 +809,7 @@ This method does not work across navigations, use [page.wait_for_selector(select
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-error.mdx
+++ b/python/docs/api/class-error.mdx
@@ -56,7 +56,7 @@ Stack of the error which got thrown inside the browser. Optional.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-filechooser.mdx
+++ b/python/docs/api/class-filechooser.mdx
@@ -95,7 +95,7 @@ Sets the value of the file input this chooser is associated with. If some of the
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-frame.mdx
+++ b/python/docs/api/class-frame.mdx
@@ -225,7 +225,7 @@ When all steps combined have not finished during the specified `timeout`, this m
 ## frame.dispatch_event(selector, type, **kwargs)
 - `selector` <[str]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `type` <[str]> DOM event type: `"click"`, `"dragstart"`, etc.
-- `event_init` <[Dict]> Optional event-specific initialization properties.
+- `event_init` <[EvaluationArgument]> Optional event-specific initialization properties.
 - `timeout` <[float]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browser_context.set_default_timeout(timeout)](./api/class-browsercontext.mdx#browser_contextset_default_timeouttimeout) or [page.set_default_timeout(timeout)](./api/class-page.mdx#pageset_default_timeouttimeout) methods.
 
 The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element, `click` is dispatched. This is equivalent to calling [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
@@ -298,7 +298,7 @@ await frame.dispatch_event("#source", "dragstart", { "dataTransfer": data_transf
 ## frame.eval_on_selector(selector, expression, **kwargs)
 - `selector` <[str]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Serializable]>
 
 Returns the return value of `expression`.
@@ -340,7 +340,7 @@ html = await frame.eval_on_selector(".main-container", "(e, suffix) => e.outerHT
 ## frame.eval_on_selector_all(selector, expression, **kwargs)
 - `selector` <[str]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Serializable]>
 
 Returns the return value of `expression`.
@@ -377,7 +377,7 @@ divs_counts = await frame.eval_on_selector_all("div", "(divs, min) => divs.lengt
 
 ## frame.evaluate(expression, **kwargs)
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Serializable]>
 
 Returns the return value of `expression`.
@@ -474,7 +474,7 @@ await body_handle.dispose()
 
 ## frame.evaluate_handle(expression, **kwargs)
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the return value of `expression` as a [JSHandle].
@@ -1014,7 +1014,7 @@ Returns frame's url.
 
 ## frame.wait_for_function(expression, **kwargs)
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - `polling` <[float]|"raf"> If `polling` is `'raf'`, then `expression` is constantly executed in `requestAnimationFrame` callback. If `polling` is a number, then it is treated as an interval in milliseconds at which the function would be executed. Defaults to `raf`.
 - `timeout` <[float]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [browser_context.set_default_timeout(timeout)](./api/class-browsercontext.mdx#browser_contextset_default_timeouttimeout).
 - returns: <[JSHandle]>
@@ -1276,7 +1276,7 @@ await frame.wait_for_url("**/target.html")
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-frame.mdx
+++ b/python/docs/api/class-frame.mdx
@@ -618,7 +618,9 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 - `no_wait_after` <[bool]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
 - `timeout` <[float]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browser_context.set_default_timeout(timeout)](./api/class-browsercontext.mdx#browser_contextset_default_timeouttimeout) or [page.set_default_timeout(timeout)](./api/class-page.mdx#pageset_default_timeouttimeout) methods.
 
-This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
 
 To send fine-grained keyboard events, use [frame.type(selector, text, **kwargs)](./api/class-frame.mdx#frametypeselector-text-kwargs).
 
@@ -848,11 +850,13 @@ The method finds all elements matching the specified selector within the frame. 
 - `label` <[str]|[List]\[[str]\]> Options to select by label. If the `<select>` has the `multiple` attribute, all given options are selected, otherwise only the first option matching one of the passed options is selected. Optional.
 - returns: <[List]\[[str]\]>
 
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element matching `selector`, the method throws an error.
-
-Will wait until all specified options are present in the `<select>` element.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
 <Tabs
   groupId="python-flavor"

--- a/python/docs/api/class-jshandle.mdx
+++ b/python/docs/api/class-jshandle.mdx
@@ -57,7 +57,7 @@ The `jsHandle.dispose` method stops referencing the element handle.
 
 ## js_handle.evaluate(expression, **kwargs)
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Serializable]>
 
 Returns the return value of `expression`.
@@ -96,7 +96,7 @@ assert await tweet_handle.evaluate("node => node.innerText") == "10 retweets"
 
 ## js_handle.evaluate_handle(expression, **kwargs)
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the return value of `expression` as a [JSHandle].
@@ -189,7 +189,7 @@ The method will return an empty JSON object if the referenced object is not stri
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-keyboard.mdx
+++ b/python/docs/api/class-keyboard.mdx
@@ -306,7 +306,7 @@ Dispatches a `keyup` event.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-mouse.mdx
+++ b/python/docs/api/class-mouse.mdx
@@ -117,7 +117,7 @@ Dispatches a `mouseup` event.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-page.mdx
+++ b/python/docs/api/class-page.mdx
@@ -578,7 +578,7 @@ Shortcut for main frame's [frame.dblclick(selector, **kwargs)](./api/class-frame
 ## page.dispatch_event(selector, type, **kwargs)
 - `selector` <[str]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
 - `type` <[str]> DOM event type: `"click"`, `"dragstart"`, etc.
-- `event_init` <[Dict]> Optional event-specific initialization properties.
+- `event_init` <[EvaluationArgument]> Optional event-specific initialization properties.
 - `timeout` <[float]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browser_context.set_default_timeout(timeout)](./api/class-browsercontext.mdx#browser_contextset_default_timeouttimeout) or [page.set_default_timeout(timeout)](./api/class-page.mdx#pageset_default_timeouttimeout) methods.
 
 The snippet below dispatches the `click` event on the element. Regardless of the visibility state of the element, `click` is dispatched. This is equivalent to calling [element.click()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click).
@@ -746,7 +746,7 @@ await page.evaluate("matchMedia('(prefers-color-scheme: no-preference)').matches
 ## page.eval_on_selector(selector, expression, **kwargs)
 - `selector` <[str]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Serializable]>
 
 The method finds an element matching the specified selector within the page and passes it as a first argument to `expression`. If no elements match the selector, the method throws an error. Returns the value of `expression`.
@@ -788,7 +788,7 @@ Shortcut for main frame's [frame.eval_on_selector(selector, expression, **kwargs
 ## page.eval_on_selector_all(selector, expression, **kwargs)
 - `selector` <[str]> A selector to query for. See [working with selectors](./selectors.mdx) for more details.
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Serializable]>
 
 The method finds all elements matching the specified selector within the page and passes an array of matched elements as a first argument to `expression`. Returns the result of `expression` invocation.
@@ -823,7 +823,7 @@ div_counts = await page.eval_on_selector_all("div", "(divs, min) => divs.length 
 
 ## page.evaluate(expression, **kwargs)
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Serializable]>
 
 Returns the value of the `expression` invocation.
@@ -924,7 +924,7 @@ Shortcut for main frame's [frame.evaluate(expression, **kwargs)](./api/class-fra
 
 ## page.evaluate_handle(expression, **kwargs)
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the value of the `expression` invocation as a [JSHandle].
@@ -2260,7 +2260,7 @@ Waits for given `event` to fire. If predicate is provided, it passes event's val
 
 ## page.wait_for_function(expression, **kwargs)
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - `polling` <[float]|"raf"> If `polling` is `'raf'`, then `expression` is constantly executed in `requestAnimationFrame` callback. If `polling` is a number, then it is treated as an interval in milliseconds at which the function would be executed. Defaults to `raf`.
 - `timeout` <[float]> maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [browser_context.set_default_timeout(timeout)](./api/class-browsercontext.mdx#browser_contextset_default_timeouttimeout).
 - returns: <[JSHandle]>
@@ -2611,7 +2611,7 @@ This does not contain ServiceWorkers
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-page.mdx
+++ b/python/docs/api/class-page.mdx
@@ -652,6 +652,8 @@ await page.dispatch_event("#source", "dragstart", { "dataTransfer": data_transfe
 - `color_scheme` <[NoneType]|"light"|"dark"|"no-preference"> Emulates `'prefers-colors-scheme'` media feature, supported values are `'light'`, `'dark'`, `'no-preference'`. Passing `null` disables color scheme emulation.
 - `media` <[NoneType]|"screen"|"print"> Changes the CSS media type of the page. The only allowed values are `'screen'`, `'print'` and `null`. Passing `null` disables CSS media emulation.
 
+This method changes the `CSS media type` through the `media` argument, and/or the `'prefers-colors-scheme'` media feature, using the `colorScheme` argument.
+
 <Tabs
   groupId="python-flavor"
   defaultValue="sync"
@@ -1458,11 +1460,13 @@ asyncio.run(main())
 - `no_wait_after` <[bool]> Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
 - `timeout` <[float]> Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the [browser_context.set_default_timeout(timeout)](./api/class-browsercontext.mdx#browser_contextset_default_timeouttimeout) or [page.set_default_timeout(timeout)](./api/class-page.mdx#pageset_default_timeouttimeout) methods.
 
-This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. If the element is inside the `<label>` element that has associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), that control will be filled instead. If the element to be filled is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. Note that you can pass an empty string to clear the input field.
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, focuses the element, fills it and triggers an `input` event after filling. Note that you can pass an empty string to clear the input field.
+
+If the target element is not an `<input>`, `<textarea>` or `[contenteditable]` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be filled instead.
 
 To send fine-grained keyboard events, use [page.type(selector, text, **kwargs)](./api/class-page.mdx#pagetypeselector-text-kwargs).
 
-Shortcut for main frame's [frame.fill(selector, value, **kwargs)](./api/class-frame.mdx#framefillselector-value-kwargs)
+Shortcut for main frame's [frame.fill(selector, value, **kwargs)](./api/class-frame.mdx#framefillselector-value-kwargs).
 
 ## page.focus(selector, **kwargs)
 - `selector` <[str]> A selector to search for element. If there are multiple elements satisfying the selector, the first will be used. See [working with selectors](./selectors.mdx) for more details.
@@ -1985,11 +1989,13 @@ Returns the buffer with the captured screenshot.
 - `label` <[str]|[List]\[[str]\]> Options to select by label. If the `<select>` has the `multiple` attribute, all given options are selected, otherwise only the first option matching one of the passed options is selected. Optional.
 - returns: <[List]\[[str]\]>
 
+This method waits for an element matching `selector`, waits for [actionability](./actionability.mdx) checks, waits until all specified options are present in the `<select>` element and selects these options.
+
+If the target element is not a `<select>` element, this method throws an error. However, if the element is inside the `<label>` element that has an associated [control](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/control), the control will be used instead.
+
 Returns the array of option values that have been successfully selected.
 
-Triggers a `change` and `input` event once all the provided options have been selected. If there's no `<select>` element matching `selector`, the method throws an error.
-
-Will wait until all specified options are present in the `<select>` element.
+Triggers a `change` and `input` event once all the provided options have been selected.
 
 <Tabs
   groupId="python-flavor"
@@ -2025,7 +2031,7 @@ await page.select_option("select#colors", value=["red", "green", "blue"])
 </TabItem>
 </Tabs>
 
-Shortcut for main frame's [frame.select_option(selector, **kwargs)](./api/class-frame.mdx#frameselect_optionselector-kwargs)
+Shortcut for main frame's [frame.select_option(selector, **kwargs)](./api/class-frame.mdx#frameselect_optionselector-kwargs).
 
 ## page.set_content(html, **kwargs)
 - `html` <[str]> HTML markup to assign to the page.

--- a/python/docs/api/class-playwright.mdx
+++ b/python/docs/api/class-playwright.mdx
@@ -187,7 +187,7 @@ This object can be used to launch or connect to WebKit, returning instances of [
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-request.mdx
+++ b/python/docs/api/class-request.mdx
@@ -242,7 +242,7 @@ URL of the request.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-response.mdx
+++ b/python/docs/api/class-response.mdx
@@ -104,7 +104,7 @@ Contains the URL of the response.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-route.mdx
+++ b/python/docs/api/class-route.mdx
@@ -181,7 +181,7 @@ A request to be routed.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-selectors.mdx
+++ b/python/docs/api/class-selectors.mdx
@@ -69,7 +69,7 @@ An example of registering selector engine that queries elements based on a tag n
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-timeouterror.mdx
+++ b/python/docs/api/class-timeouterror.mdx
@@ -38,7 +38,7 @@ TimeoutError is emitted whenever certain operations are terminated due to timeou
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-touchscreen.mdx
+++ b/python/docs/api/class-touchscreen.mdx
@@ -43,7 +43,7 @@ Dispatches a `touchstart` and `touchend` event with a single touch at the positi
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-video.mdx
+++ b/python/docs/api/class-video.mdx
@@ -77,7 +77,7 @@ Saves the video to a user-specified path. It is safe to call this method while t
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-websocket.mdx
+++ b/python/docs/api/class-websocket.mdx
@@ -96,7 +96,7 @@ Waits for given `event` to fire. If predicate is provided, it passes event's val
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/api/class-worker.mdx
+++ b/python/docs/api/class-worker.mdx
@@ -32,7 +32,7 @@ Emitted when this dedicated [WebWorker](https://developer.mozilla.org/en-US/docs
 
 ## worker.evaluate(expression, **kwargs)
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[Serializable]>
 
 Returns the return value of `expression`.
@@ -43,7 +43,7 @@ If the function passed to the [worker.evaluate(expression, **kwargs)](./api/clas
 
 ## worker.evaluate_handle(expression, **kwargs)
 - `expression` <[str]> JavaScript expression to be evaluated in the browser context. If it looks like a function declaration, it is interpreted as a function. Otherwise, evaluated as an expression.
-- `arg` <[Dict]> Optional argument to pass to `expression`.
+- `arg` <[EvaluationArgument]> Optional argument to pass to `expression`.
 - returns: <[JSHandle]>
 
 Returns the return value of `expression` as a [JSHandle].
@@ -82,7 +82,7 @@ If the function passed to the [worker.evaluate_handle(expression, **kwargs)](./a
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/assertions.mdx
+++ b/python/docs/assertions.mdx
@@ -365,7 +365,7 @@ assert length == 3
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/auth.mdx
+++ b/python/docs/auth.mdx
@@ -268,7 +268,7 @@ asyncio.run(main())
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/browsers.mdx
+++ b/python/docs/browsers.mdx
@@ -142,7 +142,7 @@ Google Chrome and Microsoft Edge respect enterprise policies, which include limi
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/browsers.mdx
+++ b/python/docs/browsers.mdx
@@ -22,6 +22,43 @@ There is also a way to opt into using Google Chrome's or Microsoft Edge's brande
 
 Playwright's Firefox version matches the recent [Firefox Beta](https://www.mozilla.org/en-US/firefox/channel/desktop/) build.
 
+### Firefox-Stable
+
+Playwright team maintains a Playwright Firefox version that matches the latest Firefox Stable, a.k.a. `firefox-stable`.
+
+Using `firefox-stable` is a 2-steps process:
+1. Installing `firefox-stable` with Playwright CLI.
+
+   ```sh
+   $ playwright install firefox-stable
+   ```
+
+2. Using `firefox-stable` channel when launching browser.
+
+<Tabs
+  groupId="python-flavor"
+  defaultValue="sync"
+  values={[
+    {label: 'Sync', value: 'sync'},
+    {label: 'Async', value: 'async'}
+  ]
+}>
+<TabItem value="sync">
+
+```py
+browser = playwright.firefox.launch(channel="firefox-stable")
+```
+
+</TabItem>
+<TabItem value="async">
+
+```py
+browser = await playwright.firefox.launch(channel="firefox-stable")
+```
+
+</TabItem>
+</Tabs>
+
 ## WebKit
 
 Playwright's WebKit version matches the recent WebKit trunk build, before it is used in Apple Safari and other WebKit-based browsers. This gives a lot of lead time to react on the potential browser update issues. We are also working on a dedicated support for builds that would match Apple Safari Technology Preview.

--- a/python/docs/ci.mdx
+++ b/python/docs/ci.mdx
@@ -362,7 +362,7 @@ xvfb-run python test.py
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/cli.mdx
+++ b/python/docs/cli.mdx
@@ -13,6 +13,7 @@ Playwright comes with the command line tools that run via `npx` or as a part of 
 - [Inspect selectors](#inspect-selectors)
 - [Take screenshot](#take-screenshot)
 - [Generate PDF](#generate-pdf)
+- [Install system dependencies](#install-system-dependencies)
 - [Known limitations](#known-limitations)
 
 ## Usage
@@ -193,6 +194,15 @@ PDF generation only works in Headless Chromium.
 ```sh
 # See command help
 $ playwright pdf https://en.wikipedia.org/wiki/PDF wiki.pdf
+```
+
+## Install system dependencies
+
+Ubuntu 18.04 and Ubuntu 20.04 system dependencies can get installed automatically. This is useful for CI environments.
+
+```sh
+# See command help
+$ playwright install-deps
 ```
 
 ## Known limitations

--- a/python/docs/cli.mdx
+++ b/python/docs/cli.mdx
@@ -236,7 +236,7 @@ Opening WebKit Web Inspector will disconnect Playwright from the browser. In suc
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/core-concepts.mdx
+++ b/python/docs/core-concepts.mdx
@@ -875,7 +875,7 @@ result = await page.evaluate("""() => {
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/debug.mdx
+++ b/python/docs/debug.mdx
@@ -158,7 +158,7 @@ $ pytest -s
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/dialogs.mdx
+++ b/python/docs/dialogs.mdx
@@ -152,7 +152,7 @@ await page.close(run_before_unload=True)
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/docker.mdx
+++ b/python/docs/docker.mdx
@@ -111,7 +111,7 @@ Browser builds for Firefox and WebKit are built for the [glibc](https://en.wikip
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/downloads.mdx
+++ b/python/docs/downloads.mdx
@@ -118,7 +118,7 @@ Note that handling the event forks the control flow and makes script harder to f
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/emulation.mdx
+++ b/python/docs/emulation.mdx
@@ -487,7 +487,7 @@ await page.emulate_media(media='print')
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/events.mdx
+++ b/python/docs/events.mdx
@@ -190,7 +190,7 @@ await page.evaluate("prompt('Enter a number:')")
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/extensibility.mdx
+++ b/python/docs/extensibility.mdx
@@ -119,7 +119,7 @@ button_count = await page.eval_on_selector_all("tag=button", buttons => buttons.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/handles.mdx
+++ b/python/docs/handles.mdx
@@ -225,7 +225,7 @@ Handles can be acquired using the page methods such as [page.evaluate_handle(exp
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/input.mdx
+++ b/python/docs/input.mdx
@@ -631,7 +631,7 @@ await page.focus('input#name')
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/inspector.mdx
+++ b/python/docs/inspector.mdx
@@ -139,7 +139,7 @@ You can copy entire generated script or clear it using toolbar actions.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/installation.mdx
+++ b/python/docs/installation.mdx
@@ -179,7 +179,7 @@ To opt-out from the unused browser removal, you can set the `PLAYWRIGHT_SKIP_BRO
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/intro.mdx
+++ b/python/docs/intro.mdx
@@ -133,7 +133,7 @@ See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) 
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/intro.mdx
+++ b/python/docs/intro.mdx
@@ -86,12 +86,25 @@ $ playwright codegen wikipedia.org
 
 ## System requirements
 
-Playwright requires Python version 3.7 or above. The browser binaries for Chromium, Firefox and WebKit work across the 3 platforms (Windows, macOS, Linux):
-* **Windows**: Works with Windows and Windows Subsystem for Linux (WSL).
-* **macOS**: Requires 10.14 or above.
-* **Linux**: Depending on your Linux distribution, you might need to install additional dependencies to run the browsers.
-  * Firefox requires Ubuntu 18.04+
-  * For Ubuntu 20.04, the additional dependencies are defined in [our Docker image](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.focal), which is based on Ubuntu.
+Playwright requires Python 3.7 or above. The browser binaries for Chromium, Firefox and WebKit work across the 3 platforms (Windows, macOS, Linux):
+
+### Windows
+
+Works with Windows and Windows Subsystem for Linux (WSL).
+
+### macOS
+
+Requires 10.14 (Mojave) or above.
+
+### Linux
+
+Depending on your Linux distribution, you might need to install additional dependencies to run the browsers.
+
+:::note
+Only Ubuntu 18.04 and Ubuntu 20.04 are officially supported.
+:::
+
+See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) which has a command to install all necessary dependencies automatically for Ubuntu LTS releases.
 
 [Accessibility]: ./api/class-accessibility.mdx "Accessibility"
 [Browser]: ./api/class-browser.mdx "Browser"

--- a/python/docs/languages.mdx
+++ b/python/docs/languages.mdx
@@ -74,7 +74,7 @@ dotnet add package PlaywrightSharp
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/mobile.mdx
+++ b/python/docs/mobile.mdx
@@ -57,7 +57,7 @@ See [Android] for documentation.
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/multi-pages.mdx
+++ b/python/docs/multi-pages.mdx
@@ -312,7 +312,7 @@ page.on("popup", handle_popup)
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/navigations.mdx
+++ b/python/docs/navigations.mdx
@@ -434,7 +434,7 @@ await page.screenshot()
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/network.mdx
+++ b/python/docs/network.mdx
@@ -475,7 +475,7 @@ page.on("websocket", on_web_socket)
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/pom.mdx
+++ b/python/docs/pom.mdx
@@ -136,7 +136,7 @@ await search_page.search("search query")
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/release-notes.mdx
+++ b/python/docs/release-notes.mdx
@@ -120,7 +120,7 @@ This version of Playwright was also tested against the following stable channels
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/screenshots.mdx
+++ b/python/docs/screenshots.mdx
@@ -157,7 +157,7 @@ await element_handle.screenshot(path="screenshot.png")
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/selectors.mdx
+++ b/python/docs/selectors.mdx
@@ -1035,7 +1035,7 @@ await page.click('//*[@id="tsf"]/div[2]/div[1]/div[1]/div/div[2]/input')
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/showcase.mdx
+++ b/python/docs/showcase.mdx
@@ -93,7 +93,7 @@ Did we miss something in this list? Send us a PR!
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/test-runners.mdx
+++ b/python/docs/test-runners.mdx
@@ -230,7 +230,7 @@ Use the [Playwright GitHub Action](https://github.com/microsoft/playwright-githu
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/troubleshooting.mdx
+++ b/python/docs/troubleshooting.mdx
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 
 Playwright does self-inspection every time it runs to make sure the browsers can be launched successfully. If there are missing dependencies, playwright will print instructions to acquire them.
 
-We also provide [Ubuntu 18.04 dockerfile](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.bionic) and [Ubuntu 20.04 dockerfile](https://github.com/microsoft/playwright/blob/master/utils/docker/Dockerfile.focal) with the list of Debian dependencies.
+See also in the [Command Line Interface](./cli.mdx#install-system-dependencies) which has a command to install all necessary dependencies automatically for Ubuntu LTS releases.
 
 ## Code transpilation issues
 
@@ -26,7 +26,7 @@ Some workarounds to this problem would be to instruct the transpiler not to mess
 
 ### ReferenceError: URL is not defined
 
-Playwright requires Node.js 10 or higher. Node.js 8 is not supported, and will cause you to receive this error.
+Playwright requires Node.js 12 or higher. Node.js 8 is not supported, and will cause you to receive this error.
 
 # Please file an issue
 

--- a/python/docs/troubleshooting.mdx
+++ b/python/docs/troubleshooting.mdx
@@ -59,7 +59,7 @@ Playwright is a new project, and we are watching the issues very closely. As we 
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/verification.mdx
+++ b/python/docs/verification.mdx
@@ -191,7 +191,7 @@ popup = await popup_info.value
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/videos.mdx
+++ b/python/docs/videos.mdx
@@ -131,7 +131,7 @@ Note that the video is only available after the page or browser context is close
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/python/docs/why-playwright.mdx
+++ b/python/docs/why-playwright.mdx
@@ -76,7 +76,7 @@ Playwright enables fast, reliable and capable automation across all modern brows
 [WebSocket]: ./api/class-websocket.mdx "WebSocket"
 [Worker]: ./api/class-worker.mdx "Worker"
 [Element]: https://developer.mozilla.org/en-US/docs/Web/API/element "Element"
-[Evaluation Argument]: ./core-concepts.mdx#evaluationargument "Evaluation Argument"
+[EvaluationArgument]: ./core-concepts.mdx#evaluation-argument "EvaluationArgument"
 [Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise "Promise"
 [iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols "Iterator"
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin "Origin"

--- a/src/generator.js
+++ b/src/generator.js
@@ -531,7 +531,6 @@ new Generator('python', path.join(__dirname, '..', 'python', 'docs'), {
       case 'void': return '[NoneType]';
       case 'boolean': return '[bool]';
       case 'string': return '[str]';
-      case 'EvaluationArgument': return '[Dict]';
       case 'Buffer': return '[bytes]';
     }
     return `[${text}]`;
@@ -608,7 +607,6 @@ new Generator('java', path.join(__dirname, '..', 'java', 'docs'), {
       case 'string': return '[String]';
       // Escape '[' and ']' so that they don't break markdown links like [byte[]](link)
       case 'Buffer': return '[byte&#91;&#93;]';
-      case 'EvaluationArgument': return '[Object]';
       case 'Readable': return '[InputStream]';
       case 'Serializable': return '[Object]';
       case 'URL': return '[String]';
@@ -689,7 +687,6 @@ new Generator('csharp', path.join(__dirname, '..', 'csharp', 'docs'), {
       case 'string': return '[string]';
       // Escape '[' and ']' so that they don't break markdown links like [byte[]](link)
       case 'Buffer': return '[byte&#91;&#93;]';
-      case 'EvaluationArgument': return '[object]';
       case 'Readable': return '[Stream]';
       case 'Serializable': return '[object]';
       case 'URL': return '[string]';


### PR DESCRIPTION
Since all languages have this problem, lets link for all the languages to it's language specific evaluation argument site, where the usage gets explained. We can also replace `[EvaluationArgument]` in the generator by `[Evaluation Argument]` which would avoid adding two links, but having a _type_ with a space seems weird. Let me know what you think is the better approach! 

(see the second commit for the EvaluationArgument changes)

Fixes https://github.com/microsoft/playwright/issues/6420