### PR TITLE
docs: Add "Learn Videos" section

### DIFF
--- a/dotnet/sidebarCommunity.js
+++ b/dotnet/sidebarCommunity.js
@@ -25,6 +25,11 @@ module.exports = {
           type: 'link',
           label: 'Feature Videos',
           href: '/community/feature-videos'
+        },
+        {
+          type: 'link',
+          label: 'Learn Videos',
+          href: '/community/learn-videos'
         }
       ],
       collapsed: false

--- a/java/sidebarCommunity.js
+++ b/java/sidebarCommunity.js
@@ -25,6 +25,11 @@ module.exports = {
           type: 'link',
           label: 'Feature Videos',
           href: '/community/feature-videos'
+        },
+        {
+          type: 'link',
+          label: 'Learn Videos',
+          href: '/community/learn-videos'
         }
       ],
       collapsed: false

--- a/nodejs/sidebarCommunity.js
+++ b/nodejs/sidebarCommunity.js
@@ -25,6 +25,11 @@ module.exports = {
           type: 'link',
           label: 'Feature Videos',
           href: '/community/feature-videos'
+        },
+        {
+          type: 'link',
+          label: 'Learn Videos',
+          href: '/community/learn-videos'
         }
       ],
       collapsed: false

--- a/python/sidebarCommunity.js
+++ b/python/sidebarCommunity.js
@@ -25,6 +25,11 @@ module.exports = {
           type: 'link',
           label: 'Feature Videos',
           href: '/community/feature-videos'
+        },
+        {
+          type: 'link',
+          label: 'Learn Videos',
+          href: '/community/learn-videos'
         }
       ],
       collapsed: false

--- a/src/data/learn-videos.tsx
+++ b/src/data/learn-videos.tsx
@@ -1,0 +1,34 @@
+const learnVideos = [
+  {
+    title: 'Introduction',
+    description: '',
+    id: '4-LwodVujTg',
+  },
+  {
+    title: 'Getting Started',
+    description: '',
+    id: 'JdMkZUePkSE',
+  },
+  {
+    title: 'Running Tests',
+    description: '',
+    id: 'DcVYaZ8QDsw',
+  },
+  {
+    title: 'Writing Tests',
+    description: '',
+    id: 'GKG9g_JGZPc',
+  },
+  {
+    title: 'Debugging Tests',
+    description: '',
+    id: 'oYCSzYG-Bbg',
+  },
+  {
+    title: 'Running Tests on CI',
+    description: '',
+    id: 'gRXPp6RuExU',
+  },
+];
+
+export default learnVideos;

--- a/src/data/video-nav.tsx
+++ b/src/data/video-nav.tsx
@@ -14,6 +14,10 @@ const videoNav = [
   {
     label: 'Feature Videos',
     href: '/community/feature-videos'
+  },
+  {
+    label: 'Learn Videos',
+    href: '/community/learn-videos'
   }
 ];
 

--- a/src/pages/community/learn-videos.tsx
+++ b/src/pages/community/learn-videos.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import Layout from '@theme/Layout';
+import VideoCards from '@site/src/components/VideoCards';
+import PageHeader from '@site/src/components/PageHeader';
+import Navigation from '@site/src/components/Navigation';
+
+import videoNav from '@site/src/data/video-nav';
+import learnVideos from '@site/src/data/learn-videos';
+
+const TITLE = 'Learn Videos';
+const DESCRIPTION = 'Check out the latest videos for learning Playwright';
+
+export default function Video(): JSX.Element {
+  return (
+    <Layout title={TITLE} description={DESCRIPTION}>
+      <main className="margin-vert--lg">
+        <PageHeader title={TITLE} description={DESCRIPTION} />
+        <Navigation links={videoNav} />
+        <VideoCards videos={learnVideos} />
+      </main>
+    </Layout>
+  );
+}
+


### PR DESCRIPTION
Add videos from VS Code course published late last year on a new section in videos called Learn Videos
