### PR TITLE
fix(dotnet): Fix inheritance and event types

### DIFF
--- a/src/format_csharp.js
+++ b/src/format_csharp.js
@@ -99,7 +99,7 @@ class CSharpFormatter {
           case 'Page.waitForEvent.predicate': return '[Func]<T, [bool]>';
           case 'Page.waitForEvent2.predicate': return '[Func]<T, [bool]>';
         }
-        throw new Error(`Unknwon C# type for "${fullName(member)}": "${text}"`);
+        throw new Error(`Unknown C# type for "${fullName(member)}": "${text}"`);
       };
       case 'null': return '[null]';
       case 'Object': {
@@ -141,7 +141,7 @@ class CSharpFormatter {
   }
 
   preprocessComment(spec) {
-    return spec;
+    return spec.filter(n => !n.text || !n.text.startsWith('extends: [EventEmitter]'));
   }
 }
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -175,7 +175,7 @@ import TabItem from '@theme/TabItem';
         if (member.type && (member.type.name !== 'void' || member.kind === 'method')) {
           let name;
           switch (member.kind) {
-            case 'event': name = 'type:'; break;
+            case 'event': name = this.lang === 'csharp' ? 'EventArgs type:' :'type:'; break;
             case 'property': name = this.lang === 'java' ? 'returns:' : 'type:'; break;
             case 'method': name = 'returns:'; break;
           }


### PR DESCRIPTION
I found two things on the .NET Site:
 * In some places, we were saying that the class inherits from an `EventEmitter`, which is wrong. I added the same filter the java version has.
 * In the events, we say that the event type is `X`, when in fact, it is the `EventArgs type` (the second argument of the event).