### PR TITLE
fix: Remove Java from .NET code samples

### DIFF
--- a/dotnet/docs/cheat-sheet.mdx
+++ b/dotnet/docs/cheat-sheet.mdx
@@ -54,7 +54,7 @@ await page.SetInputFilesAsync("input#upload", new FilePayload
 {
     Name = "file.txt",
     MimeType = "text/plain",
-    Buffer = "this is a test".getBytes(StandardCharsets.UTF_8),
+    Buffer = System.Text.Encoding.UTF8.GetBytes("this is a test"),
 });
 ```
 

--- a/dotnet/docs/input.mdx
+++ b/dotnet/docs/input.mdx
@@ -248,7 +248,7 @@ await page.SetInputFilesAsync("input#upload", new FilePayload
 {
     Name = "file.txt",
     MimeType = "text/plain",
-    Buffer = "this is a test".getBytes(StandardCharsets.UTF_8),
+    Buffer = System.Text.Encoding.UTF8.GetBytes("this is a test"),
 });
 ```
 


### PR DESCRIPTION
Use the appropriate .NET API for converting a string to bytes in the code snippets for file uploads.
