### PR TITLE
chore: Update Slack community to Discord community

### DIFF
--- a/community/0-welcome.mdx
+++ b/community/0-welcome.mdx
@@ -24,9 +24,9 @@ Or why not join our [GitHub Discussions community](https://github.com/microsoft/
 
 Check out our [contributing guide](https://github.com/microsoft/playwright/blob/main/CONTRIBUTING.md) if you would like to contribute to Playwright.
 
-## Community Slack
+## Community Discord
 
-Join our community [Slack Channel](https://aka.ms/playwright-slack) to connect with other developers using Playwright.
+Join our community [Discord Server](https://aka.ms/playwright/discord) to connect with other developers using Playwright.
 
 ## Stack Overflow {#stack-overflow}
 

--- a/community/ambassadors.mdx
+++ b/community/ambassadors.mdx
@@ -15,6 +15,6 @@ We are more than excited to introduce to you our awesome Playwright Ambassadors 
 
 ## Join the Program
 
-If you are creating video content, workshops, courses, conference talks and are sharing your knowledge of Playwright with the community then reach out to us by DM or through our [Community Slack Channel](https://aka.ms/playwright-slack). We would love to hear from you and see the amazing content you are creating.
+If you are creating video content, workshops, courses, conference talks and are sharing your knowledge of Playwright with the community then reach out to us by DM or through our [Community Discord Server](https://aka.ms/playwright/discord). We would love to hear from you and see the amazing content you are creating.
 
 <ProfileCards people={team} />

--- a/dotnet/docusaurus.config.js
+++ b/dotnet/docusaurus.config.js
@@ -142,8 +142,8 @@ module.exports = {
               href: "https://stackoverflow.com/questions/tagged/playwright",
             },
             {
-              label: "Slack",
-              href: "https://aka.ms/playwright-slack",
+              label: "Discord",
+              href: "https://aka.ms/playwright/discord",
             },
             {
               label: "Twitter",

--- a/dotnet/sidebarCommunity.js
+++ b/dotnet/sidebarCommunity.js
@@ -32,8 +32,8 @@ module.exports = {
 
     {
       type: 'link',
-      label: 'Join our Community Slack',
-      href: 'https://aka.ms/playwright-slack'
+      label: 'Join our Community Discord',
+      href: 'https://aka.ms/playwright/discord'
     }
   ]
 };

--- a/java/docusaurus.config.js
+++ b/java/docusaurus.config.js
@@ -142,8 +142,8 @@ module.exports = {
               href: "https://stackoverflow.com/questions/tagged/playwright",
             },
             {
-              label: "Slack",
-              href: "https://aka.ms/playwright-slack",
+              label: "Discord",
+              href: "https://aka.ms/playwright/discord",
             },
             {
               label: "Twitter",

--- a/java/sidebarCommunity.js
+++ b/java/sidebarCommunity.js
@@ -32,8 +32,8 @@ module.exports = {
 
     {
       type: 'link',
-      label: 'Join our Community Slack',
-      href: 'https://aka.ms/playwright-slack'
+      label: 'Join our Community Discord',
+      href: 'https://aka.ms/playwright/discord'
     }
   ]
 };

--- a/nodejs/docusaurus.config.js
+++ b/nodejs/docusaurus.config.js
@@ -143,8 +143,8 @@ module.exports = {
               href: "https://stackoverflow.com/questions/tagged/playwright",
             },
             {
-              label: "Slack",
-              href: "https://aka.ms/playwright-slack",
+              label: "Discord",
+              href: "https://aka.ms/playwright/discord",
             },
             {
               label: "Twitter",

--- a/nodejs/sidebarCommunity.js
+++ b/nodejs/sidebarCommunity.js
@@ -32,8 +32,8 @@ module.exports = {
 
     {
       type: 'link',
-      label: 'Join our Community Slack',
-      href: 'https://aka.ms/playwright-slack'
+      label: 'Join our Community Discord',
+      href: 'https://aka.ms/playwright/discord'
     }
   ]
 };

--- a/python/docusaurus.config.js
+++ b/python/docusaurus.config.js
@@ -143,8 +143,8 @@ module.exports = {
               href: "https://stackoverflow.com/questions/tagged/playwright",
             },
             {
-              label: "Slack",
-              href: "https://aka.ms/playwright-slack",
+              label: "Discord",
+              href: "https://aka.ms/playwright/discord",
             },
             {
               label: "Twitter",

--- a/python/sidebarCommunity.js
+++ b/python/sidebarCommunity.js
@@ -32,8 +32,8 @@ module.exports = {
 
     {
       type: 'link',
-      label: 'Join our Community Slack',
-      href: 'https://aka.ms/playwright-slack'
+      label: 'Join our Community Discord',
+      href: 'https://aka.ms/playwright/discord'
     }
   ]
 };


### PR DESCRIPTION
Hi there! When clicking "Join our community Slack Channel" on the Community page, I noticed it redirected me to a Discord Server invite. This pull request updates all references to Slack by replacing it with Discord. Notice how the new link uses a slash, rather than a dash.

Thank you for everything you've been doing, Playwright is truly amazing!