### PR TITLE
chore: show property discouraged and deprecated warnings

### DIFF
--- a/dotnet/docs/api/class-accessibility.mdx
+++ b/dotnet/docs/api/class-accessibility.mdx
@@ -24,7 +24,7 @@ Most of the accessibility tree gets filtered out when converting from internal b
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>accessibility.SnapshotAsync</x-search>
 
-:::caution
+:::caution Deprecated
 
 This method is deprecated. Please use other libraries such as [Axe](https://www.deque.com/axe/) if you need to test page accessibility. See our Node.js [guide](https://playwright.dev/docs/accessibility-testing) for integration with Axe.
 

--- a/dotnet/docs/api/class-frame.mdx
+++ b/dotnet/docs/api/class-frame.mdx
@@ -1197,7 +1197,7 @@ await frame.WaitForURLAsync("**/target.html");
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.CheckAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.CheckAsync()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -1256,7 +1256,7 @@ await Frame.CheckAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.ClickAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.ClickAsync()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -1325,7 +1325,7 @@ await Frame.ClickAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.DblClickAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.DblClickAsync()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -1395,7 +1395,7 @@ await Frame.DblClickAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.DispatchEventAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.DispatchEventAsync()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -1453,7 +1453,7 @@ await frame.DispatchEventAsync("#source", "dragstart", new { dataTransfer });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.EvalOnSelectorAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 This method does not wait for the element to pass the actionability checks and therefore can lead to the flaky tests. Use [Locator.EvaluateAsync()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -1498,7 +1498,7 @@ var html = await frame.EvalOnSelectorAsync(".main-container", "(e, suffix) => e.
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.EvalOnSelectorAllAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 In most cases, [Locator.EvaluateAllAsync()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -1537,7 +1537,7 @@ var divsCount = await frame.EvalOnSelectorAllAsync<bool>("div", "(divs, min) => 
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.FillAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.FillAsync()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -1583,7 +1583,7 @@ await Frame.FillAsync(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.FocusAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.FocusAsync()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -1616,7 +1616,7 @@ await Frame.FocusAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.GetAttributeAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.GetAttributeAsync()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -1655,7 +1655,7 @@ await Frame.GetAttributeAsync(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.HoverAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.HoverAsync()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -1715,7 +1715,7 @@ await Frame.HoverAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.InnerHTMLAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.InnerHTMLAsync()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -1751,7 +1751,7 @@ await Frame.InnerHTMLAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.InnerTextAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.InnerTextAsync()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -1787,7 +1787,7 @@ await Frame.InnerTextAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>frame.InputValueAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.InputValueAsync()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -1825,7 +1825,7 @@ await Frame.InputValueAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsCheckedAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.IsCheckedAsync()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -1861,7 +1861,7 @@ await Frame.IsCheckedAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsDisabledAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.IsDisabledAsync()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -1897,7 +1897,7 @@ await Frame.IsDisabledAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsEditableAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.IsEditableAsync()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -1933,7 +1933,7 @@ await Frame.IsEditableAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsHiddenAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.IsHiddenAsync()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -1958,7 +1958,7 @@ await Frame.IsHiddenAsync(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Frame.IsHiddenAsync()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -1972,7 +1972,7 @@ await Frame.IsHiddenAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsVisibleAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.IsVisibleAsync()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -1997,7 +1997,7 @@ await Frame.IsVisibleAsync(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Frame.IsVisibleAsync()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -2011,7 +2011,7 @@ await Frame.IsVisibleAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.PressAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.PressAsync()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -2063,7 +2063,7 @@ await Frame.PressAsync(selector, key, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.QuerySelectorAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Frame.Locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2102,7 +2102,7 @@ await Frame.QuerySelectorAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.QuerySelectorAllAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Frame.Locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2137,7 +2137,7 @@ await Frame.QuerySelectorAllAsync(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.SelectOptionAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.SelectOptionAsync()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -2202,7 +2202,7 @@ await frame.SelectOptionAsync("select#colors", new[] { "red", "green", "blue" })
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>frame.SetCheckedAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.SetCheckedAsync()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -2265,7 +2265,7 @@ await Frame.SetCheckedAsync(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.SetInputFilesAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.SetInputFilesAsync()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -2313,7 +2313,7 @@ await Frame.SetInputFilesAsync(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.TapAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.TapAsync()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -2377,7 +2377,7 @@ await Frame.TapAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.TextContentAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.TextContentAsync()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -2413,7 +2413,7 @@ await Frame.TextContentAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.TypeAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.TypeAsync()](/api/class-locator.mdx#locator-type) instead. Read more about [locators](../locators.mdx).
 
@@ -2458,7 +2458,7 @@ await frame.TypeAsync("#mytextarea", "world", new() { Delay = 100 }); // types s
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.UncheckAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.UncheckAsync()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 

--- a/dotnet/docs/api/class-frame.mdx
+++ b/dotnet/docs/api/class-frame.mdx
@@ -1957,6 +1957,11 @@ await Frame.IsHiddenAsync(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Frame.IsHiddenAsync()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
+    :::
+    
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-return"/><a href="#frame-is-hidden-return" class="list-anchor">#</a>
@@ -1991,6 +1996,11 @@ await Frame.IsVisibleAsync(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Frame.IsVisibleAsync()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
+    :::
+    
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-return"/><a href="#frame-is-visible-return" class="list-anchor">#</a>

--- a/dotnet/docs/api/class-locator.mdx
+++ b/dotnet/docs/api/class-locator.mdx
@@ -1321,6 +1321,11 @@ Boolean hidden = await page.GetByRole(AriaRole.Button).IsHiddenAsync();
 **Arguments**
 - `options` `LocatorIsHiddenOptions?` *(optional)*
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Locator.IsHiddenAsync()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
+    :::
+    
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-return"/><a href="#locator-is-hidden-return" class="list-anchor">#</a>
@@ -1342,6 +1347,11 @@ Boolean visible = await page.GetByRole(AriaRole.Button).IsVisibleAsync();
 **Arguments**
 - `options` `LocatorIsVisibleOptions?` *(optional)*
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Locator.IsVisibleAsync()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
+    :::
+    
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-return"/><a href="#locator-is-visible-return" class="list-anchor">#</a>

--- a/dotnet/docs/api/class-locator.mdx
+++ b/dotnet/docs/api/class-locator.mdx
@@ -1322,7 +1322,7 @@ Boolean hidden = await page.GetByRole(AriaRole.Button).IsHiddenAsync();
 - `options` `LocatorIsHiddenOptions?` *(optional)*
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Locator.IsHiddenAsync()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -1348,7 +1348,7 @@ Boolean visible = await page.GetByRole(AriaRole.Button).IsVisibleAsync();
 - `options` `LocatorIsVisibleOptions?` *(optional)*
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Locator.IsVisibleAsync()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -1999,7 +1999,7 @@ orderSent.WaitForAsync();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.ElementHandleAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 
@@ -2029,7 +2029,7 @@ await Locator.ElementHandleAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.ElementHandlesAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 

--- a/dotnet/docs/api/class-page.mdx
+++ b/dotnet/docs/api/class-page.mdx
@@ -2950,7 +2950,7 @@ Page.Worker += async data => {};
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.Accessibility</x-search>
 
-:::caution
+:::caution Deprecated
 
 This property is discouraged. Please use other libraries such as [Axe](https://www.deque.com/axe/) if you need to test page accessibility. See our Node.js [guide](https://playwright.dev/docs/accessibility-testing) for integration with Axe.
 
@@ -2972,7 +2972,7 @@ Page.Accessibility
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.CheckAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.CheckAsync()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -3031,7 +3031,7 @@ await Page.CheckAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.ClickAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.ClickAsync()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -3100,7 +3100,7 @@ await Page.ClickAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.DblClickAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.DblClickAsync()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -3170,7 +3170,7 @@ await Page.DblClickAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.DispatchEventAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.DispatchEventAsync()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -3227,7 +3227,7 @@ await page.DispatchEventAsync("#source", "dragstart", new { dataTransfer });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.EvalOnSelectorAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [Locator.EvaluateAsync()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -3270,7 +3270,7 @@ var html = await page.EvalOnSelectorAsync(".main-container", "(e, suffix) => e.o
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.EvalOnSelectorAllAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 In most cases, [Locator.EvaluateAllAsync()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -3307,7 +3307,7 @@ var divsCount = await page.EvalOnSelectorAllAsync<bool>("div", "(divs, min) => d
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.FillAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.FillAsync()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -3353,7 +3353,7 @@ await Page.FillAsync(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.FocusAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.FocusAsync()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -3386,7 +3386,7 @@ await Page.FocusAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.GetAttributeAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.GetAttributeAsync()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -3425,7 +3425,7 @@ await Page.GetAttributeAsync(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.HoverAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.HoverAsync()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -3485,7 +3485,7 @@ await Page.HoverAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.InnerHTMLAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.InnerHTMLAsync()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -3521,7 +3521,7 @@ await Page.InnerHTMLAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.InnerTextAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.InnerTextAsync()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -3557,7 +3557,7 @@ await Page.InnerTextAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>page.InputValueAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.InputValueAsync()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -3595,7 +3595,7 @@ await Page.InputValueAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsCheckedAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.IsCheckedAsync()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -3631,7 +3631,7 @@ await Page.IsCheckedAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsDisabledAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.IsDisabledAsync()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3667,7 +3667,7 @@ await Page.IsDisabledAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsEditableAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.IsEditableAsync()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -3703,7 +3703,7 @@ await Page.IsEditableAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsEnabledAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.IsEnabledAsync()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3739,7 +3739,7 @@ await Page.IsEnabledAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsHiddenAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.IsHiddenAsync()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -3764,7 +3764,7 @@ await Page.IsHiddenAsync(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Page.IsHiddenAsync()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -3778,7 +3778,7 @@ await Page.IsHiddenAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsVisibleAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.IsVisibleAsync()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -3803,7 +3803,7 @@ await Page.IsVisibleAsync(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Page.IsVisibleAsync()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -3817,7 +3817,7 @@ await Page.IsVisibleAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.PressAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.PressAsync()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -3878,7 +3878,7 @@ await page.ScreenshotAsync(new PageScreenshotOptions { Path = "O.png" });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.QuerySelectorAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Page.Locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -3911,7 +3911,7 @@ await Page.QuerySelectorAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.QuerySelectorAllAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Page.Locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -3940,7 +3940,7 @@ await Page.QuerySelectorAllAsync(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.RunAndWaitForNavigationAsync</x-search>
 
-:::caution
+:::caution Deprecated
 
 This method is inherently racy, please use [Page.WaitForURLAsync()](/api/class-page.mdx#page-wait-for-url) instead.
 
@@ -3995,7 +3995,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.WaitForNavigationAsync</x-search>
 
-:::caution
+:::caution Deprecated
 
 This method is inherently racy, please use [Page.WaitForURLAsync()](/api/class-page.mdx#page-wait-for-url) instead.
 
@@ -4036,7 +4036,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.SelectOptionAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.SelectOptionAsync()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -4101,7 +4101,7 @@ await page.SelectOptionAsync("select#colors", new[] { "red", "green", "blue" });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>page.SetCheckedAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.SetCheckedAsync()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -4164,7 +4164,7 @@ await Page.SetCheckedAsync(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.SetInputFilesAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.SetInputFilesAsync()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -4212,7 +4212,7 @@ await Page.SetInputFilesAsync(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.TapAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.TapAsync()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -4276,7 +4276,7 @@ await Page.TapAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.TextContentAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.TextContentAsync()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -4312,7 +4312,7 @@ await Page.TextContentAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.TypeAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.TypeAsync()](/api/class-locator.mdx#locator-type) instead. Read more about [locators](../locators.mdx).
 
@@ -4357,7 +4357,7 @@ await page.TypeAsync("#mytextarea", "world", new() { Delay = 100 }); // types sl
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.UncheckAsync</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.UncheckAsync()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 

--- a/dotnet/docs/api/class-page.mdx
+++ b/dotnet/docs/api/class-page.mdx
@@ -3763,6 +3763,11 @@ await Page.IsHiddenAsync(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Page.IsHiddenAsync()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
+    :::
+    
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-return"/><a href="#page-is-hidden-return" class="list-anchor">#</a>
@@ -3797,6 +3802,11 @@ await Page.IsVisibleAsync(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [double]? *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Page.IsVisibleAsync()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
+    :::
+    
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-return"/><a href="#page-is-visible-return" class="list-anchor">#</a>

--- a/java/docs/api/class-frame.mdx
+++ b/java/docs/api/class-frame.mdx
@@ -1162,7 +1162,7 @@ frame.waitForURL("**/target.html");
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.check</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -1222,7 +1222,7 @@ Frame.check(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.click</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -1292,7 +1292,7 @@ Frame.click(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dblclick</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -1363,7 +1363,7 @@ Frame.dblclick(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dispatchEvent</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.dispatchEvent()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -1423,7 +1423,7 @@ frame.dispatchEvent("#source", "dragstart", arg);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.evalOnSelector</x-search>
 
-:::caution
+:::caution Discouraged
 
 This method does not wait for the element to pass the actionability checks and therefore can lead to the flaky tests. Use [Locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -1468,7 +1468,7 @@ String html = (String) frame.evalOnSelector(".main-container", "(e, suffix) => e
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.evalOnSelectorAll</x-search>
 
-:::caution
+:::caution Discouraged
 
 In most cases, [Locator.evaluateAll()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -1507,7 +1507,7 @@ boolean divsCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => div
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.fill</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -1554,7 +1554,7 @@ Frame.fill(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.focus</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -1588,7 +1588,7 @@ Frame.focus(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.getAttribute</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.getAttribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -1628,7 +1628,7 @@ Frame.getAttribute(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.hover</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -1689,7 +1689,7 @@ Frame.hover(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerHTML</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.innerHTML()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -1726,7 +1726,7 @@ Frame.innerHTML(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerText</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.innerText()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -1763,7 +1763,7 @@ Frame.innerText(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>frame.inputValue</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.inputValue()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -1802,7 +1802,7 @@ Frame.inputValue(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isChecked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.isChecked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -1839,7 +1839,7 @@ Frame.isChecked(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isDisabled</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.isDisabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -1876,7 +1876,7 @@ Frame.isDisabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isEditable</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.isEditable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -1913,7 +1913,7 @@ Frame.isEditable(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isHidden</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -1939,7 +1939,7 @@ Frame.isHidden(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Frame.isHidden()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -1953,7 +1953,7 @@ Frame.isHidden(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isVisible</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.isVisible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -1979,7 +1979,7 @@ Frame.isVisible(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Frame.isVisible()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -1993,7 +1993,7 @@ Frame.isVisible(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.press</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -2046,7 +2046,7 @@ Frame.press(selector, key, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.querySelector</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2086,7 +2086,7 @@ Frame.querySelector(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.querySelectorAll</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2121,7 +2121,7 @@ Frame.querySelectorAll(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.selectOption</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.selectOption()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -2186,7 +2186,7 @@ frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>frame.setChecked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.setChecked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -2250,7 +2250,7 @@ Frame.setChecked(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.setInputFiles</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.setInputFiles()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -2299,7 +2299,7 @@ Frame.setInputFiles(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.tap</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -2364,7 +2364,7 @@ Frame.tap(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.textContent</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.textContent()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -2401,7 +2401,7 @@ Frame.textContent(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.type</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.type()](/api/class-locator.mdx#locator-type) instead. Read more about [locators](../locators.mdx).
 
@@ -2448,7 +2448,7 @@ frame.type("#mytextarea", "World", new Frame.TypeOptions().setDelay(100));
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.uncheck</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 

--- a/java/docs/api/class-frame.mdx
+++ b/java/docs/api/class-frame.mdx
@@ -1938,6 +1938,11 @@ Frame.isHidden(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Frame.isHidden()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
+    :::
+    
 
 **Returns**
 - [boolean]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-return"/><a href="#frame-is-hidden-return" class="list-anchor">#</a>
@@ -1973,6 +1978,11 @@ Frame.isVisible(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Frame.isVisible()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
+    :::
+    
 
 **Returns**
 - [boolean]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-return"/><a href="#frame-is-visible-return" class="list-anchor">#</a>

--- a/java/docs/api/class-locator.mdx
+++ b/java/docs/api/class-locator.mdx
@@ -1322,6 +1322,11 @@ boolean hidden = page.getByRole(AriaRole.BUTTON).isHidden();
 **Arguments**
 - `options` `Locator.IsHiddenOptions` *(optional)*
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
+    :::
+    
 
 **Returns**
 - [boolean]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-return"/><a href="#locator-is-hidden-return" class="list-anchor">#</a>
@@ -1343,6 +1348,11 @@ boolean visible = page.getByRole(AriaRole.BUTTON).isVisible();
 **Arguments**
 - `options` `Locator.IsVisibleOptions` *(optional)*
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Locator.isVisible()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
+    :::
+    
 
 **Returns**
 - [boolean]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-return"/><a href="#locator-is-visible-return" class="list-anchor">#</a>

--- a/java/docs/api/class-locator.mdx
+++ b/java/docs/api/class-locator.mdx
@@ -1323,7 +1323,7 @@ boolean hidden = page.getByRole(AriaRole.BUTTON).isHidden();
 - `options` `Locator.IsHiddenOptions` *(optional)*
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -1349,7 +1349,7 @@ boolean visible = page.getByRole(AriaRole.BUTTON).isVisible();
 - `options` `Locator.IsVisibleOptions` *(optional)*
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Locator.isVisible()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -2000,7 +2000,7 @@ orderSent.waitFor();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.elementHandle</x-search>
 
-:::caution
+:::caution Discouraged
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 
@@ -2031,7 +2031,7 @@ Locator.elementHandle(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.elementHandles</x-search>
 
-:::caution
+:::caution Discouraged
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 

--- a/java/docs/api/class-page.mdx
+++ b/java/docs/api/class-page.mdx
@@ -2810,7 +2810,7 @@ Page.onWorker(handler)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.check</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -2870,7 +2870,7 @@ Page.check(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.click</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -2940,7 +2940,7 @@ Page.click(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dblclick</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -3011,7 +3011,7 @@ Page.dblclick(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dispatchEvent</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.dispatchEvent()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -3071,7 +3071,7 @@ page.dispatchEvent("#source", "dragstart", arg);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.evalOnSelector</x-search>
 
-:::caution
+:::caution Discouraged
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [Locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -3114,7 +3114,7 @@ String html = (String) page.evalOnSelector(".main-container", "(e, suffix) => e.
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.evalOnSelectorAll</x-search>
 
-:::caution
+:::caution Discouraged
 
 In most cases, [Locator.evaluateAll()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -3151,7 +3151,7 @@ boolean divCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.fill</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -3198,7 +3198,7 @@ Page.fill(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.focus</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -3232,7 +3232,7 @@ Page.focus(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.getAttribute</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.getAttribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -3272,7 +3272,7 @@ Page.getAttribute(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.hover</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -3333,7 +3333,7 @@ Page.hover(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerHTML</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.innerHTML()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -3370,7 +3370,7 @@ Page.innerHTML(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerText</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.innerText()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -3407,7 +3407,7 @@ Page.innerText(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>page.inputValue</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.inputValue()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -3446,7 +3446,7 @@ Page.inputValue(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isChecked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.isChecked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -3483,7 +3483,7 @@ Page.isChecked(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isDisabled</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.isDisabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3520,7 +3520,7 @@ Page.isDisabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEditable</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.isEditable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -3557,7 +3557,7 @@ Page.isEditable(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEnabled</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.isEnabled()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3594,7 +3594,7 @@ Page.isEnabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isHidden</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -3620,7 +3620,7 @@ Page.isHidden(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Page.isHidden()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -3634,7 +3634,7 @@ Page.isHidden(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isVisible</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.isVisible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -3660,7 +3660,7 @@ Page.isVisible(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [Page.isVisible()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -3674,7 +3674,7 @@ Page.isVisible(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.press</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -3735,7 +3735,7 @@ page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("O.png" )));
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.querySelector</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -3769,7 +3769,7 @@ Page.querySelector(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.querySelectorAll</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -3798,7 +3798,7 @@ Page.querySelectorAll(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.selectOption</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.selectOption()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -3863,7 +3863,7 @@ page.selectOption("select#colors", new String[] {"red", "green", "blue"});
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>page.setChecked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.setChecked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -3927,7 +3927,7 @@ Page.setChecked(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setInputFiles</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.setInputFiles()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -3976,7 +3976,7 @@ Page.setInputFiles(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.tap</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -4041,7 +4041,7 @@ Page.tap(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.textContent</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.textContent()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -4078,7 +4078,7 @@ Page.textContent(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.type</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.type()](/api/class-locator.mdx#locator-type) instead. Read more about [locators](../locators.mdx).
 
@@ -4125,7 +4125,7 @@ page.type("#mytextarea", "World", new Page.TypeOptions().setDelay(100));
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.uncheck</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [Locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -4185,7 +4185,7 @@ Page.uncheck(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForNavigation</x-search>
 
-:::caution
+:::caution Deprecated
 
 This method is inherently racy, please use [Page.waitForURL()](/api/class-page.mdx#page-wait-for-url) instead.
 

--- a/java/docs/api/class-page.mdx
+++ b/java/docs/api/class-page.mdx
@@ -3619,6 +3619,11 @@ Page.isHidden(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Page.isHidden()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
+    :::
+    
 
 **Returns**
 - [boolean]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-return"/><a href="#page-is-hidden-return" class="list-anchor">#</a>
@@ -3654,6 +3659,11 @@ Page.isVisible(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [Page.isVisible()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
+    :::
+    
 
 **Returns**
 - [boolean]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-return"/><a href="#page-is-visible-return" class="list-anchor">#</a>

--- a/nodejs/docs/api/class-accessibility.mdx
+++ b/nodejs/docs/api/class-accessibility.mdx
@@ -24,7 +24,7 @@ Most of the accessibility tree gets filtered out when converting from internal b
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>accessibility.snapshot</x-search>
 
-:::caution
+:::caution Deprecated
 
 This method is deprecated. Please use other libraries such as [Axe](https://www.deque.com/axe/) if you need to test page accessibility. See our Node.js [guide](https://playwright.dev/docs/accessibility-testing) for integration with Axe.
 

--- a/nodejs/docs/api/class-androiddevice.mdx
+++ b/nodejs/docs/api/class-androiddevice.mdx
@@ -329,7 +329,7 @@ await androidDevice.launchBrowser(options);
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="android-device-launch-browser-option-video-size"/><a href="#android-device-launch-browser-option-video-size" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     Use `recordVideo` instead.
     :::
     
@@ -341,7 +341,7 @@ await androidDevice.launchBrowser(options);
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="android-device-launch-browser-option-videos-path"/><a href="#android-device-launch-browser-option-videos-path" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     Use `recordVideo` instead.
     :::
     

--- a/nodejs/docs/api/class-androiddevice.mdx
+++ b/nodejs/docs/api/class-androiddevice.mdx
@@ -328,6 +328,11 @@ await androidDevice.launchBrowser(options);
     
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="android-device-launch-browser-option-video-size"/><a href="#android-device-launch-browser-option-video-size" class="list-anchor">#</a>
+    
+    :::caution
+    Use `recordVideo` instead.
+    :::
+    
     - `width` [number]
       
       Video frame width.
@@ -335,6 +340,11 @@ await androidDevice.launchBrowser(options);
       
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="android-device-launch-browser-option-videos-path"/><a href="#android-device-launch-browser-option-videos-path" class="list-anchor">#</a>
+    
+    :::caution
+    Use `recordVideo` instead.
+    :::
+    
   - `viewport` [null]|[Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="android-device-launch-browser-option-viewport"/><a href="#android-device-launch-browser-option-viewport" class="list-anchor">#</a>
     - `width` [number]
       

--- a/nodejs/docs/api/class-browser.mdx
+++ b/nodejs/docs/api/class-browser.mdx
@@ -342,6 +342,11 @@ If directly using this method to create [BrowserContext]s, it is best practice t
     
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-new-context-option-video-size"/><a href="#browser-new-context-option-video-size" class="list-anchor">#</a>
+    
+    :::caution
+    Use `recordVideo` instead.
+    :::
+    
     - `width` [number]
       
       Video frame width.
@@ -349,6 +354,11 @@ If directly using this method to create [BrowserContext]s, it is best practice t
       
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-new-context-option-videos-path"/><a href="#browser-new-context-option-videos-path" class="list-anchor">#</a>
+    
+    :::caution
+    Use `recordVideo` instead.
+    :::
+    
   - `viewport` [null]|[Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-new-context-option-viewport"/><a href="#browser-new-context-option-viewport" class="list-anchor">#</a>
     - `width` [number]
       
@@ -570,6 +580,11 @@ await browser.newPage(options);
     
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-new-page-option-video-size"/><a href="#browser-new-page-option-video-size" class="list-anchor">#</a>
+    
+    :::caution
+    Use `recordVideo` instead.
+    :::
+    
     - `width` [number]
       
       Video frame width.
@@ -577,6 +592,11 @@ await browser.newPage(options);
       
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-new-page-option-videos-path"/><a href="#browser-new-page-option-videos-path" class="list-anchor">#</a>
+    
+    :::caution
+    Use `recordVideo` instead.
+    :::
+    
   - `viewport` [null]|[Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-new-page-option-viewport"/><a href="#browser-new-page-option-viewport" class="list-anchor">#</a>
     - `width` [number]
       

--- a/nodejs/docs/api/class-browser.mdx
+++ b/nodejs/docs/api/class-browser.mdx
@@ -343,7 +343,7 @@ If directly using this method to create [BrowserContext]s, it is best practice t
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-new-context-option-video-size"/><a href="#browser-new-context-option-video-size" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     Use `recordVideo` instead.
     :::
     
@@ -355,7 +355,7 @@ If directly using this method to create [BrowserContext]s, it is best practice t
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-new-context-option-videos-path"/><a href="#browser-new-context-option-videos-path" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     Use `recordVideo` instead.
     :::
     
@@ -581,7 +581,7 @@ await browser.newPage(options);
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-new-page-option-video-size"/><a href="#browser-new-page-option-video-size" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     Use `recordVideo` instead.
     :::
     
@@ -593,7 +593,7 @@ await browser.newPage(options);
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-new-page-option-videos-path"/><a href="#browser-new-page-option-videos-path" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     Use `recordVideo` instead.
     :::
     

--- a/nodejs/docs/api/class-browsercontext.mdx
+++ b/nodejs/docs/api/class-browsercontext.mdx
@@ -1037,7 +1037,7 @@ browserContext.on('serviceworker', data => {});
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setHTTPCredentials</x-search>
 
-:::caution
+:::caution Deprecated
 
 Browsers may cache credentials after successful authentication. Create a new browser context instead.
 

--- a/nodejs/docs/api/class-browsertype.mdx
+++ b/nodejs/docs/api/class-browsertype.mdx
@@ -427,6 +427,11 @@ await browserType.launchPersistentContext(userDataDir, options);
     
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-video-size"/><a href="#browser-type-launch-persistent-context-option-video-size" class="list-anchor">#</a>
+    
+    :::caution
+    Use `recordVideo` instead.
+    :::
+    
     - `width` [number]
       
       Video frame width.
@@ -434,6 +439,11 @@ await browserType.launchPersistentContext(userDataDir, options);
       
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-videos-path"/><a href="#browser-type-launch-persistent-context-option-videos-path" class="list-anchor">#</a>
+    
+    :::caution
+    Use `recordVideo` instead.
+    :::
+    
   - `viewport` [null]|[Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-viewport"/><a href="#browser-type-launch-persistent-context-option-viewport" class="list-anchor">#</a>
     - `width` [number]
       

--- a/nodejs/docs/api/class-browsertype.mdx
+++ b/nodejs/docs/api/class-browsertype.mdx
@@ -428,7 +428,7 @@ await browserType.launchPersistentContext(userDataDir, options);
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-video-size"/><a href="#browser-type-launch-persistent-context-option-video-size" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     Use `recordVideo` instead.
     :::
     
@@ -440,7 +440,7 @@ await browserType.launchPersistentContext(userDataDir, options);
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-videos-path"/><a href="#browser-type-launch-persistent-context-option-videos-path" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     Use `recordVideo` instead.
     :::
     

--- a/nodejs/docs/api/class-frame.mdx
+++ b/nodejs/docs/api/class-frame.mdx
@@ -1995,6 +1995,11 @@ await frame.isHidden(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [frame.isHidden()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
+    :::
+    
 
 **Returns**
 - [Promise]<[boolean]><a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-return"/><a href="#frame-is-hidden-return" class="list-anchor">#</a>
@@ -2030,6 +2035,11 @@ await frame.isVisible(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [frame.isVisible()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
+    :::
+    
 
 **Returns**
 - [Promise]<[boolean]><a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-return"/><a href="#frame-is-visible-return" class="list-anchor">#</a>

--- a/nodejs/docs/api/class-frame.mdx
+++ b/nodejs/docs/api/class-frame.mdx
@@ -1146,7 +1146,7 @@ await frame.waitForURL('**/target.html');
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.$</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -1186,7 +1186,7 @@ await frame.$(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.$$</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -1221,7 +1221,7 @@ await frame.$$(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.$eval</x-search>
 
-:::caution
+:::caution Discouraged
 
 This method does not wait for the element to pass the actionability checks and therefore can lead to the flaky tests. Use [locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -1266,7 +1266,7 @@ const html = await frame.$eval('.main-container', (e, suffix) => e.outerHTML + s
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.$$eval</x-search>
 
-:::caution
+:::caution Discouraged
 
 In most cases, [locator.evaluateAll()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -1305,7 +1305,7 @@ const divsCounts = await frame.$$eval('div', (divs, min) => divs.length >= min, 
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.check</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -1365,7 +1365,7 @@ await frame.check(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.click</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -1435,7 +1435,7 @@ await frame.click(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dblclick</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -1506,7 +1506,7 @@ await frame.dblclick(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dispatchEvent</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.dispatchEvent()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -1564,7 +1564,7 @@ await frame.dispatchEvent('#source', 'dragstart', { dataTransfer });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.fill</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -1611,7 +1611,7 @@ await frame.fill(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.focus</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -1645,7 +1645,7 @@ await frame.focus(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.getAttribute</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.getAttribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -1685,7 +1685,7 @@ await frame.getAttribute(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.hover</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -1746,7 +1746,7 @@ await frame.hover(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerHTML</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.innerHTML()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -1783,7 +1783,7 @@ await frame.innerHTML(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerText</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.innerText()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -1820,7 +1820,7 @@ await frame.innerText(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>frame.inputValue</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.inputValue()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -1859,7 +1859,7 @@ await frame.inputValue(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isChecked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.isChecked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -1896,7 +1896,7 @@ await frame.isChecked(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isDisabled</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.isDisabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -1933,7 +1933,7 @@ await frame.isDisabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isEditable</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.isEditable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -1970,7 +1970,7 @@ await frame.isEditable(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isHidden</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -1996,7 +1996,7 @@ await frame.isHidden(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [frame.isHidden()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -2010,7 +2010,7 @@ await frame.isHidden(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isVisible</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.isVisible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -2036,7 +2036,7 @@ await frame.isVisible(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [frame.isVisible()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -2050,7 +2050,7 @@ await frame.isVisible(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.press</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -2103,7 +2103,7 @@ await frame.press(selector, key, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.selectOption</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.selectOption()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -2170,7 +2170,7 @@ frame.selectOption('select#colors', 'red', 'green', 'blue');
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>frame.setChecked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.setChecked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -2234,7 +2234,7 @@ await frame.setChecked(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.setInputFiles</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.setInputFiles()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -2283,7 +2283,7 @@ await frame.setInputFiles(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.tap</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -2348,7 +2348,7 @@ await frame.tap(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.textContent</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.textContent()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -2385,7 +2385,7 @@ await frame.textContent(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.type</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.type()](/api/class-locator.mdx#locator-type) instead. Read more about [locators](../locators.mdx).
 
@@ -2430,7 +2430,7 @@ await frame.type('#mytextarea', 'World', {delay: 100}); // Types slower, like a 
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.uncheck</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 

--- a/nodejs/docs/api/class-locator.mdx
+++ b/nodejs/docs/api/class-locator.mdx
@@ -1322,6 +1322,11 @@ const hidden = await page.getByRole('button').isHidden();
 **Arguments**
 - `options` [Object] *(optional)*
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
+    :::
+    
 
 **Returns**
 - [Promise]<[boolean]><a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-return"/><a href="#locator-is-hidden-return" class="list-anchor">#</a>
@@ -1343,6 +1348,11 @@ const visible = await page.getByRole('button').isVisible();
 **Arguments**
 - `options` [Object] *(optional)*
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [locator.isVisible()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
+    :::
+    
 
 **Returns**
 - [Promise]<[boolean]><a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-return"/><a href="#locator-is-visible-return" class="list-anchor">#</a>

--- a/nodejs/docs/api/class-locator.mdx
+++ b/nodejs/docs/api/class-locator.mdx
@@ -1323,7 +1323,7 @@ const hidden = await page.getByRole('button').isHidden();
 - `options` [Object] *(optional)*
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -1349,7 +1349,7 @@ const visible = await page.getByRole('button').isVisible();
 - `options` [Object] *(optional)*
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [locator.isVisible()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -2003,7 +2003,7 @@ await orderSent.waitFor();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.elementHandle</x-search>
 
-:::caution
+:::caution Discouraged
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 
@@ -2034,7 +2034,7 @@ await locator.elementHandle(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.elementHandles</x-search>
 
-:::caution
+:::caution Discouraged
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 

--- a/nodejs/docs/api/class-page.mdx
+++ b/nodejs/docs/api/class-page.mdx
@@ -3440,6 +3440,11 @@ await page.isHidden(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [page.isHidden()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
+    :::
+    
 
 **Returns**
 - [Promise]<[boolean]><a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-return"/><a href="#page-is-hidden-return" class="list-anchor">#</a>
@@ -3475,6 +3480,11 @@ await page.isVisible(selector, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
+    
+    :::caution
+    This option is ignored. [page.isVisible()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
+    :::
+    
 
 **Returns**
 - [Promise]<[boolean]><a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-return"/><a href="#page-is-visible-return" class="list-anchor">#</a>

--- a/nodejs/docs/api/class-page.mdx
+++ b/nodejs/docs/api/class-page.mdx
@@ -2546,7 +2546,7 @@ page.on('worker', data => {});
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.$</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2580,7 +2580,7 @@ await page.$(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.$$</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2609,7 +2609,7 @@ await page.$$(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.$eval</x-search>
 
-:::caution
+:::caution Discouraged
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -2654,7 +2654,7 @@ const preloadHrefTS = await page.$eval('link[rel=preload]', (el: HTMLLinkElement
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.$$eval</x-search>
 
-:::caution
+:::caution Discouraged
 
 In most cases, [locator.evaluateAll()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -2691,7 +2691,7 @@ const divCounts = await page.$$eval('div', (divs, min) => divs.length >= min, 10
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.accessibility</x-search>
 
-:::caution
+:::caution Deprecated
 
 This property is discouraged. Please use other libraries such as [Axe](https://www.deque.com/axe/) if you need to test page accessibility. See our Node.js [guide](https://playwright.dev/docs/accessibility-testing) for integration with Axe.
 
@@ -2713,7 +2713,7 @@ page.accessibility
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.check</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -2773,7 +2773,7 @@ await page.check(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.click</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -2843,7 +2843,7 @@ await page.click(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dblclick</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -2914,7 +2914,7 @@ await page.dblclick(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dispatchEvent</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.dispatchEvent()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -2972,7 +2972,7 @@ await page.dispatchEvent('#source', 'dragstart', { dataTransfer });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.fill</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -3019,7 +3019,7 @@ await page.fill(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.focus</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -3053,7 +3053,7 @@ await page.focus(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.getAttribute</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.getAttribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -3093,7 +3093,7 @@ await page.getAttribute(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.hover</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -3154,7 +3154,7 @@ await page.hover(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerHTML</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.innerHTML()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -3191,7 +3191,7 @@ await page.innerHTML(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerText</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.innerText()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -3228,7 +3228,7 @@ await page.innerText(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>page.inputValue</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.inputValue()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -3267,7 +3267,7 @@ await page.inputValue(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isChecked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.isChecked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -3304,7 +3304,7 @@ await page.isChecked(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isDisabled</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.isDisabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3341,7 +3341,7 @@ await page.isDisabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEditable</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.isEditable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -3378,7 +3378,7 @@ await page.isEditable(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEnabled</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.isEnabled()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3415,7 +3415,7 @@ await page.isEnabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isHidden</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -3441,7 +3441,7 @@ await page.isHidden(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [page.isHidden()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -3455,7 +3455,7 @@ await page.isHidden(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isVisible</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.isVisible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -3481,7 +3481,7 @@ await page.isVisible(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution
+    :::caution Deprecated
     This option is ignored. [page.isVisible()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -3495,7 +3495,7 @@ await page.isVisible(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.press</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -3557,7 +3557,7 @@ await browser.close();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.selectOption</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.selectOption()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -3625,7 +3625,7 @@ page.selectOption('select#colors', ['red', 'green', 'blue']);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>page.setChecked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.setChecked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -3689,7 +3689,7 @@ await page.setChecked(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setInputFiles</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.setInputFiles()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -3738,7 +3738,7 @@ await page.setInputFiles(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.tap</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -3803,7 +3803,7 @@ await page.tap(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.textContent</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.textContent()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -3840,7 +3840,7 @@ await page.textContent(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.type</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.type()](/api/class-locator.mdx#locator-type) instead. Read more about [locators](../locators.mdx).
 
@@ -3885,7 +3885,7 @@ await page.type('#mytextarea', 'World', {delay: 100}); // Types slower, like a u
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.uncheck</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -3945,7 +3945,7 @@ await page.uncheck(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForNavigation</x-search>
 
-:::caution
+:::caution Deprecated
 
 This method is inherently racy, please use [page.waitForURL()](/api/class-page.mdx#page-wait-for-url) instead.
 

--- a/nodejs/docs/api/class-test.mdx
+++ b/nodejs/docs/api/class-test.mdx
@@ -2123,7 +2123,7 @@ test('example', async ({ page }) => {
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.10</font><x-search>test.test.describe.parallel</x-search>
 
-:::caution
+:::caution Discouraged
 
 See [test.describe.configure()](/api/class-test.mdx#test-describe-configure) for the preferred way of configuring the execution mode.
 
@@ -2180,7 +2180,7 @@ Note that parallel tests are executed in separate processes and cannot share any
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.10</font><x-search>test.test.describe.parallel.only</x-search>
 
-:::caution
+:::caution Discouraged
 
 See [test.describe.configure()](/api/class-test.mdx#test-describe-configure) for the preferred way of configuring the execution mode.
 
@@ -2235,7 +2235,7 @@ test.describe.parallel.only('group', () => {
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.10</font><x-search>test.test.describe.serial</x-search>
 
-:::caution
+:::caution Discouraged
 
 See [test.describe.configure()](/api/class-test.mdx#test-describe-configure) for the preferred way of configuring the execution mode.
 
@@ -2294,7 +2294,7 @@ test.describe.serial('group', () => {
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.10</font><x-search>test.test.describe.serial.only</x-search>
 
-:::caution
+:::caution Discouraged
 
 See [test.describe.configure()](/api/class-test.mdx#test-describe-configure) for the preferred way of configuring the execution mode.
 

--- a/nodejs/docs/api/class-testconfig.mdx
+++ b/nodejs/docs/api/class-testconfig.mdx
@@ -2045,7 +2045,7 @@ module.exports = config;
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.10</font><x-search>testConfig.snapshotDir</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use [testConfig.snapshotPathTemplate](/api/class-testconfig.mdx#test-config-snapshot-path-template) to configure snapshot paths.
 

--- a/python/docs/api/class-accessibility.mdx
+++ b/python/docs/api/class-accessibility.mdx
@@ -24,7 +24,7 @@ Most of the accessibility tree gets filtered out when converting from internal b
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>accessibility.snapshot</x-search>
 
-:::caution
+:::caution Deprecated
 
 This method is deprecated. Please use other libraries such as [Axe](https://www.deque.com/axe/) if you need to test page accessibility. See our Node.js [guide](https://playwright.dev/docs/accessibility-testing) for integration with Axe.
 

--- a/python/docs/api/class-frame.mdx
+++ b/python/docs/api/class-frame.mdx
@@ -1646,7 +1646,7 @@ await frame.wait_for_url("**/target.html")
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.check</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -1705,7 +1705,7 @@ frame.check(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.click</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -1774,7 +1774,7 @@ frame.click(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dblclick</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -1844,7 +1844,7 @@ frame.dblclick(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dispatch_event</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.dispatch_event()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -1943,7 +1943,7 @@ await frame.dispatch_event("#source", "dragstart", { "dataTransfer": data_transf
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.eval_on_selector</x-search>
 
-:::caution
+:::caution Discouraged
 
 This method does not wait for the element to pass the actionability checks and therefore can lead to the flaky tests. Use [locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -2009,7 +2009,7 @@ html = await frame.eval_on_selector(".main-container", "(e, suffix) => e.outerHT
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.eval_on_selector_all</x-search>
 
-:::caution
+:::caution Discouraged
 
 In most cases, [locator.evaluate_all()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -2068,7 +2068,7 @@ divs_counts = await frame.eval_on_selector_all("div", "(divs, min) => divs.lengt
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.fill</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -2114,7 +2114,7 @@ frame.fill(selector, value, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.focus</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -2147,7 +2147,7 @@ frame.focus(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.get_attribute</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.get_attribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -2186,7 +2186,7 @@ frame.get_attribute(selector, name, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.hover</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -2246,7 +2246,7 @@ frame.hover(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.inner_html</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.inner_html()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -2282,7 +2282,7 @@ frame.inner_html(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.inner_text</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.inner_text()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -2318,7 +2318,7 @@ frame.inner_text(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>frame.input_value</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.input_value()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -2356,7 +2356,7 @@ frame.input_value(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_checked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.is_checked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -2392,7 +2392,7 @@ frame.is_checked(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_disabled</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.is_disabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -2428,7 +2428,7 @@ frame.is_disabled(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_editable</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.is_editable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -2464,7 +2464,7 @@ frame.is_editable(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_hidden</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.is_hidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -2489,7 +2489,7 @@ frame.is_hidden(selector, **kwargs)
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
   
-  :::caution
+  :::caution Deprecated
   This option is ignored. [frame.is_hidden()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
   :::
   
@@ -2503,7 +2503,7 @@ frame.is_hidden(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_visible</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.is_visible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -2528,7 +2528,7 @@ frame.is_visible(selector, **kwargs)
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
   
-  :::caution
+  :::caution Deprecated
   This option is ignored. [frame.is_visible()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
   :::
   
@@ -2542,7 +2542,7 @@ frame.is_visible(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.press</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -2594,7 +2594,7 @@ frame.press(selector, key, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.query_selector</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2633,7 +2633,7 @@ frame.query_selector(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.query_selector_all</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2668,7 +2668,7 @@ frame.query_selector_all(selector)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.select_option</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.select_option()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -2757,7 +2757,7 @@ await frame.select_option("select#colors", value=["red", "green", "blue"])
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>frame.set_checked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.set_checked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -2820,7 +2820,7 @@ frame.set_checked(selector, checked, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.set_input_files</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.set_input_files()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -2868,7 +2868,7 @@ frame.set_input_files(selector, files, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.tap</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -2932,7 +2932,7 @@ frame.tap(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.text_content</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.text_content()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -2968,7 +2968,7 @@ frame.text_content(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.type</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.type()](/api/class-locator.mdx#locator-type) instead. Read more about [locators](../locators.mdx).
 
@@ -3033,7 +3033,7 @@ await frame.type("#mytextarea", "world", delay=100) # types slower, like a user
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.uncheck</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 

--- a/python/docs/api/class-frame.mdx
+++ b/python/docs/api/class-frame.mdx
@@ -2488,6 +2488,11 @@ frame.is_hidden(selector, **kwargs)
   
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
+  
+  :::caution
+  This option is ignored. [frame.is_hidden()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
+  :::
+  
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-hidden-return"/><a href="#frame-is-hidden-return" class="list-anchor">#</a>
@@ -2522,6 +2527,11 @@ frame.is_visible(selector, **kwargs)
   
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
+  
+  :::caution
+  This option is ignored. [frame.is_visible()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
+  :::
+  
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="frame-is-visible-return"/><a href="#frame-is-visible-return" class="list-anchor">#</a>

--- a/python/docs/api/class-locator.mdx
+++ b/python/docs/api/class-locator.mdx
@@ -1943,6 +1943,11 @@ hidden = await page.get_by_role("button").is_hidden()
 
 **Arguments**
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
+  
+  :::caution
+  This option is ignored. [locator.is_hidden()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
+  :::
+  
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-return"/><a href="#locator-is-hidden-return" class="list-anchor">#</a>
@@ -1983,6 +1988,11 @@ visible = await page.get_by_role("button").is_visible()
 
 **Arguments**
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
+  
+  :::caution
+  This option is ignored. [locator.is_visible()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
+  :::
+  
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-return"/><a href="#locator-is-visible-return" class="list-anchor">#</a>

--- a/python/docs/api/class-locator.mdx
+++ b/python/docs/api/class-locator.mdx
@@ -1944,7 +1944,7 @@ hidden = await page.get_by_role("button").is_hidden()
 **Arguments**
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
   
-  :::caution
+  :::caution Deprecated
   This option is ignored. [locator.is_hidden()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
   :::
   
@@ -1989,7 +1989,7 @@ visible = await page.get_by_role("button").is_visible()
 **Arguments**
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
   
-  :::caution
+  :::caution Deprecated
   This option is ignored. [locator.is_visible()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
   :::
   
@@ -2891,7 +2891,7 @@ await order_sent.wait_for()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.element_handle</x-search>
 
-:::caution
+:::caution Discouraged
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 
@@ -2921,7 +2921,7 @@ locator.element_handle(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.element_handles</x-search>
 
-:::caution
+:::caution Discouraged
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 

--- a/python/docs/api/class-page.mdx
+++ b/python/docs/api/class-page.mdx
@@ -4701,6 +4701,11 @@ page.is_hidden(selector, **kwargs)
   
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
+  
+  :::caution
+  This option is ignored. [page.is_hidden()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
+  :::
+  
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-return"/><a href="#page-is-hidden-return" class="list-anchor">#</a>
@@ -4735,6 +4740,11 @@ page.is_visible(selector, **kwargs)
   
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
+  
+  :::caution
+  This option is ignored. [page.is_visible()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
+  :::
+  
 
 **Returns**
 - [bool]<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-return"/><a href="#page-is-visible-return" class="list-anchor">#</a>

--- a/python/docs/api/class-page.mdx
+++ b/python/docs/api/class-page.mdx
@@ -3734,7 +3734,7 @@ page.on("worker", handler)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.accessibility</x-search>
 
-:::caution
+:::caution Deprecated
 
 This property is discouraged. Please use other libraries such as [Axe](https://www.deque.com/axe/) if you need to test page accessibility. See our Node.js [guide](https://playwright.dev/docs/accessibility-testing) for integration with Axe.
 
@@ -3756,7 +3756,7 @@ page.accessibility
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.check</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -3815,7 +3815,7 @@ page.check(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.click</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -3884,7 +3884,7 @@ page.click(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dblclick</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -3954,7 +3954,7 @@ page.dblclick(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dispatch_event</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.dispatch_event()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -4053,7 +4053,7 @@ await page.dispatch_event("#source", "dragstart", { "dataTransfer": data_transfe
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.eval_on_selector</x-search>
 
-:::caution
+:::caution Discouraged
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -4117,7 +4117,7 @@ html = await page.eval_on_selector(".main-container", "(e, suffix) => e.outer_ht
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.eval_on_selector_all</x-search>
 
-:::caution
+:::caution Discouraged
 
 In most cases, [locator.evaluate_all()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -4174,7 +4174,7 @@ div_counts = await page.eval_on_selector_all("div", "(divs, min) => divs.length 
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.expect_navigation</x-search>
 
-:::caution
+:::caution Deprecated
 
 This method is inherently racy, please use [page.wait_for_url()](/api/class-page.mdx#page-wait-for-url) instead.
 
@@ -4245,7 +4245,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.fill</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -4291,7 +4291,7 @@ page.fill(selector, value, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.focus</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -4324,7 +4324,7 @@ page.focus(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.get_attribute</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.get_attribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -4363,7 +4363,7 @@ page.get_attribute(selector, name, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.hover</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -4423,7 +4423,7 @@ page.hover(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.inner_html</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.inner_html()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -4459,7 +4459,7 @@ page.inner_html(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.inner_text</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.inner_text()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -4495,7 +4495,7 @@ page.inner_text(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>page.input_value</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.input_value()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -4533,7 +4533,7 @@ page.input_value(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_checked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.is_checked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -4569,7 +4569,7 @@ page.is_checked(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_disabled</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.is_disabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -4605,7 +4605,7 @@ page.is_disabled(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_editable</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.is_editable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -4641,7 +4641,7 @@ page.is_editable(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_enabled</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.is_enabled()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -4677,7 +4677,7 @@ page.is_enabled(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_hidden</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.is_hidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -4702,7 +4702,7 @@ page.is_hidden(selector, **kwargs)
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
   
-  :::caution
+  :::caution Deprecated
   This option is ignored. [page.is_hidden()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
   :::
   
@@ -4716,7 +4716,7 @@ page.is_hidden(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_visible</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.is_visible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -4741,7 +4741,7 @@ page.is_visible(selector, **kwargs)
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabindex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
   
-  :::caution
+  :::caution Deprecated
   This option is ignored. [page.is_visible()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
   :::
   
@@ -4755,7 +4755,7 @@ page.is_visible(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.press</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -4844,7 +4844,7 @@ await browser.close()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.query_selector</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -4877,7 +4877,7 @@ page.query_selector(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.query_selector_all</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -4906,7 +4906,7 @@ page.query_selector_all(selector)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.select_option</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.select_option()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -4995,7 +4995,7 @@ await page.select_option("select#colors", value=["red", "green", "blue"])
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>page.set_checked</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.set_checked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -5058,7 +5058,7 @@ page.set_checked(selector, checked, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.set_input_files</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.set_input_files()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -5106,7 +5106,7 @@ page.set_input_files(selector, files, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.tap</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -5170,7 +5170,7 @@ page.tap(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.text_content</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.text_content()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -5206,7 +5206,7 @@ page.text_content(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.type</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.type()](/api/class-locator.mdx#locator-type) instead. Read more about [locators](../locators.mdx).
 
@@ -5271,7 +5271,7 @@ await page.type("#mytextarea", "world", delay=100) # types slower, like a user
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.uncheck</x-search>
 
-:::caution
+:::caution Discouraged
 
 Use locator-based [locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -263,7 +263,7 @@ import HTMLCard from '@site/src/components/HTMLCard';
         if (member.deprecated) {
           sections.deprecation.push({
             type: 'text',
-            text: `:::caution
+            text: `:::caution Deprecated
 
 ${this.documentation.renderLinksInText(member.deprecated)}
 
@@ -275,7 +275,7 @@ ${this.documentation.renderLinksInText(member.deprecated)}
         if (member.discouraged) {
           sections.deprecation.push({
             type: 'text',
-            text: `:::caution
+            text: `:::caution Discouraged
 
 ${this.documentation.renderLinksInText(member.discouraged)}
 
@@ -501,7 +501,7 @@ import HTMLCard from '@site/src/components/HTMLCard';`);
     if (member.deprecated && direction === 'in') {
       children.push({
         type: 'text',
-        text: `:::caution
+        text: `:::caution Deprecated
 ${this.documentation.renderLinksInText(member.deprecated)}
 :::
 `
@@ -511,7 +511,7 @@ ${this.documentation.renderLinksInText(member.deprecated)}
     if (member.discouraged && direction === 'in') {
       children.push({
         type: 'text',
-        text: `:::caution
+        text: `:::caution Discouraged
 ${this.documentation.renderLinksInText(member.discouraged)}
 :::
 `

--- a/src/generator.js
+++ b/src/generator.js
@@ -497,6 +497,26 @@ import HTMLCard from '@site/src/components/HTMLCard';`);
     const properties = type.deepProperties();
     /** @type {MarkdownNode[]} */
     let children = [];
+    // Generate deprecations.
+    if (member.deprecated && direction === 'in') {
+      children.push({
+        type: 'text',
+        text: `:::caution
+${this.documentation.renderLinksInText(member.deprecated)}
+:::
+`
+      });
+    }
+
+    if (member.discouraged && direction === 'in') {
+      children.push({
+        type: 'text',
+        text: `:::caution
+${this.documentation.renderLinksInText(member.discouraged)}
+:::
+`
+      });
+    }
     if (properties && properties.length) {
       children.push(...properties.map(p => {
         let alias = p.alias;


### PR DESCRIPTION
Looks now like that:

![image](https://user-images.githubusercontent.com/17984549/211858855-e059d03d-0ded-4874-a0da-d5a43cfcc55b.png)


Before we did not say anymore that `Page.isVisible.timeout` is deprecated, the red stuff is new.

Drive-by: Caution -> Deprecated / Discouraged.

Fixes https://github.com/microsoft/playwright/issues/20033