### PR TITLE
fix: update broken Dockefile.jammy links

### DIFF
--- a/common/links-csharp.md
+++ b/common/links-csharp.md
@@ -17,4 +17,4 @@
 
 [all available image tags]: https://mcr.microsoft.com/en-us/product/playwright/dotnet/about "all available image tags"
 [Microsoft Artifact Registry]: https://mcr.microsoft.com/en-us/product/playwright/dotnet/about "Microsoft Artifact Registry"
-[Dockerfile.focal]: https://github.com/microsoft/playwright-dotnet/blob/main/utils/docker/Dockerfile.focal "Dockerfile.focal"
+[Dockerfile.jammy]: https://github.com/microsoft/playwright-dotnet/blob/main/utils/docker/Dockerfile.jammy "Dockerfile.jammy"

--- a/common/links-java.md
+++ b/common/links-java.md
@@ -18,4 +18,4 @@
 
 [all available image tags]: https://mcr.microsoft.com/en-us/product/playwright/java/about "all available image tags"
 [Microsoft Artifact Registry]: https://mcr.microsoft.com/en-us/product/playwright/java/about "Microsoft Artifact Registry"
-[Dockerfile.focal]: https://github.com/microsoft/playwright-java/blob/main/utils/docker/Dockerfile.focal "Dockerfile.focal"
+[Dockerfile.jammy]: https://github.com/microsoft/playwright-java/blob/main/utils/docker/Dockerfile.jammy "Dockerfile.jammy"

--- a/common/links-js.md
+++ b/common/links-js.md
@@ -19,4 +19,4 @@
 
 [all available image tags]: https://mcr.microsoft.com/en-us/product/playwright/about "all available image tags"
 [Microsoft Artifact Registry]: https://mcr.microsoft.com/en-us/product/playwright/about "Microsoft Artifact Registry"
-[Dockerfile.focal]: https://github.com/microsoft/playwright/blob/main/utils/docker/Dockerfile.focal "Dockerfile.focal"
+[Dockerfile.jammy]: https://github.com/microsoft/playwright/blob/main/utils/docker/Dockerfile.jammy "Dockerfile.jammy"

--- a/common/links-python.md
+++ b/common/links-python.md
@@ -18,4 +18,4 @@
 
 [all available image tags]: https://mcr.microsoft.com/en-us/product/playwright/python/about "all available image tags"
 [Microsoft Artifact Registry]: https://mcr.microsoft.com/en-us/product/playwright/python/about "Microsoft Artifact Registry"
-[Dockerfile.focal]: https://github.com/microsoft/playwright-python/blob/main/utils/docker/Dockerfile.focal "Dockerfile.focal"
+[Dockerfile.jammy]: https://github.com/microsoft/playwright-python/blob/main/utils/docker/Dockerfile.jammy "Dockerfile.jammy"


### PR DESCRIPTION
<!-- 
  Hey, thank you for your contribution!
  The actual source of the file which you are probably editing lives in this repository
  https://github.com/microsoft/playwright/blob/main/docs
  Thank you for doing the Pull Request there!
-->
fix #1055

Probably this requires changing `common/links-*.md` files that I cannot find the main `microsoft/playwright` repository. Let me know if I can fix it on the main repository. Thanks.