### PR TITLE
chore: use right version of NPM with Azure Static WebApps

### DIFF
--- a/.github/workflows/azure-static-web-apps-delightful-forest-0a29f6210.yml
+++ b/.github/workflows/azure-static-web-apps-delightful-forest-0a29f6210.yml
@@ -33,6 +33,8 @@ jobs:
           output_location: "/build" # Built app content directory - optional
           build_timeout_in_minutes: 120
           ###### End of Repository/Build Configurations ######
+        env:
+          CUSTOM_BUILD_COMMAND: "npm i -g npm@8 && npm ci && npm run build"
 
   close_pull_request_job:
     # Only when Pull Requests gets closed which are no forks 


### PR DESCRIPTION
This fixes that Azure Static WebApps did not pick up the right NPM version. It picked up NPM 6 instead which can't handle lock format v2.