### PR TITLE
Fix GitHub casing in title

### DIFF
--- a/nodejs/versioned_docs/version-stable/ci-intro.mdx
+++ b/nodejs/versioned_docs/version-stable/ci-intro.mdx
@@ -1,6 +1,6 @@
 ---
 id: ci-intro
-title: "CI Github Actions"
+title: "CI GitHub Actions"
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';


### PR DESCRIPTION
<!-- 
  Hey, thank you for your contribution!
  The actual source of the file which you are probably editing lives in this repository
  https://github.com/microsoft/playwright/blob/main/docs
  Thank you for doing the Pull Request there!
-->

First of all, thanks for Playwright! 🙌 Great tool :)

Fix the casing of GitHub (small `h` -> large `H`) in 3 places on the page (also page title)

<img width="741" alt="Screen Shot 2022-10-05 at 12 39 19" src="https://user-images.githubusercontent.com/1935696/194042380-3d76e4d3-a869-43dd-a4fa-f147e59b951f.png">
