### PR TITLE
doc:apostrophes 

### DIFF
--- a/dotnet/versioned_docs/version-stable/cli.mdx
+++ b/dotnet/versioned_docs/version-stable/cli.mdx
@@ -108,7 +108,7 @@ var browser = await chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless
 
 // Setup context however you like.
 var context = await browser.NewContextAsync(); // Pass any options
-await context.RouteAsync('**/*', route => route.ContinueAsync());
+await context.RouteAsync("**/*", route => route.ContinueAsync());
 
 // Pause the page, and start recording manually.
 var page = await context.NewPageAsync();

--- a/dotnet/versioned_docs/version-stable/codegen.mdx
+++ b/dotnet/versioned_docs/version-stable/codegen.mdx
@@ -97,7 +97,7 @@ var browser = await chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless
 
 // Setup context however you like.
 var context = await browser.NewContextAsync(); // Pass any options
-await context.RouteAsync('**/*', route => route.ContinueAsync());
+await context.RouteAsync("**/*", route => route.ContinueAsync());
 
 // Pause the page, and start recording manually.
 var page = await context.NewPageAsync();


### PR DESCRIPTION
Fixed two occurrences where apostrophes were used and caused markdown to format incorrectly. I noticed this when reading the codegen page and also found it in the cli page.

Example:
![image](https://user-images.githubusercontent.com/24222640/188966799-922ac868-ecc7-4103-ad06-b2c7dce452ff.png)
