### PR TITLE
Update playwright module name in imports

### DIFF
--- a/nodejs/docs/api/class-android.mdx
+++ b/nodejs/docs/api/class-android.mdx
@@ -23,7 +23,7 @@ Playwright has **experimental** support for Android automation. This includes Ch
 An example of the Android automation script would be:
 
 ```js
-const { _android: android } = require('playwright');
+const { _android: android } = require('@playwright/test');
 
 (async () => {
   // Connect to the device.
@@ -133,7 +133,7 @@ Launches Playwright Android server that clients can connect to. See the followin
 Server Side:
 
 ```js
-const { _android } = require('playwright');
+const { _android } = require('@playwright/test');
 
 (async () => {
   const browserServer = await _android.launchServer({
@@ -148,7 +148,7 @@ const { _android } = require('playwright');
 Client Side:
 
 ```js
-const { _android } = require('playwright');
+const { _android } = require('@playwright/test');
 
 (async () => {
   const device = await _android.connect('<wsEndpoint>');

--- a/nodejs/docs/api/class-browser.mdx
+++ b/nodejs/docs/api/class-browser.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 A Browser is created via [browserType.launch([options])](/api/class-browsertype.mdx#browser-type-launch). An example of using a [Browser] to create a [Page]:
 
 ```js
-const { firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
+const { firefox } = require('@playwright/test');  // Or 'chromium' or 'webkit'.
 
 (async () => {
   const browser = await firefox.launch();

--- a/nodejs/docs/api/class-browsercontext.mdx
+++ b/nodejs/docs/api/class-browsercontext.mdx
@@ -307,7 +307,7 @@ See [page.exposeBinding(name, callback[, options])](/api/class-page.mdx#page-exp
 An example of exposing page URL to all frames in all pages in the context:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 
 (async () => {
   const browser = await webkit.launch({ headless: false });
@@ -359,7 +359,7 @@ See [page.exposeFunction(name, callback)](/api/class-page.mdx#page-expose-functi
 An example of adding a `sha256` function to all pages in the context:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 const crypto = require('crypto');
 
 (async () => {

--- a/nodejs/docs/api/class-browsertype.mdx
+++ b/nodejs/docs/api/class-browsertype.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 BrowserType provides methods to launch a specific browser instance or connect to an existing one. The following is a typical example of using Playwright to drive automation:
 
 ```js
-const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
+const { chromium } = require('@playwright/test');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch();
@@ -247,7 +247,7 @@ Returns the browser app instance. You can connect to it via [browserType.connect
 Launches browser server that client can connect to. An example of launching a browser executable and connecting to it later:
 
 ```js
-const { chromium } = require('playwright');  // Or 'webkit' or 'firefox'.
+const { chromium } = require('@playwright/test');  // Or 'webkit' or 'firefox'.
 
 (async () => {
   const browserServer = await chromium.launchServer();

--- a/nodejs/docs/api/class-coverage.mdx
+++ b/nodejs/docs/api/class-coverage.mdx
@@ -14,7 +14,7 @@ Coverage APIs are only supported on Chromium-based browsers.
 :::
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 const v8toIstanbul = require('v8-to-istanbul');
 
 (async() => {

--- a/nodejs/docs/api/class-dialog.mdx
+++ b/nodejs/docs/api/class-dialog.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 An example of using `Dialog` class:
 
 ```js
-const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
+const { chromium } = require('@playwright/test');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch();

--- a/nodejs/docs/api/class-electron.mdx
+++ b/nodejs/docs/api/class-electron.mdx
@@ -8,13 +8,13 @@ import TabItem from '@theme/TabItem';
 Playwright has **experimental** support for Electron automation. You can access electron namespace via:
 
 ```js
-const { _electron } = require('playwright');
+const { _electron } = require('@playwright/test');
 ```
 
 An example of the Electron automation script would be:
 
 ```js
-const { _electron: electron } = require('playwright');
+const { _electron: electron } = require('@playwright/test');
 
 (async () => {
   // Launch Electron app.

--- a/nodejs/docs/api/class-electronapplication.mdx
+++ b/nodejs/docs/api/class-electronapplication.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 Electron application representation. You can use [electron.launch([options])](/api/class-electron.mdx#electron-launch) to obtain the application instance. This instance you can control main electron process as well as work with Electron windows:
 
 ```js
-const { _electron: electron } = require('playwright');
+const { _electron: electron } = require('@playwright/test');
 
 (async () => {
   // Launch Electron app.

--- a/nodejs/docs/api/class-frame.mdx
+++ b/nodejs/docs/api/class-frame.mdx
@@ -15,7 +15,7 @@ At every point of time, page exposes its current frame tree via the [page.mainFr
 An example of dumping frame tree:
 
 ```js
-const { firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
+const { firefox } = require('@playwright/test');  // Or 'chromium' or 'webkit'.
 
 (async () => {
   const browser = await firefox.launch();
@@ -1163,7 +1163,7 @@ Returns when the `pageFunction` returns a truthy value, returns that value.
 The [frame.waitForFunction(pageFunction[, arg, options])](/api/class-frame.mdx#frame-wait-for-function) can be used to observe viewport size change:
 
 ```js
-const { firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
+const { firefox } = require('@playwright/test');  // Or 'chromium' or 'webkit'.
 
 (async () => {
   const browser = await firefox.launch();
@@ -1258,7 +1258,7 @@ Wait for the `selector` to satisfy `state` option (either appear/disappear from 
 This method works across navigations:
 
 ```js
-const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
+const { chromium } = require('@playwright/test');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch();

--- a/nodejs/docs/api/class-logger.mdx
+++ b/nodejs/docs/api/class-logger.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 Playwright generates a lot of logs and they are accessible via the pluggable logger sink.
 
 ```js
-const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
+const { chromium } = require('@playwright/test');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch({

--- a/nodejs/docs/api/class-page.mdx
+++ b/nodejs/docs/api/class-page.mdx
@@ -12,7 +12,7 @@ Page provides methods to interact with a single tab in a [Browser], or an [exten
 This example creates a page, navigates it to a URL, and then saves a screenshot:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 
 (async () => {
   const browser = await webkit.launch();
@@ -894,7 +894,7 @@ Functions installed via [page.exposeBinding(name, callback[, options])](/api/cla
 An example of exposing page URL to all frames in a page:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 
 (async () => {
   const browser = await webkit.launch({ headless: false });
@@ -950,7 +950,7 @@ Functions installed via [page.exposeFunction(name, callback)](/api/class-page.md
 An example of adding a `sha256` function to the page:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 const crypto = require('crypto');
 
 (async () => {
@@ -2070,7 +2070,7 @@ Returns when the `pageFunction` returns a truthy value. It resolves to a JSHandl
 The [page.waitForFunction(pageFunction[, arg, options])](/api/class-page.mdx#page-wait-for-function) can be used to observe viewport size change:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 
 (async () => {
   const browser = await webkit.launch();
@@ -2246,7 +2246,7 @@ Wait for the `selector` to satisfy `state` option (either appear/disappear from 
 This method works across navigations:
 
 ```js
-const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
+const { chromium } = require('@playwright/test');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch();

--- a/nodejs/docs/api/class-playwright.mdx
+++ b/nodejs/docs/api/class-playwright.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 Playwright module provides a method to launch a browser instance. The following is a typical example of using Playwright to drive automation:
 
 ```js
-const { chromium, firefox, webkit } = require('playwright');
+const { chromium, firefox, webkit } = require('@playwright/test');
 
 (async () => {
   const browser = await chromium.launch();  // Or 'firefox' or 'webkit'.
@@ -45,7 +45,7 @@ This object can be used to launch or connect to Chromium, returning instances of
 Returns a dictionary of devices to be used with [browser.newContext([options])](/api/class-browser.mdx#browser-new-context) or [browser.newPage([options])](/api/class-browser.mdx#browser-new-page).
 
 ```js
-const { webkit, devices } = require('playwright');
+const { webkit, devices } = require('@playwright/test');
 const iPhone = devices['iPhone 6'];
 
 (async () => {

--- a/nodejs/docs/api/class-selectors.mdx
+++ b/nodejs/docs/api/class-selectors.mdx
@@ -26,7 +26,7 @@ Selectors can be used to install custom selector engines. See [Working with sele
 An example of registering selector engine that queries elements based on a tag name:
 
 ```js
-const { selectors, firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
+const { selectors, firefox } = require('@playwright/test');  // Or 'chromium' or 'webkit'.
 
 (async () => {
   // Must be a function that evaluates to a selector engine instance.

--- a/nodejs/docs/api/class-timeouterror.mdx
+++ b/nodejs/docs/api/class-timeouterror.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 TimeoutError is emitted whenever certain operations are terminated due to timeout, e.g. [locator.waitFor([options])](/api/class-locator.mdx#locator-wait-for) or [browserType.launch([options])](/api/class-browsertype.mdx#browser-type-launch).
 
 ```js
-const playwright = require('playwright');
+const playwright = require('@playwright/test');
 
 (async () => {
   const browser = await playwright.chromium.launch();

--- a/nodejs/docs/auth.mdx
+++ b/nodejs/docs/auth.mdx
@@ -831,7 +831,7 @@ Note that persistent authentication is not suited for CI environments since it r
 User data directories can be used with the [browserType.launchPersistentContext(userDataDir[, options])](/api/class-browsertype.mdx#browser-type-launch-persistent-context) API.
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 
 const userDataDir = '/path/to/directory';
 const context = await chromium.launchPersistentContext(userDataDir, { headless: false });

--- a/nodejs/docs/browser-contexts.mdx
+++ b/nodejs/docs/browser-contexts.mdx
@@ -130,7 +130,7 @@ test('admin and user', async ({ browser }) => {
 <TabItem value="library">
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 
 // Create a Chromium browser instance
 const browser = await chromium.launch();

--- a/nodejs/docs/browsers.mdx
+++ b/nodejs/docs/browsers.mdx
@@ -68,7 +68,7 @@ module.exports = config;
 <TabItem value="library">
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 const browser = await chromium.launch({
   channel: 'chrome' // or 'msedge', 'chrome-beta', 'msedge-beta', 'msedge-dev', etc.
 });

--- a/nodejs/docs/chrome-extensions.mdx
+++ b/nodejs/docs/chrome-extensions.mdx
@@ -12,7 +12,7 @@ Extensions only work in Chrome / Chromium in non-headless mode, launched with a 
 The following is code for getting a handle to the [background page](https://developer.chrome.com/extensions/background_pages) of a [Manifest v2](https://developer.chrome.com/docs/extensions/mv2/) extension whose source is located in `./my-extension`:
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 
 (async () => {
   const pathToExtension = require('path').join(__dirname, 'my-extension');

--- a/nodejs/docs/ci.mdx
+++ b/nodejs/docs/ci.mdx
@@ -389,7 +389,7 @@ By default, Playwright launches browsers in headless mode. This can be changed b
 
 ```js
 // Works across chromium, firefox and webkit
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 const browser = await chromium.launch({ headless: false });
 ```
 

--- a/nodejs/docs/cli.mdx
+++ b/nodejs/docs/cli.mdx
@@ -98,7 +98,7 @@ npx playwright codegen --load-storage=auth.json my.web.app
 If you would like to use codegen in some non-standard setup (for example, use [browserContext.route(url, handler[, options])](/api/class-browsercontext.mdx#browser-context-route)), it is possible to call [page.pause()](/api/class-page.mdx#page-pause) that will open a separate window with codegen controls.
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 
 (async () => {
   // Make sure to run headed.

--- a/nodejs/docs/emulation.mdx
+++ b/nodejs/docs/emulation.mdx
@@ -78,7 +78,7 @@ module.exports = config;
 <TabItem value="library">
 
 ```js
-const { chromium, devices } = require('playwright');
+const { chromium, devices } = require('@playwright/test');
 const browser = await chromium.launch();
 
 const iphone12 = devices['iPhone 12'];

--- a/nodejs/docs/library.mdx
+++ b/nodejs/docs/library.mdx
@@ -56,7 +56,7 @@ import assert from 'node:assert';
 
 ```js
 const assert = require('node:assert');
-const { chromium, devices } = require('playwright');
+const { chromium, devices } = require('@playwright/test');
 
 (async () => {
   // Setup
@@ -165,7 +165,7 @@ This single command downloads the Playwright NPM package and browser binaries fo
 Once installed, you can `require` Playwright in a Node.js script, and launch any of the 3 browsers (`chromium`, `firefox` and `webkit`).
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 
 (async () => {
   const browser = await chromium.launch();
@@ -188,7 +188,7 @@ Playwright APIs are asynchronous and return Promise objects. Our code examples u
 In our first script, we will navigate to `whatsmyuseragent.org` and take a screenshot in WebKit.
 
 ```js
-const { webkit } = require('playwright');
+const { webkit } = require('@playwright/test');
 
 (async () => {
   const browser = await webkit.launch();

--- a/nodejs/docs/network.mdx
+++ b/nodejs/docs/network.mdx
@@ -57,7 +57,7 @@ const context = await browser.newContext({
 You can monitor all the [Request]s and [Response]s:
 
 ```js
-const { chromium, webkit, firefox } = require('playwright');
+const { chromium, webkit, firefox } = require('@playwright/test');
 
 (async () => {
   const browser = await chromium.launch();

--- a/nodejs/docs/puppeteer.mdx
+++ b/nodejs/docs/puppeteer.mdx
@@ -77,7 +77,7 @@ const puppeteer = require('puppeteer');
 Line-by-line migration to Playwright:
 
 ```js
-const { chromium } = require('playwright'); // 1
+const { chromium } = require('@playwright/test'); // 1
 
 (async () => {
   const browser = await chromium.launch();

--- a/nodejs/docs/test-runners.mdx
+++ b/nodejs/docs/test-runners.mdx
@@ -23,7 +23,7 @@ With a few lines of code, you can hook up Playwright to your existing JavaScript
 For Jest, [jest-playwright](https://github.com/playwright-community/jest-playwright) can be used. However for a light-weight solution, requiring playwright directly works fine. Jest shares it's syntax with Jasmine, so this applies to Jasmine as well.
 
 ```js
-const {chromium} = require('playwright');
+const {chromium} = require('@playwright/test');
 const expect = require('expect');
 let browser;
 let page;
@@ -51,7 +51,7 @@ it('should work', async () => {
 Tests run concurrently in AVA, so a single page variable cannot be shared between tests. Instead, create new pages with a macro function.
 
 ```js
-const {chromium} = require('playwright');
+const {chromium} = require('@playwright/test');
 const test = require('ava').default;
 const browserPromise = chromium.launch();
 
@@ -76,7 +76,7 @@ test('should work', pageMacro, async (t, page) => {
 Mocha looks very similar to the Jest/Jasmine setup, and functions in the same way.
 
 ```js
-const {chromium} = require('playwright');
+const {chromium} = require('@playwright/test');
 const assert = require('assert');
 let browser;
 before(async() => {
@@ -132,7 +132,7 @@ test('should work', async () => {
 These simple examples can be extended to support multiple browsers using an environment variable.
 
 ```js
-const {chromium, webkit, firefox} = require('playwright');
+const {chromium, webkit, firefox} = require('@playwright/test');
 const browserName = process.env.BROWSER || 'webkit';
 let browser;
 beforeAll(async() => {

--- a/nodejs/versioned_docs/version-stable/api/class-android.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-android.mdx
@@ -23,7 +23,7 @@ Playwright has **experimental** support for Android automation. This includes Ch
 An example of the Android automation script would be:
 
 ```js
-const { _android: android } = require('playwright');
+const { _android: android } = require('@playwright/test');
 
 (async () => {
   // Connect to the device.

--- a/nodejs/versioned_docs/version-stable/api/class-browser.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-browser.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 A Browser is created via [browserType.launch([options])](/api/class-browsertype.mdx#browser-type-launch). An example of using a [Browser] to create a [Page]:
 
 ```js
-const { firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
+const { firefox } = require('@playwright/test');  // Or 'chromium' or 'webkit'.
 
 (async () => {
   const browser = await firefox.launch();

--- a/nodejs/versioned_docs/version-stable/api/class-browsercontext.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-browsercontext.mdx
@@ -307,7 +307,7 @@ See [page.exposeBinding(name, callback[, options])](/api/class-page.mdx#page-exp
 An example of exposing page URL to all frames in all pages in the context:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 
 (async () => {
   const browser = await webkit.launch({ headless: false });
@@ -359,7 +359,7 @@ See [page.exposeFunction(name, callback)](/api/class-page.mdx#page-expose-functi
 An example of adding a `sha256` function to all pages in the context:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 const crypto = require('crypto');
 
 (async () => {

--- a/nodejs/versioned_docs/version-stable/api/class-browsertype.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-browsertype.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 BrowserType provides methods to launch a specific browser instance or connect to an existing one. The following is a typical example of using Playwright to drive automation:
 
 ```js
-const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
+const { chromium } = require('@playwright/test');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch();
@@ -247,7 +247,7 @@ Returns the browser app instance. You can connect to it via [browserType.connect
 Launches browser server that client can connect to. An example of launching a browser executable and connecting to it later:
 
 ```js
-const { chromium } = require('playwright');  // Or 'webkit' or 'firefox'.
+const { chromium } = require('@playwright/test');  // Or 'webkit' or 'firefox'.
 
 (async () => {
   const browserServer = await chromium.launchServer();

--- a/nodejs/versioned_docs/version-stable/api/class-coverage.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-coverage.mdx
@@ -14,7 +14,7 @@ Coverage APIs are only supported on Chromium-based browsers.
 :::
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 const v8toIstanbul = require('v8-to-istanbul');
 
 (async() => {

--- a/nodejs/versioned_docs/version-stable/api/class-dialog.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-dialog.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 An example of using `Dialog` class:
 
 ```js
-const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
+const { chromium } = require('@playwright/test');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch();

--- a/nodejs/versioned_docs/version-stable/api/class-electron.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-electron.mdx
@@ -8,13 +8,13 @@ import TabItem from '@theme/TabItem';
 Playwright has **experimental** support for Electron automation. You can access electron namespace via:
 
 ```js
-const { _electron } = require('playwright');
+const { _electron } = require('@playwright/test');
 ```
 
 An example of the Electron automation script would be:
 
 ```js
-const { _electron: electron } = require('playwright');
+const { _electron: electron } = require('@playwright/test');
 
 (async () => {
   // Launch Electron app.

--- a/nodejs/versioned_docs/version-stable/api/class-electronapplication.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-electronapplication.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 Electron application representation. You can use [electron.launch([options])](/api/class-electron.mdx#electron-launch) to obtain the application instance. This instance you can control main electron process as well as work with Electron windows:
 
 ```js
-const { _electron: electron } = require('playwright');
+const { _electron: electron } = require('@playwright/test');
 
 (async () => {
   // Launch Electron app.

--- a/nodejs/versioned_docs/version-stable/api/class-frame.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-frame.mdx
@@ -15,7 +15,7 @@ At every point of time, page exposes its current frame tree via the [page.mainFr
 An example of dumping frame tree:
 
 ```js
-const { firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
+const { firefox } = require('@playwright/test');  // Or 'chromium' or 'webkit'.
 
 (async () => {
   const browser = await firefox.launch();
@@ -1138,7 +1138,7 @@ Returns when the `pageFunction` returns a truthy value, returns that value.
 The [frame.waitForFunction(pageFunction[, arg, options])](/api/class-frame.mdx#frame-wait-for-function) can be used to observe viewport size change:
 
 ```js
-const { firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
+const { firefox } = require('@playwright/test');  // Or 'chromium' or 'webkit'.
 
 (async () => {
   const browser = await firefox.launch();
@@ -1233,7 +1233,7 @@ Wait for the `selector` to satisfy `state` option (either appear/disappear from 
 This method works across navigations:
 
 ```js
-const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
+const { chromium } = require('@playwright/test');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch();

--- a/nodejs/versioned_docs/version-stable/api/class-logger.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-logger.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 Playwright generates a lot of logs and they are accessible via the pluggable logger sink.
 
 ```js
-const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
+const { chromium } = require('@playwright/test');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch({

--- a/nodejs/versioned_docs/version-stable/api/class-page.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-page.mdx
@@ -12,7 +12,7 @@ Page provides methods to interact with a single tab in a [Browser], or an [exten
 This example creates a page, navigates it to a URL, and then saves a screenshot:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 
 (async () => {
   const browser = await webkit.launch();
@@ -877,7 +877,7 @@ Functions installed via [page.exposeBinding(name, callback[, options])](/api/cla
 An example of exposing page URL to all frames in a page:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 
 (async () => {
   const browser = await webkit.launch({ headless: false });
@@ -933,7 +933,7 @@ Functions installed via [page.exposeFunction(name, callback)](/api/class-page.md
 An example of adding a `sha256` function to the page:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 const crypto = require('crypto');
 
 (async () => {
@@ -2045,7 +2045,7 @@ Returns when the `pageFunction` returns a truthy value. It resolves to a JSHandl
 The [page.waitForFunction(pageFunction[, arg, options])](/api/class-page.mdx#page-wait-for-function) can be used to observe viewport size change:
 
 ```js
-const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
+const { webkit } = require('@playwright/test');  // Or 'chromium' or 'firefox'.
 
 (async () => {
   const browser = await webkit.launch();
@@ -2221,7 +2221,7 @@ Wait for the `selector` to satisfy `state` option (either appear/disappear from 
 This method works across navigations:
 
 ```js
-const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
+const { chromium } = require('@playwright/test');  // Or 'firefox' or 'webkit'.
 
 (async () => {
   const browser = await chromium.launch();

--- a/nodejs/versioned_docs/version-stable/api/class-playwright.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-playwright.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 Playwright module provides a method to launch a browser instance. The following is a typical example of using Playwright to drive automation:
 
 ```js
-const { chromium, firefox, webkit } = require('playwright');
+const { chromium, firefox, webkit } = require('@playwright/test');
 
 (async () => {
   const browser = await chromium.launch();  // Or 'firefox' or 'webkit'.
@@ -45,7 +45,7 @@ This object can be used to launch or connect to Chromium, returning instances of
 Returns a dictionary of devices to be used with [browser.newContext([options])](/api/class-browser.mdx#browser-new-context) or [browser.newPage([options])](/api/class-browser.mdx#browser-new-page).
 
 ```js
-const { webkit, devices } = require('playwright');
+const { webkit, devices } = require('@playwright/test');
 const iPhone = devices['iPhone 6'];
 
 (async () => {

--- a/nodejs/versioned_docs/version-stable/api/class-selectors.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-selectors.mdx
@@ -26,7 +26,7 @@ Selectors can be used to install custom selector engines. See [Working with sele
 An example of registering selector engine that queries elements based on a tag name:
 
 ```js
-const { selectors, firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
+const { selectors, firefox } = require('@playwright/test');  // Or 'chromium' or 'webkit'.
 
 (async () => {
   // Must be a function that evaluates to a selector engine instance.

--- a/nodejs/versioned_docs/version-stable/api/class-timeouterror.mdx
+++ b/nodejs/versioned_docs/version-stable/api/class-timeouterror.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 TimeoutError is emitted whenever certain operations are terminated due to timeout, e.g. [locator.waitFor([options])](/api/class-locator.mdx#locator-wait-for) or [browserType.launch([options])](/api/class-browsertype.mdx#browser-type-launch).
 
 ```js
-const playwright = require('playwright');
+const playwright = require('@playwright/test');
 
 (async () => {
   const browser = await playwright.chromium.launch();

--- a/nodejs/versioned_docs/version-stable/auth.mdx
+++ b/nodejs/versioned_docs/version-stable/auth.mdx
@@ -831,7 +831,7 @@ Note that persistent authentication is not suited for CI environments since it r
 User data directories can be used with the [browserType.launchPersistentContext(userDataDir[, options])](/api/class-browsertype.mdx#browser-type-launch-persistent-context) API.
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 
 const userDataDir = '/path/to/directory';
 const context = await chromium.launchPersistentContext(userDataDir, { headless: false });

--- a/nodejs/versioned_docs/version-stable/browser-contexts.mdx
+++ b/nodejs/versioned_docs/version-stable/browser-contexts.mdx
@@ -117,7 +117,7 @@ test('admin and user', async ({ browser }) => {
 <TabItem value="library">
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 
 // Create a Chromium browser instance
 const browser = await chromium.launch();

--- a/nodejs/versioned_docs/version-stable/browsers.mdx
+++ b/nodejs/versioned_docs/version-stable/browsers.mdx
@@ -68,7 +68,7 @@ module.exports = config;
 <TabItem value="library">
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 const browser = await chromium.launch({
   channel: 'chrome' // or 'msedge', 'chrome-beta', 'msedge-beta', 'msedge-dev', etc.
 });

--- a/nodejs/versioned_docs/version-stable/chrome-extensions.mdx
+++ b/nodejs/versioned_docs/version-stable/chrome-extensions.mdx
@@ -12,7 +12,7 @@ Extensions only work in Chrome / Chromium in non-headless mode, launched with a 
 The following is code for getting a handle to the [background page](https://developer.chrome.com/extensions/background_pages) of a [Manifest v2](https://developer.chrome.com/docs/extensions/mv2/) extension whose source is located in `./my-extension`:
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 
 (async () => {
   const pathToExtension = require('path').join(__dirname, 'my-extension');

--- a/nodejs/versioned_docs/version-stable/ci.mdx
+++ b/nodejs/versioned_docs/version-stable/ci.mdx
@@ -389,7 +389,7 @@ By default, Playwright launches browsers in headless mode. This can be changed b
 
 ```js
 // Works across chromium, firefox and webkit
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 const browser = await chromium.launch({ headless: false });
 ```
 

--- a/nodejs/versioned_docs/version-stable/cli.mdx
+++ b/nodejs/versioned_docs/version-stable/cli.mdx
@@ -98,7 +98,7 @@ npx playwright codegen --load-storage=auth.json my.web.app
 If you would like to use codegen in some non-standard setup (for example, use [browserContext.route(url, handler[, options])](/api/class-browsercontext.mdx#browser-context-route)), it is possible to call [page.pause()](/api/class-page.mdx#page-pause) that will open a separate window with codegen controls.
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 
 (async () => {
   // Make sure to run headed.

--- a/nodejs/versioned_docs/version-stable/emulation.mdx
+++ b/nodejs/versioned_docs/version-stable/emulation.mdx
@@ -78,7 +78,7 @@ module.exports = config;
 <TabItem value="library">
 
 ```js
-const { chromium, devices } = require('playwright');
+const { chromium, devices } = require('@playwright/test');
 const browser = await chromium.launch();
 
 const iphone12 = devices['iPhone 12'];

--- a/nodejs/versioned_docs/version-stable/library.mdx
+++ b/nodejs/versioned_docs/version-stable/library.mdx
@@ -62,7 +62,7 @@ import playwright, { devices } from 'playwright';
 <TabItem value="js">
 
 ```js
-const playwright = require('playwright');
+const playwright = require('@playwright/test');
 
 (async () => {
   // Setup
@@ -199,7 +199,7 @@ This single command downloads the Playwright NPM package and browser binaries fo
 Once installed, you can `require` Playwright in a Node.js script, and launch any of the 3 browsers (`chromium`, `firefox` and `webkit`).
 
 ```js
-const { chromium } = require('playwright');
+const { chromium } = require('@playwright/test');
 
 (async () => {
   const browser = await chromium.launch();
@@ -222,7 +222,7 @@ Playwright APIs are asynchronous and return Promise objects. Our code examples u
 In our first script, we will navigate to `whatsmyuseragent.org` and take a screenshot in WebKit.
 
 ```js
-const { webkit } = require('playwright');
+const { webkit } = require('@playwright/test');
 
 (async () => {
   const browser = await webkit.launch();

--- a/nodejs/versioned_docs/version-stable/network.mdx
+++ b/nodejs/versioned_docs/version-stable/network.mdx
@@ -57,7 +57,7 @@ const context = await browser.newContext({
 You can monitor all the [Request]s and [Response]s:
 
 ```js
-const { chromium, webkit, firefox } = require('playwright');
+const { chromium, webkit, firefox } = require('@playwright/test');
 
 (async () => {
   const browser = await chromium.launch();

--- a/nodejs/versioned_docs/version-stable/puppeteer.mdx
+++ b/nodejs/versioned_docs/version-stable/puppeteer.mdx
@@ -77,7 +77,7 @@ const puppeteer = require('puppeteer');
 Line-by-line migration to Playwright:
 
 ```js
-const { chromium } = require('playwright'); // 1
+const { chromium } = require('@playwright/test'); // 1
 
 (async () => {
   const browser = await chromium.launch();

--- a/nodejs/versioned_docs/version-stable/test-runners.mdx
+++ b/nodejs/versioned_docs/version-stable/test-runners.mdx
@@ -23,7 +23,7 @@ With a few lines of code, you can hook up Playwright to your existing JavaScript
 For Jest, [jest-playwright](https://github.com/playwright-community/jest-playwright) can be used. However for a light-weight solution, requiring playwright directly works fine. Jest shares it's syntax with Jasmine, so this applies to Jasmine as well.
 
 ```js
-const {chromium} = require('playwright');
+const {chromium} = require('@playwright/test');
 const expect = require('expect');
 let browser;
 let page;
@@ -51,7 +51,7 @@ it('should work', async () => {
 Tests run concurrently in AVA, so a single page variable cannot be shared between tests. Instead, create new pages with a macro function.
 
 ```js
-const {chromium} = require('playwright');
+const {chromium} = require('@playwright/test');
 const test = require('ava').default;
 const browserPromise = chromium.launch();
 
@@ -76,7 +76,7 @@ test('should work', pageMacro, async (t, page) => {
 Mocha looks very similar to the Jest/Jasmine setup, and functions in the same way.
 
 ```js
-const {chromium} = require('playwright');
+const {chromium} = require('@playwright/test');
 const assert = require('assert');
 let browser;
 before(async() => {
@@ -132,7 +132,7 @@ test('should work', async () => {
 These simple examples can be extended to support multiple browsers using an environment variable.
 
 ```js
-const {chromium, webkit, firefox} = require('playwright');
+const {chromium, webkit, firefox} = require('@playwright/test');
 const browserName = process.env.BROWSER || 'webkit';
 let browser;
 beforeAll(async() => {


### PR DESCRIPTION
<!-- 
  Hey, thank you for your contribution!
  The actual source of the file which you are probably editing lives in this repository
  https://github.com/microsoft/playwright/blob/main/docs
  Thank you for doing the Pull Request there!
-->
This pull request replaces all occurrences of `require('playwright')` with `require('@playwright/test')` as running
`npm init playwright` installs the [@playwright/test](https://www.npmjs.com/package/@playwright/test) package by default, and does not install the [playwright](https://www.npmjs.com/package/playwright) package.  

This will help prevent any errors when a user copies code from the documentation into their codebase.

For example,
```js
const { webkit } = require('playwright');
```
has been replaced with:
```js
const { webkit } = require('@playwright/test');
```