### PR TITLE
devops: migrate deployment to official GitHub Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,27 +4,43 @@ on:
   push:
     branches:
     - main
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  build-and-deploy:
+  # Build job
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - run: npm i -g npm@8
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v1
       - run: npm ci
       - run: npm run build
-      - run: mv build ../.
-      - run: git checkout gh-pages
-      - name: Clean existing files
-        run: rm -rf *
-      - name: Move build files to repo dir
-        run: mv ../build/* .
-      - run: git status
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          branch: gh-pages
+          path: ./build
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Tested on my private fork, seems to work fine.

See [here](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta) about the announcement.