### PR TITLE
docs(nodejs): add accessibility testing to js sidebar

### DIFF
--- a/nodejs/sidebars.js
+++ b/nodejs/sidebars.js
@@ -42,6 +42,7 @@ module.exports = {
       "label": "Guides",
       "items": [
         { "type": "doc", "id": "library" },
+        { "type": "doc", "id": "accessibility-testing" },
         { "type": "doc", "id": "actionability" },
         { "type": "doc", "id": "auth" },
         { "type": "doc", "id": "browsers" },


### PR DESCRIPTION
This PR adds the new `accessibility-testing-js.md` guide authored in https://github.com/microsoft/playwright/pull/15154 to the nodejs sidebar, per discussion in https://github.com/microsoft/playwright/issues/14112.

I verified the change locally by rolling the docs, verifying that the new page shows up in the "Next" docs, and manually reviewing its contents. This resulted in followup PRs https://github.com/microsoft/playwright/pull/15204 and https://github.com/microsoft/playwright/pull/15205 (neither of which block this one)