### PR TITLE
fix: docs roll after csharp LocatorHandlerAsync type changes

### DIFF
--- a/nodejs/docs/api/class-test.mdx
+++ b/nodejs/docs/api/class-test.mdx
@@ -1316,7 +1316,7 @@ test('test', async ({ page }) => {
 - `title` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-step-option-title"/><a href="#test-step-option-title" class="list-anchor">#</a>
   
   Step name.
-- `body` [function]\([]\):[Promise]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-step-option-body"/><a href="#test-step-option-body" class="list-anchor">#</a>
+- `body` [function]\(\):[Promise]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-step-option-body"/><a href="#test-step-option-body" class="list-anchor">#</a>
   
   Step body.
 - `options` [Object] *(optional)*

--- a/nodejs/docs/ci-intro.mdx
+++ b/nodejs/docs/ci-intro.mdx
@@ -10,7 +10,7 @@ import HTMLCard from '@site/src/components/HTMLCard';
 
 Playwright tests can be run on any CI provider. In this section we will cover running tests on GitHub using GitHub actions. If you would like to see how to configure other CI providers check out our detailed [doc on Continuous Integration](./ci.mdx).
 
-When [installing Playwright](./intro.mdx) using the [VS Code extension](./getting-started-vscode.mdx) or with `npm init playwright@latest` you are given the option to add a [GitHub Actions](https://docs.github.com/en/actions). This creates a `playwright.yml` file inside a `.github/workflows` folder containing everything you need so that your tests run on each push and pull request into the main/master branch.
+When [installing Playwright](./intro.mdx) using the [VS Code extension](./getting-started-vscode.mdx) or with `npm init playwright@latest` you are given the option to add a [GitHub Actions](https://docs.github.com/en/actions) workflow. This creates a `playwright.yml` file inside a `.github/workflows` folder containing everything you need so that your tests run on each push and pull request into the main/master branch.
 
 #### You will learn
 - [How to run tests on push/pull_request](/ci-intro.mdx#on-pushpull_request)

--- a/nodejs/docs/release-notes.mdx
+++ b/nodejs/docs/release-notes.mdx
@@ -9,6 +9,84 @@ import HTMLCard from '@site/src/components/HTMLCard';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 
+## Version 1.42
+
+### New APIs
+- New method [page.addLocatorHandler()](/api/class-page.mdx#page-add-locator-handler) registers a callback that will be invoked when specified element becomes visible and may block Playwright actions. The callback can get rid of the overlay. Here is an example that closes a cookie dialog when it appears:
+
+```js
+// Setup the handler.
+await page.addLocatorHandler(page.getByRole('button', { name: 'Accept all cookies' }), async () => {
+  await page.getByRole('button', { name: 'Reject all cookies' }).click();
+});
+
+// Write the test as usual.
+await page.goto('https://example.com');
+await page.getByRole('button', { name: 'Start here' }).click();
+```
+
+- `expect(callback).toPass()` timeout can now be configured by `expect.toPass.timeout` option [globally](./api/class-testconfig#test-config-expect) or in [project config](./api/class-testproject#test-project-expect)
+- [electronApplication.on('console')](/api/class-electronapplication.mdx#electron-application-event-console) event is emitted when Electron main process calls console API methods.
+
+```js
+electronApp.on('console', async msg => {
+  const values = [];
+  for (const arg of msg.args())
+    values.push(await arg.jsonValue());
+  console.log(...values);
+});
+await electronApp.evaluate(() => console.log('hello', 5, { foo: 'bar' }));
+```
+
+- [New syntax](./test-annotations#tag-tests) for adding tags to the tests (@-tokens in the test title are still supported):
+
+```js
+test('test customer login', {
+  tag: ['@fast', '@login'],
+}, async ({ page }) => {
+  // ...
+});
+```
+
+Use `--grep` command line option to run only tests with certain tags.
+
+```sh
+npx playwright test --grep @fast
+```
+
+- `--project` command line [flag](./test-cli#reference) now supports '*' wildcard:
+
+```sh
+npx playwright test --project='*mobile*'
+```
+
+- [New syntax](./test-annotations#annotate-tests) for test annotations:
+
+```js
+test('test full report', {
+  annotation: [
+    { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23180' },
+    { type: 'docs', description: 'https://playwright.dev/docs/test-annotations#tag-tests' },
+  ],
+}, async ({ page }) => {
+  // ...
+});
+```
+
+- [page.pdf()](/api/class-page.mdx#page-pdf) accepts two new options [`tagged`](./api/class-page#page-pdf-option-tagged) and [`outline`](./api/class-page#page-pdf-option-outline).
+
+### Announcements
+* ⚠️ Ubuntu 18 is not supported anymore.
+
+### Browser Versions
+* Chromium 123.0.6312.4
+* Mozilla Firefox 123.0
+* WebKit 17.4
+
+This version was also tested against the following stable channels:
+* Google Chrome 122
+* Microsoft Edge 123
+
 ## Version 1.41
 
 ### New APIs

--- a/nodejs/docs/service-workers-experimental-network-events.mdx
+++ b/nodejs/docs/service-workers-experimental-network-events.mdx
@@ -133,10 +133,12 @@ self.addEventListener('fetch', event => {
       (async () => {
         // 1. Try to first serve directly from caches
         const response = await caches.match(event.request);
-        if (response) return response;
+        if (response)
+          return response;
 
         // 2. Re-write request for /foo to /bar
-        if (event.request.url.endsWith('foo')) return fetch('./bar');
+        if (event.request.url.endsWith('foo'))
+          return fetch('./bar');
 
         // 3. Prevent tracker.js from being retrieved, and returns a placeholder response
         if (event.request.url.endsWith('tracker.js')) {

--- a/nodejs/docs/test-typescript.mdx
+++ b/nodejs/docs/test-typescript.mdx
@@ -8,7 +8,27 @@ import HTMLCard from '@site/src/components/HTMLCard';
 
 ## Introduction
 
-Playwright supports TypeScript out of the box. You just write tests in TypeScript, and Playwright will read them, transform to JavaScript and run.
+Playwright supports TypeScript out of the box. You just write tests in TypeScript, and Playwright will read them, transform to JavaScript and run. Note that Playwright does not check the types and will run tests even if there are non-critical TypeScript compilation errors.
+
+We recommend you run TypeScript compiler alongside Playwright. For example on GitHub actions:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    ...
+    - name: Run type checks
+      run: npx tsc -p tsconfig.json --noEmit
+    - name: Run Playwright tests
+      run: npx playwright test
+```
+
+For local development, you can run `tsc` in [watch](https://www.typescriptlang.org/docs/handbook/configuring-watch.html) mode like this:
+
+```sh
+npx tsc -p tsconfig.json --noEmit -w
+```
 
 ## tsconfig.json
 

--- a/src/documentation.js
+++ b/src/documentation.js
@@ -566,7 +566,7 @@ class Type {
       return type;
     }
 
-    if (parsedType.args) {
+    if (parsedType.args || parsedType.retType) {
       const type = new Type('function');
       type.args = [];
       // @ts-ignore
@@ -737,7 +737,8 @@ function parseTypeExpression(type) {
     if (type[i] === '(') {
       name = type.substring(0, i);
       const matching = matchingBracket(type.substring(i), '(', ')');
-      args = parseTypeExpression(type.substring(i + 1, i + matching - 1));
+      const argsString = type.substring(i + 1, i + matching - 1);
+      args = argsString ? parseTypeExpression(argsString) : null;
       i = i + matching;
       if (type[i] === ':') {
         retType = parseTypeExpression(type.substring(i + 1));

--- a/src/format_csharp.js
+++ b/src/format_csharp.js
@@ -93,6 +93,8 @@ class CSharpFormatter {
   }
 
   formatFunction(args, ret, type) {
+    if (type.args.length === 0 && type.returnType.name === 'Promise')
+      return `[Func]<[Task]>`;
     if (type.args.length !== 1)
       throw new Error('Unsupported number of arguments in function: ' + type);
     if (!type.returnType)
@@ -132,7 +134,6 @@ class CSharpFormatter {
           case 'Page.exposeFunction.callback': return '[Action]<T, [TResult]>';
           case 'Page.waitForEvent.predicate': return '[Func]<T, [bool]>';
           case 'Page.waitForEvent2.predicate': return '[Func]<T, [bool]>';
-          case 'Page.addLocatorHandler.handler': return '[Func]<[Task]>';
         }
         throw new Error(`Unknwon C# type for "${fullName(member)}": "${text}"`);
       };


### PR DESCRIPTION
<!-- 
  Hey, thank you for your contribution!
  The actual source of the file which you are probably editing lives in this repository
  https://github.com/microsoft/playwright/blob/main/docs
  Thank you for doing the Pull Request there!
-->
