### PR TITLE
chore: use only stable versions for .NET latest version

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -62,7 +62,8 @@ async function getVersionForLanguageBinding(lang) {
     case 'csharp':
       const nugetResponse = await fetch('https://api.nuget.org/v3-flatcontainer/microsoft.playwright/index.json');
       const nugetData = await nugetResponse.json();
-      return nugetData.versions.pop();
+      const stableVersions = nugetData.versions.filter(version => !version.includes('-'));
+      return stableVersions.pop();
 
     default:
       throw new Error(`Unknown language binding ${lang}`);


### PR DESCRIPTION
This prevents https://github.com/microsoft/playwright.dev/pull/1092/files#diff-97dbf4cf97d3d5b41bd6897743930f75536805c5cca49f3730eeb4e0c6296df8 from happening again.