### PR TITLE
docs: add puppeteer migration to nodejs sidebar

### DIFF
--- a/nodejs/sidebars.js
+++ b/nodejs/sidebars.js
@@ -82,6 +82,7 @@ module.exports = {
       label: 'Migration',
       items: [
         { type: 'doc', id: 'protractor' },
+        { type: 'doc', id: 'puppeteer' },
         { type: 'doc', id: 'testing-library' }
       ],
       collapsed: true


### PR DESCRIPTION
Puppeteer migration guide was merged to Playwright repo. This PR adds the migration guide to the sidebar

I believe `Playwright Service` will roll the doc from the main repo
