### PR TITLE
Add links for the “Powerful Tooling” items on the homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -109,7 +109,7 @@ const features = [
           <b><a href="docs/debug#playwright-inspector">Playwright inspector.</a></b> Inspect page, generate selectors, step through the test execution, see click points, explore execution logs.
         </p>
         <p>
-          <b><a href="https://trace.playwright.dev/">Trace Viewer.</a></b> Capture all the information to investigate the test failure. Playwright trace
+          <b><a href="docs/trace-viewer-intro">Trace Viewer.</a></b> Capture all the information to investigate the test failure. Playwright trace
           contains test execution screencast, live DOM snapshots, action explorer, test source, and many more.
         </p>
       </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -103,10 +103,10 @@ const features = [
     description: (
       <>
         <p>
-          <b><a href="/docs/codegen">Codegen.</a></b> Generate tests by recording your actions. Save them into any language.
+          <b><a href="docs/codegen">Codegen.</a></b> Generate tests by recording your actions. Save them into any language.
         </p>
         <p>
-          <b><a href="/docs/debug#playwright-inspector">Playwright inspector.</a></b> Inspect page, generate selectors, step through the test execution, see click points, explore execution logs.
+          <b><a href="docs/debug#playwright-inspector">Playwright inspector.</a></b> Inspect page, generate selectors, step through the test execution, see click points, explore execution logs.
         </p>
         <p>
           <b><a href="https://trace.playwright.dev/">Trace Viewer.</a></b> Capture all the information to investigate the test failure. Playwright trace

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -103,13 +103,13 @@ const features = [
     description: (
       <>
         <p>
-          <b>Codegen.</b> Generate tests by recording your actions. Save them into any language.
+          <b><a href="/docs/codegen">Codegen.</a></b> Generate tests by recording your actions. Save them into any language.
         </p>
         <p>
-          <b>Playwright inspector.</b> Inspect page, generate selectors, step through the test execution, see click points, explore execution logs.
+          <b><a href="/docs/debug#playwright-inspector">Playwright inspector.</a></b> Inspect page, generate selectors, step through the test execution, see click points, explore execution logs.
         </p>
         <p>
-          <b>Trace Viewer.</b> Capture all the information to investigate the test failure. Playwright trace
+          <b><a href="https://trace.playwright.dev/">Trace Viewer.</a></b> Capture all the information to investigate the test failure. Playwright trace
           contains test execution screencast, live DOM snapshots, action explorer, test source, and many more.
         </p>
       </>


### PR DESCRIPTION
I believe this is the right repo to update the homepage.

I had a Playwright trace I wanted to open locally, and it took several clicks to get to https://trace.playwright.dev from the homepage. Now, clicking on “Trace Viewer” toward the bottom of the page will take you right to it. (I linked the other two to docs pages since they don’t appear to have dedicated websites, and I wanted all 3 to have a link)