### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -46,9 +46,9 @@ jobs:
           HAS_CHANGES="$?"
           set -e
           GIT_COMMIT="$(cd playwright && git rev-parse HEAD && cd ..)"
-          echo "::set-output name=HAS_CHANGES::$HAS_CHANGES"
-          echo "::set-output name=BRANCH_NAME::$BRANCH_NAME"
-          echo "::set-output name=GIT_COMMIT::$GIT_COMMIT"
+          echo "HAS_CHANGES=$HAS_CHANGES" >> $GITHUB_OUTPUT
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "GIT_COMMIT=$GIT_COMMIT" >> $GITHUB_OUTPUT
           if [[ $HAS_CHANGES == 0 ]]; then
             echo "No changes detected, skipping PR"
             exit 0

--- a/.github/workflows/roll.yml
+++ b/.github/workflows/roll.yml
@@ -32,9 +32,9 @@ jobs:
           HAS_CHANGES="$?"
           set -e
           GIT_COMMIT="$(cd playwright && git rev-parse HEAD && cd ..)"
-          echo "::set-output name=HAS_CHANGES::$HAS_CHANGES"
-          echo "::set-output name=BRANCH_NAME::$BRANCH_NAME"
-          echo "::set-output name=GIT_COMMIT::$GIT_COMMIT"
+          echo "HAS_CHANGES=$HAS_CHANGES" >> $GITHUB_OUTPUT
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "GIT_COMMIT=$GIT_COMMIT" >> $GITHUB_OUTPUT
           if [[ $HAS_CHANGES == 0 ]]; then
             echo "No changes detected, skipping PR"
             exit 0


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


