### PR TITLE
Update intro.mdx

### DIFF
--- a/nodejs/docs/intro.mdx
+++ b/nodejs/docs/intro.mdx
@@ -245,9 +245,6 @@ test('my test', async ({ page }) => {
   // Expect an attribute "to be strictly equal" to the value.
   await expect(page.locator('text=Get Started').first()).toHaveAttribute('href', '/docs/intro');
 
-  // Expect an element "to be visible".
-  await expect(page.locator('text=Learn more').first()).toBeVisible();
-
   await page.click('text=Get Started');
   // Expect some text to be visible on the page.
   await expect(page.locator('text=Introduction').first()).toBeVisible();
@@ -269,9 +266,6 @@ test('my test', async ({ page }) => {
 
   // Expect an attribute "to be strictly equal" to the value.
   await expect(page.locator('text=Get Started').first()).toHaveAttribute('href', '/docs/intro');
-
-  // Expect an element "to be visible".
-  await expect(page.locator('text=Learn more').first()).toBeVisible();
 
   await page.click('text=Get Started');
   // Expect some text to be visible on the page.


### PR DESCRIPTION
When I was following getting started docs, I found a failing test case on node.js docs [Writing Assertions](https://playwright.dev/docs/intro#writing-assertions) section.

So I removed a failing test step asserting 'Learn more' text should be visible.
