### PR TITLE
chore: generate all languages on watch

### DIFF
--- a/src/format_csharp.js
+++ b/src/format_csharp.js
@@ -31,7 +31,7 @@ class CSharpFormatter {
    * @param {Documentation.Member} member 
    */
   formatMember(member) {
-    let text;
+    let text = '';
     let args = [];
 
     let prefix = `${toTitleCase(member.clazz.varName)}.`;

--- a/src/format_java.js
+++ b/src/format_java.js
@@ -28,7 +28,7 @@ class JavaFormatter {
     this.lang = 'java';
   }
   formatMember(member) {
-    let text;
+    let text = '';
     let args = [];
 
     let prefix = `${member.clazz.name}.`;

--- a/src/format_js.js
+++ b/src/format_js.js
@@ -29,7 +29,7 @@ class JavaScriptFormatter {
     this.lang = 'js';
   }
   formatMember(member) {
-    let text;
+    let text = '';
     let args = [];
 
     let prefix = `${member.clazz.varName}.`;

--- a/src/format_python.js
+++ b/src/format_python.js
@@ -30,7 +30,7 @@ class PythonFormatter {
     this.lang = 'python';
   }
   formatMember(member) {
-    let text;
+    let text = '';
     const args = [];
 
     let prefix = `${toSnakeCase(member.clazz.varName)}.`;

--- a/src/generate.js
+++ b/src/generate.js
@@ -38,18 +38,11 @@ const lang2Folder = {
   'csharp': 'dotnet',
 }
 
-/**
- * @param {string[]} languages
- */
-async function generateDocsForLanguage (languages) {
-  const lang2Generator = {
-    'js': JavaScriptFormatter,
-    'python': PythonFormatter,
-    'java': JavaFormatter,
-    'csharp': CSharpFormatter,
-  };
-  for (const lang of languages)
-    new Generator(lang, srcDir, path.join(__dirname, '..', lang2Folder[lang], 'docs'), new lang2Generator[lang]);
+async function generateDocsForLanguages () {
+  new Generator('js', srcDir, path.join(__dirname, '..', 'nodejs', 'docs'), new JavaScriptFormatter());
+  new Generator('python', srcDir, path.join(__dirname, '..', 'python', 'docs'), new PythonFormatter());
+  new Generator('java', srcDir, path.join(__dirname, '..', 'java', 'docs'), new JavaFormatter());
+  new Generator('csharp', srcDir, path.join(__dirname, '..', 'dotnet', 'docs'), new CSharpFormatter());
 };
 
 /**
@@ -78,7 +71,7 @@ async function syncWithWorkingDirectory (event, from) {
 (async () => {
   if (isWatch) {
     chokidar.watch(srcDir, { ignoreInitial: true }).on('all', (event, path) => {
-      generateDocsForLanguage([watchProject]).catch((error) => {
+      generateDocsForLanguages().catch((error) => {
         console.error(`Error auto syncing docs (generating): ${error}`);
       })
     });
@@ -87,9 +80,9 @@ async function syncWithWorkingDirectory (event, from) {
         console.error(`Error auto syncing docs (mirroring): ${error}`);
       })
     });
-    await generateDocsForLanguage([watchProject]);
+    await generateDocsForLanguages();
   } else {
-    await generateDocsForLanguage(['js', 'python', 'java', 'csharp']);
+    await generateDocsForLanguages();
     await updateStarsButton();
   }
 
@@ -112,7 +105,7 @@ async function updateStarsButton() {
         data += chunk;
       });
       res.on('end', () => {
-        if (res.statusCode >= 200 && res.statusCode < 300)
+        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300)
           resolve(JSON.parse(data));
         else
           reject(new Error(`Request failed with status code ${res.statusCode}: ${data}`));


### PR DESCRIPTION
When `npm run start-nodejs` was used and e.g. debug.md was changed, it generated nodejs/debug.md as intended but not python/debug.md, which required another npm run roll before pushing. This fixes it.

(Fix for Debbie)