### PR TITLE
Fix for search showing too much results

### DIFF
--- a/dotnet/docusaurus.config.js
+++ b/dotnet/docusaurus.config.js
@@ -169,7 +169,7 @@ module.exports = {
       {
         hashed: true,
         language: ["en", "zh"],
-        searchResultLimits: 10,
+        searchResultLimits: 8,
       },
     ],
   ],

--- a/java/docusaurus.config.js
+++ b/java/docusaurus.config.js
@@ -169,7 +169,7 @@ module.exports = {
       {
         hashed: true,
         language: ["en", "zh"],
-        searchResultLimits: 10,
+        searchResultLimits: 8,
       },
     ],
   ],

--- a/nodejs/docusaurus.config.js
+++ b/nodejs/docusaurus.config.js
@@ -169,7 +169,7 @@ module.exports = {
       {
         hashed: true,
         language: ["en", "zh"],
-        searchResultLimits: 10,
+        searchResultLimits: 8,
       },
     ],
   ],

--- a/python/docusaurus.config.js
+++ b/python/docusaurus.config.js
@@ -169,7 +169,7 @@ module.exports = {
       {
         hashed: true,
         language: ["en", "zh"],
-        searchResultLimits: 10,
+        searchResultLimits: 8,
       },
     ],
   ],


### PR DESCRIPTION
<!-- 
  Hey, thank you for your contribution!
  The actual source of the file which you are probably editing lives in this repository
  https://github.com/microsoft/playwright/blob/main/docs
  Thank you for doing the Pull Request there!
-->
Fixes #403 

Previously when searching for results on search bar shows too much results that some results chip at the end of screen also you cannot scroll. 

**This situation gets worse if you are reading docs from mobile as you are totally stuck in search results.**
See this 👇
![image](https://user-images.githubusercontent.com/51379307/142210112-e2a6bc88-dc5f-4c78-b90b-8cf492a48faa.png)


This PR sets the Docusaurus search `searchResultLimits` to 8 so that it can fit and gives a great experience for developers reading docs.

##How did you test this change
By building the docs and serving them on `localhost:3000` and I pretty satisfied with the results.

After Results 
![image](https://user-images.githubusercontent.com/51379307/142210384-e82b64ec-266b-431e-a697-389f9c7810f9.png)

