### PR TITLE
Add default image for meta tags

### DIFF
--- a/dotnet/docusaurus.config.js
+++ b/dotnet/docusaurus.config.js
@@ -175,6 +175,7 @@ module.exports = {
       appId: 'K09ICMCV6X',
       apiKey: 'a5b64422711c37ab6a0ce4d86d16cdd9',
     },
+    image: 'https://repository-images.githubusercontent.com/221981891/8c5c6942-c91f-4df1-825f-4cf474056bd7',
   },
   themes: [
     [

--- a/java/docusaurus.config.js
+++ b/java/docusaurus.config.js
@@ -175,6 +175,7 @@ module.exports = {
       appId: 'K09ICMCV6X',
       apiKey: 'a5b64422711c37ab6a0ce4d86d16cdd9',
     },
+    image: 'https://repository-images.githubusercontent.com/221981891/8c5c6942-c91f-4df1-825f-4cf474056bd7',
   },
   themes: [
     [

--- a/nodejs/docusaurus.config.js
+++ b/nodejs/docusaurus.config.js
@@ -176,6 +176,7 @@ module.exports = {
       appId: 'K09ICMCV6X',
       apiKey: 'a5b64422711c37ab6a0ce4d86d16cdd9',
     },
+    image: 'https://repository-images.githubusercontent.com/221981891/8c5c6942-c91f-4df1-825f-4cf474056bd7',
   },
   themes: [
     [

--- a/python/docusaurus.config.js
+++ b/python/docusaurus.config.js
@@ -176,6 +176,7 @@ module.exports = {
       appId: 'K09ICMCV6X',
       apiKey: 'a5b64422711c37ab6a0ce4d86d16cdd9',
     },
+    image: 'https://repository-images.githubusercontent.com/221981891/8c5c6942-c91f-4df1-825f-4cf474056bd7',
   },
   themes: [
     [


### PR DESCRIPTION
Add image for meta tags. This will populate the share image for social networks such as Twitter, Facebook or LinkedIn and create a nice preview card.

Result for Twitter will be as below
![image](https://user-images.githubusercontent.com/12395973/194720393-6dba5432-e372-4a24-a117-90e7a6ada01a.png)

I tried my best to fit Playwright's website style, fonts and used the SVG logo. Source PSD file is available here : https://drive.google.com/file/d/1XyV2UzzoslFWYDRkSM1p0tYMmzQckSiJ/view?usp=sharing
