### PR TITLE
devops: bump Node.js versions

### DIFF
--- a/.github/workflows/azure-static-web-apps-delightful-forest-0a29f6210.yml
+++ b/.github/workflows/azure-static-web-apps-delightful-forest-0a29f6210.yml
@@ -33,8 +33,6 @@ jobs:
           output_location: "/build" # Built app content directory - optional
           build_timeout_in_minutes: 120
           ###### End of Repository/Build Configurations ######
-        env:
-          CUSTOM_BUILD_COMMAND: "npm i -g npm@8 && npm ci && npm run build"
 
   close_pull_request_job:
     # Only when Pull Requests gets closed which are no forks 
@@ -56,8 +54,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: '16'
-    - run: npm i -g npm@8
+        node-version: '18'
     - name: Install dependencies
       run: npm ci
     - name: Build site

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -26,8 +26,7 @@ jobs:
           ref: 'release-${{ github.event.inputs.version }}'
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
-      - run: npm i -g npm@8
+          node-version: '18'
       - name: Install dependencies
         run: npm ci
       - name: Delete previous Stable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
-      - run: npm i -g npm@8
+          node-version: '18'
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v1

--- a/.github/workflows/roll.yml
+++ b/.github/workflows/roll.yml
@@ -16,8 +16,7 @@ jobs:
           path: playwright
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
-      - run: npm i -g npm@8
+          node-version: '18'
       - name: Install dependencies
         run: npm ci
       - name: Roll

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "postinstall": "npm run build-analytics-plugin",


### PR DESCRIPTION
We require Node.js 18 now since we use fetch during rolling. Let's upgrade it everywhere.