### PR TITLE
docs: add PlaywrightAssertions to the API sidebar

### DIFF
--- a/java/sidebars.js
+++ b/java/sidebars.js
@@ -117,7 +117,8 @@ module.exports = {
           items: [
             { type: 'doc', id: 'api/class-apiresponseassertions' },
             { type: 'doc', id: 'api/class-locatorassertions' },
-            { type: 'doc', id: 'api/class-pageassertions' }
+            { type: 'doc', id: 'api/class-pageassertions' },
+            { type: 'doc', id: 'api/class-playwrightassertions' }
           ],
           collapsed: false
         }


### PR DESCRIPTION
Adding the class to the API sidebar, otherwise [setDefaultAssertionTimeout()](https://playwright.dev/java/docs/api/class-playwrightassertions#playwright-assertions-set-default-assertion-timeout) is only accessible through search.

Reference https://github.com/microsoft/playwright-java/issues/1395