### PR TITLE
chore: migrate :::caution to :::warning

### DIFF
--- a/dotnet/docs/api/class-browsertype.mdx
+++ b/dotnet/docs/api/class-browsertype.mdx
@@ -174,7 +174,7 @@ var browser = await playwright.Chromium.LaunchAsync(new() {
     Enable Chromium sandboxing. Defaults to `false`.
   - `Devtools` [bool]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-devtools"/><a href="#browser-type-launch-option-devtools" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use [debugging tools](../debug.mdx) instead.
     :::
     
@@ -292,7 +292,7 @@ await BrowserType.LaunchPersistentContextAsync(userDataDir, options);
     Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about [emulating devices with device scale factor](../emulation.mdx#devices).
   - `Devtools` [bool]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-devtools"/><a href="#browser-type-launch-persistent-context-option-devtools" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use [debugging tools](../debug.mdx) instead.
     :::
     

--- a/dotnet/docs/api/class-elementhandle.mdx
+++ b/dotnet/docs/api/class-elementhandle.mdx
@@ -158,7 +158,7 @@ await ElementHandle.WaitForElementStateAsync(state, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.CheckAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.CheckAsync()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -215,7 +215,7 @@ await ElementHandle.CheckAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.ClickAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.ClickAsync()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -282,7 +282,7 @@ await ElementHandle.ClickAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.DblClickAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.DblClickAsync()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -350,7 +350,7 @@ await ElementHandle.DblClickAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.DispatchEventAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.DispatchEventAsync()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -406,7 +406,7 @@ await elementHandle.DispatchEventAsync("dragstart", new Dictionary<string, objec
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.EvalOnSelectorAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [Locator.EvaluateAsync()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -447,7 +447,7 @@ Assert.AreEqual("10", await tweetHandle.EvalOnSelectorAsync(".retweets", "node =
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.EvalOnSelectorAllAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [Locator.EvaluateAllAsync()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -494,7 +494,7 @@ Assert.AreEqual(new [] { "Hello!", "Hi!" }, await feedHandle.EvalOnSelectorAllAs
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.FillAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.FillAsync()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -537,7 +537,7 @@ await ElementHandle.FillAsync(value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.FocusAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.FocusAsync()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -561,7 +561,7 @@ await ElementHandle.FocusAsync();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.GetAttributeAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.GetAttributeAsync()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -590,7 +590,7 @@ await ElementHandle.GetAttributeAsync(name);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.HoverAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.HoverAsync()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -648,7 +648,7 @@ await ElementHandle.HoverAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.InnerHTMLAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.InnerHTMLAsync()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -672,7 +672,7 @@ await ElementHandle.InnerHTMLAsync();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.InnerTextAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.InnerTextAsync()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -696,7 +696,7 @@ await ElementHandle.InnerTextAsync();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>elementHandle.InputValueAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.InputValueAsync()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -728,7 +728,7 @@ await ElementHandle.InputValueAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsCheckedAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsCheckedAsync()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -752,7 +752,7 @@ await ElementHandle.IsCheckedAsync();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsDisabledAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsDisabledAsync()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -776,7 +776,7 @@ await ElementHandle.IsDisabledAsync();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsEditableAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsEditableAsync()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -800,7 +800,7 @@ await ElementHandle.IsEditableAsync();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsEnabledAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsEnabledAsync()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -824,7 +824,7 @@ await ElementHandle.IsEnabledAsync();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsHiddenAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsHiddenAsync()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -848,7 +848,7 @@ await ElementHandle.IsHiddenAsync();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsVisibleAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsVisibleAsync()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -872,7 +872,7 @@ await ElementHandle.IsVisibleAsync();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.PressAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.PressAsync()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -923,7 +923,7 @@ await ElementHandle.PressAsync(key, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.QuerySelectorAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Page.Locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -952,7 +952,7 @@ await ElementHandle.QuerySelectorAsync(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.QuerySelectorAllAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Page.Locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -981,7 +981,7 @@ await ElementHandle.QuerySelectorAllAsync(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.ScreenshotAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.ScreenshotAsync()](/api/class-locator.mdx#locator-screenshot) instead. Read more about [locators](../locators.mdx).
 
@@ -1051,7 +1051,7 @@ await ElementHandle.ScreenshotAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.ScrollIntoViewIfNeededAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.ScrollIntoViewIfNeededAsync()](/api/class-locator.mdx#locator-scroll-into-view-if-needed) instead. Read more about [locators](../locators.mdx).
 
@@ -1083,7 +1083,7 @@ await ElementHandle.ScrollIntoViewIfNeededAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.SelectOptionAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.SelectOptionAsync()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -1147,7 +1147,7 @@ await handle.SelectOptionAsync(new[] {
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.SelectTextAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.SelectTextAsync()](/api/class-locator.mdx#locator-select-text) instead. Read more about [locators](../locators.mdx).
 
@@ -1182,7 +1182,7 @@ await ElementHandle.SelectTextAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>elementHandle.SetCheckedAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.SetCheckedAsync()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -1241,7 +1241,7 @@ await ElementHandle.SetCheckedAsync(checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.SetInputFilesAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.SetInputFilesAsync()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -1286,7 +1286,7 @@ await ElementHandle.SetInputFilesAsync(files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.TapAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.TapAsync()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -1348,7 +1348,7 @@ await ElementHandle.TapAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.TextContentAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.TextContentAsync()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -1409,7 +1409,7 @@ To press a special key, like `Control` or `ArrowDown`, use [ElementHandle.PressA
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.UncheckAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.UncheckAsync()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -1466,7 +1466,7 @@ await ElementHandle.UncheckAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.WaitForSelectorAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [Locator.WaitForAsync()](/api/class-locator.mdx#locator-wait-for) instead.
 

--- a/dotnet/docs/api/class-frame.mdx
+++ b/dotnet/docs/api/class-frame.mdx
@@ -1057,7 +1057,7 @@ await frame.WaitForURLAsync("**/target.html");
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.CheckAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.CheckAsync()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -1119,7 +1119,7 @@ await Frame.CheckAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.ClickAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.ClickAsync()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -1191,7 +1191,7 @@ await Frame.ClickAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.DblClickAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.DblClickAsync()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -1264,7 +1264,7 @@ await Frame.DblClickAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.DispatchEventAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.DispatchEventAsync()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -1328,7 +1328,7 @@ await frame.DispatchEventAsync("#source", "dragstart", new { dataTransfer });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.EvalOnSelectorAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass the actionability checks and therefore can lead to the flaky tests. Use [Locator.EvaluateAsync()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -1373,7 +1373,7 @@ var html = await frame.EvalOnSelectorAsync(".main-container", "(e, suffix) => e.
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.EvalOnSelectorAllAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [Locator.EvaluateAllAsync()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -1412,7 +1412,7 @@ var divsCount = await frame.EvalOnSelectorAllAsync<bool>("div", "(divs, min) => 
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.FillAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.FillAsync()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -1461,7 +1461,7 @@ await Frame.FillAsync(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.FocusAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.FocusAsync()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -1497,7 +1497,7 @@ await Frame.FocusAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.GetAttributeAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.GetAttributeAsync()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -1536,7 +1536,7 @@ await Frame.GetAttributeAsync(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.HoverAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.HoverAsync()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -1599,7 +1599,7 @@ await Frame.HoverAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.InnerHTMLAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.InnerHTMLAsync()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -1635,7 +1635,7 @@ await Frame.InnerHTMLAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.InnerTextAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.InnerTextAsync()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -1671,7 +1671,7 @@ await Frame.InnerTextAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>frame.InputValueAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.InputValueAsync()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -1709,7 +1709,7 @@ await Frame.InputValueAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsCheckedAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsCheckedAsync()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -1745,7 +1745,7 @@ await Frame.IsCheckedAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsDisabledAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsDisabledAsync()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -1781,7 +1781,7 @@ await Frame.IsDisabledAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsEditableAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsEditableAsync()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -1817,7 +1817,7 @@ await Frame.IsEditableAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsHiddenAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsHiddenAsync()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -1842,7 +1842,7 @@ await Frame.IsHiddenAsync(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [float]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Frame.IsHiddenAsync()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -1856,7 +1856,7 @@ await Frame.IsHiddenAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsVisibleAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsVisibleAsync()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -1881,7 +1881,7 @@ await Frame.IsVisibleAsync(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [float]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Frame.IsVisibleAsync()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -1895,7 +1895,7 @@ await Frame.IsVisibleAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.PressAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.PressAsync()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -1950,7 +1950,7 @@ await Frame.PressAsync(selector, key, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.QuerySelectorAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Frame.Locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -1989,7 +1989,7 @@ await Frame.QuerySelectorAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.QuerySelectorAllAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Frame.Locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2131,7 +2131,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.SelectOptionAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.SelectOptionAsync()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -2196,7 +2196,7 @@ await frame.SelectOptionAsync("select#colors", new[] { "red", "green", "blue" })
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>frame.SetCheckedAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.SetCheckedAsync()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -2262,7 +2262,7 @@ await Frame.SetCheckedAsync(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.SetInputFilesAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.SetInputFilesAsync()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -2313,7 +2313,7 @@ await Frame.SetInputFilesAsync(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.TapAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.TapAsync()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -2380,7 +2380,7 @@ await Frame.TapAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.TextContentAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.TextContentAsync()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -2459,7 +2459,7 @@ To press a special key, like `Control` or `ArrowDown`, use [Keyboard.PressAsync(
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.UncheckAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.UncheckAsync()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -2521,7 +2521,7 @@ await Frame.UncheckAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.WaitForSelectorAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [Locator.WaitForAsync()](/api/class-locator.mdx#locator-wait-for) instead. Read more about [locators](../locators.mdx).
 
@@ -2591,7 +2591,7 @@ class FrameExamples
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.WaitForTimeoutAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Never wait for timeout in production. Tests that wait for time are inherently flaky. Use [Locator] actions and web assertions that wait automatically.
 

--- a/dotnet/docs/api/class-locator.mdx
+++ b/dotnet/docs/api/class-locator.mdx
@@ -44,8 +44,8 @@ foreach (var li in await page.GetByRole("listitem").AllAsync())
 
 Returns an array of `node.innerText` values for all matching nodes.
 
-:::caution Asserting text
-If you need to assert text on the page, prefer [Expect(Locator).ToHaveTextAsync()](/api/class-locatorassertions.mdx#locator-assertions-to-have-text) with `useInnerText` option to avoid flakiness. See [assertions guide](../test-assertions.mdx) for more details.
+:::warning 1Asserting text
+If you need ato assert text on the page, prefer [Expect(Locator).ToHaveTextAsync()](/api/class-locatorassertions.mdx#locator-assertions-to-have-text) with `useInnerText` option to avoid flakiness. See [assertions guide](../test-assertions.mdx) for more details.
 :::
 
 **Usage**
@@ -1464,7 +1464,7 @@ Boolean hidden = await page.GetByRole(AriaRole.Button).IsHiddenAsync();
 - `options` `LocatorIsHiddenOptions?` *(optional)*
   - `Timeout` [float]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Locator.IsHiddenAsync()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -1494,7 +1494,7 @@ Boolean visible = await page.GetByRole(AriaRole.Button).IsVisibleAsync();
 - `options` `LocatorIsVisibleOptions?` *(optional)*
   - `Timeout` [float]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Locator.IsVisibleAsync()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -2208,7 +2208,7 @@ orderSent.WaitForAsync();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.ElementHandleAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 
@@ -2238,7 +2238,7 @@ await Locator.ElementHandleAsync(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.ElementHandlesAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 

--- a/dotnet/docs/api/class-page.mdx
+++ b/dotnet/docs/api/class-page.mdx
@@ -3088,7 +3088,7 @@ Page.Accessibility
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.CheckAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.CheckAsync()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -3150,7 +3150,7 @@ await Page.CheckAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.ClickAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.ClickAsync()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -3222,7 +3222,7 @@ await Page.ClickAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.DblClickAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.DblClickAsync()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -3295,7 +3295,7 @@ await Page.DblClickAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.DispatchEventAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.DispatchEventAsync()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -3358,7 +3358,7 @@ await page.DispatchEventAsync("#source", "dragstart", new { dataTransfer });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.EvalOnSelectorAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [Locator.EvaluateAsync()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -3401,7 +3401,7 @@ var html = await page.EvalOnSelectorAsync(".main-container", "(e, suffix) => e.o
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.EvalOnSelectorAllAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [Locator.EvaluateAllAsync()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -3438,7 +3438,7 @@ var divsCount = await page.EvalOnSelectorAllAsync<bool>("div", "(divs, min) => d
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.FillAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.FillAsync()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -3487,7 +3487,7 @@ await Page.FillAsync(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.FocusAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.FocusAsync()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -3523,7 +3523,7 @@ await Page.FocusAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.GetAttributeAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.GetAttributeAsync()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -3562,7 +3562,7 @@ await Page.GetAttributeAsync(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.HoverAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.HoverAsync()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -3625,7 +3625,7 @@ await Page.HoverAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.InnerHTMLAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.InnerHTMLAsync()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -3661,7 +3661,7 @@ await Page.InnerHTMLAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.InnerTextAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.InnerTextAsync()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -3697,7 +3697,7 @@ await Page.InnerTextAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>page.InputValueAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.InputValueAsync()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -3735,7 +3735,7 @@ await Page.InputValueAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsCheckedAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsCheckedAsync()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -3771,7 +3771,7 @@ await Page.IsCheckedAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsDisabledAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsDisabledAsync()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3807,7 +3807,7 @@ await Page.IsDisabledAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsEditableAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsEditableAsync()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -3843,7 +3843,7 @@ await Page.IsEditableAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsEnabledAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsEnabledAsync()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3879,7 +3879,7 @@ await Page.IsEnabledAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsHiddenAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsHiddenAsync()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -3904,7 +3904,7 @@ await Page.IsHiddenAsync(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [float]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Page.IsHiddenAsync()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -3918,7 +3918,7 @@ await Page.IsHiddenAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsVisibleAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.IsVisibleAsync()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -3943,7 +3943,7 @@ await Page.IsVisibleAsync(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `Timeout` [float]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Page.IsVisibleAsync()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -3957,7 +3957,7 @@ await Page.IsVisibleAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.PressAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.PressAsync()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -4021,7 +4021,7 @@ await page.ScreenshotAsync(new() { Path = "O.png" });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.QuerySelectorAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Page.Locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -4054,7 +4054,7 @@ await Page.QuerySelectorAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.QuerySelectorAllAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Page.Locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -4190,7 +4190,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.SelectOptionAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.SelectOptionAsync()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -4255,7 +4255,7 @@ await page.SelectOptionAsync("select#colors", new[] { "red", "green", "blue" });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>page.SetCheckedAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.SetCheckedAsync()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -4321,7 +4321,7 @@ await Page.SetCheckedAsync(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.SetInputFilesAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.SetInputFilesAsync()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -4372,7 +4372,7 @@ await Page.SetInputFilesAsync(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.TapAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.TapAsync()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -4439,7 +4439,7 @@ await Page.TapAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.TextContentAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.TextContentAsync()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -4518,7 +4518,7 @@ To press a special key, like `Control` or `ArrowDown`, use [Keyboard.PressAsync(
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.UncheckAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.UncheckAsync()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -4580,7 +4580,7 @@ await Page.UncheckAsync(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.WaitForSelectorAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [Locator.WaitForAsync()](/api/class-locator.mdx#locator-wait-for) instead. Read more about [locators](../locators.mdx).
 
@@ -4652,7 +4652,7 @@ class FrameExamples
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.WaitForTimeoutAsync</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Never wait for timeout in production. Tests that wait for time are inherently flaky. Use [Locator] actions and web assertions that wait automatically.
 

--- a/java/docs/api/class-browsertype.mdx
+++ b/java/docs/api/class-browsertype.mdx
@@ -173,7 +173,7 @@ Browser browser = chromium.launch(new BrowserType.LaunchOptions()
     Enable Chromium sandboxing. Defaults to `false`.
   - `setDevtools` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-devtools"/><a href="#browser-type-launch-option-devtools" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use [debugging tools](../debug.mdx) instead.
     :::
     
@@ -292,7 +292,7 @@ BrowserType.launchPersistentContext(userDataDir, options);
     Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about [emulating devices with device scale factor](../emulation.mdx#devices).
   - `setDevtools` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-devtools"/><a href="#browser-type-launch-persistent-context-option-devtools" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use [debugging tools](../debug.mdx) instead.
     :::
     

--- a/java/docs/api/class-elementhandle.mdx
+++ b/java/docs/api/class-elementhandle.mdx
@@ -159,7 +159,7 @@ ElementHandle.waitForElementState(state, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.check</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -217,7 +217,7 @@ ElementHandle.check(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.click</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -285,7 +285,7 @@ ElementHandle.click(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dblclick</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -354,7 +354,7 @@ ElementHandle.dblclick(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dispatchEvent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.dispatchEvent()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -410,7 +410,7 @@ elementHandle.dispatchEvent("dragstart", arg);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.evalOnSelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [Locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -451,7 +451,7 @@ assertEquals("10", tweetHandle.evalOnSelector(".retweets", "node => node.innerTe
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.evalOnSelectorAll</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [Locator.evaluateAll()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -498,7 +498,7 @@ assertEquals(Arrays.asList("Hello!", "Hi!"), feedHandle.evalOnSelectorAll(".twee
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.fill</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -542,7 +542,7 @@ ElementHandle.fill(value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.focus</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -566,7 +566,7 @@ ElementHandle.focus();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.getAttribute</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.getAttribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -595,7 +595,7 @@ ElementHandle.getAttribute(name);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.hover</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -654,7 +654,7 @@ ElementHandle.hover(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.innerHTML</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.innerHTML()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -678,7 +678,7 @@ ElementHandle.innerHTML();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.innerText</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.innerText()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -702,7 +702,7 @@ ElementHandle.innerText();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>elementHandle.inputValue</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.inputValue()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -735,7 +735,7 @@ ElementHandle.inputValue(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isChecked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -759,7 +759,7 @@ ElementHandle.isChecked();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isDisabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isDisabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -783,7 +783,7 @@ ElementHandle.isDisabled();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isEditable</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isEditable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -807,7 +807,7 @@ ElementHandle.isEditable();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isEnabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isEnabled()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -831,7 +831,7 @@ ElementHandle.isEnabled();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isHidden</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -855,7 +855,7 @@ ElementHandle.isHidden();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isVisible</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isVisible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -879,7 +879,7 @@ ElementHandle.isVisible();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.press</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -931,7 +931,7 @@ ElementHandle.press(key, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.querySelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -960,7 +960,7 @@ ElementHandle.querySelector(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.querySelectorAll</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -989,7 +989,7 @@ ElementHandle.querySelectorAll(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.screenshot</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.screenshot()](/api/class-locator.mdx#locator-screenshot) instead. Read more about [locators](../locators.mdx).
 
@@ -1060,7 +1060,7 @@ ElementHandle.screenshot(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.scrollIntoViewIfNeeded</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.scrollIntoViewIfNeeded()](/api/class-locator.mdx#locator-scroll-into-view-if-needed) instead. Read more about [locators](../locators.mdx).
 
@@ -1093,7 +1093,7 @@ ElementHandle.scrollIntoViewIfNeeded(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.selectOption</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.selectOption()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -1152,7 +1152,7 @@ handle.selectOption(new String[] {"red", "green", "blue"});
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.selectText</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.selectText()](/api/class-locator.mdx#locator-select-text) instead. Read more about [locators](../locators.mdx).
 
@@ -1188,7 +1188,7 @@ ElementHandle.selectText(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>elementHandle.setChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.setChecked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -1248,7 +1248,7 @@ ElementHandle.setChecked(checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.setInputFiles</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.setInputFiles()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -1294,7 +1294,7 @@ ElementHandle.setInputFiles(files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.tap</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -1357,7 +1357,7 @@ ElementHandle.tap(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.textContent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.textContent()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -1418,7 +1418,7 @@ To press a special key, like `Control` or `ArrowDown`, use [ElementHandle.press(
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.uncheck</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -1476,7 +1476,7 @@ ElementHandle.uncheck(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.waitForSelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [Locator.waitFor()](/api/class-locator.mdx#locator-wait-for) instead.
 

--- a/java/docs/api/class-frame.mdx
+++ b/java/docs/api/class-frame.mdx
@@ -1061,7 +1061,7 @@ frame.waitForURL("**/target.html");
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.check</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -1124,7 +1124,7 @@ Frame.check(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.click</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -1197,7 +1197,7 @@ Frame.click(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dblclick</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -1271,7 +1271,7 @@ Frame.dblclick(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dispatchEvent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.dispatchEvent()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -1337,7 +1337,7 @@ frame.dispatchEvent("#source", "dragstart", arg);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.evalOnSelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass the actionability checks and therefore can lead to the flaky tests. Use [Locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -1382,7 +1382,7 @@ String html = (String) frame.evalOnSelector(".main-container", "(e, suffix) => e
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.evalOnSelectorAll</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [Locator.evaluateAll()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -1421,7 +1421,7 @@ boolean divsCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => div
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.fill</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -1471,7 +1471,7 @@ Frame.fill(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.focus</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -1508,7 +1508,7 @@ Frame.focus(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.getAttribute</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.getAttribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -1548,7 +1548,7 @@ Frame.getAttribute(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.hover</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -1612,7 +1612,7 @@ Frame.hover(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerHTML</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.innerHTML()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -1649,7 +1649,7 @@ Frame.innerHTML(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerText</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.innerText()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -1686,7 +1686,7 @@ Frame.innerText(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>frame.inputValue</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.inputValue()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -1725,7 +1725,7 @@ Frame.inputValue(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isChecked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -1762,7 +1762,7 @@ Frame.isChecked(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isDisabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isDisabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -1799,7 +1799,7 @@ Frame.isDisabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isEditable</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isEditable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -1836,7 +1836,7 @@ Frame.isEditable(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isHidden</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -1862,7 +1862,7 @@ Frame.isHidden(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Frame.isHidden()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -1876,7 +1876,7 @@ Frame.isHidden(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isVisible</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isVisible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -1902,7 +1902,7 @@ Frame.isVisible(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Frame.isVisible()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -1916,7 +1916,7 @@ Frame.isVisible(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.press</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -1972,7 +1972,7 @@ Frame.press(selector, key, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.querySelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2012,7 +2012,7 @@ Frame.querySelector(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.querySelectorAll</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2047,7 +2047,7 @@ Frame.querySelectorAll(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.selectOption</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.selectOption()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -2112,7 +2112,7 @@ frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>frame.setChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.setChecked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -2179,7 +2179,7 @@ Frame.setChecked(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.setInputFiles</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.setInputFiles()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -2231,7 +2231,7 @@ Frame.setInputFiles(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.tap</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -2299,7 +2299,7 @@ Frame.tap(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.textContent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.textContent()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -2379,7 +2379,7 @@ To press a special key, like `Control` or `ArrowDown`, use [Keyboard.press()](/a
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.uncheck</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -2495,7 +2495,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForSelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [Locator.waitFor()](/api/class-locator.mdx#locator-wait-for) instead. Read more about [locators](../locators.mdx).
 
@@ -2562,7 +2562,7 @@ public class Example {
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForTimeout</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Never wait for timeout in production. Tests that wait for time are inherently flaky. Use [Locator] actions and web assertions that wait automatically.
 

--- a/java/docs/api/class-locator.mdx
+++ b/java/docs/api/class-locator.mdx
@@ -44,8 +44,8 @@ for (Locator li : page.getByRole('listitem').all())
 
 Returns an array of `node.innerText` values for all matching nodes.
 
-:::caution Asserting text
-If you need to assert text on the page, prefer [assertThat(locator).hasText()](/api/class-locatorassertions.mdx#locator-assertions-to-have-text) with `useInnerText` option to avoid flakiness. See [assertions guide](../test-assertions.mdx) for more details.
+:::warning 1Asserting text
+If you need ato assert text on the page, prefer [assertThat(locator).hasText()](/api/class-locatorassertions.mdx#locator-assertions-to-have-text) with `useInnerText` option to avoid flakiness. See [assertions guide](../test-assertions.mdx) for more details.
 :::
 
 **Usage**
@@ -1465,7 +1465,7 @@ boolean hidden = page.getByRole(AriaRole.BUTTON).isHidden();
 - `options` `Locator.IsHiddenOptions` *(optional)*
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -1495,7 +1495,7 @@ boolean visible = page.getByRole(AriaRole.BUTTON).isVisible();
 - `options` `Locator.IsVisibleOptions` *(optional)*
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Locator.isVisible()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -2209,7 +2209,7 @@ orderSent.waitFor();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.elementHandle</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 
@@ -2240,7 +2240,7 @@ Locator.elementHandle(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.elementHandles</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 

--- a/java/docs/api/class-page.mdx
+++ b/java/docs/api/class-page.mdx
@@ -2925,7 +2925,7 @@ Page.onWorker(handler)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.check</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -2988,7 +2988,7 @@ Page.check(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.click</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -3061,7 +3061,7 @@ Page.click(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dblclick</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -3135,7 +3135,7 @@ Page.dblclick(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dispatchEvent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.dispatchEvent()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -3201,7 +3201,7 @@ page.dispatchEvent("#source", "dragstart", arg);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.evalOnSelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [Locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -3244,7 +3244,7 @@ String html = (String) page.evalOnSelector(".main-container", "(e, suffix) => e.
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.evalOnSelectorAll</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [Locator.evaluateAll()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -3281,7 +3281,7 @@ boolean divCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.fill</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -3331,7 +3331,7 @@ Page.fill(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.focus</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -3368,7 +3368,7 @@ Page.focus(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.getAttribute</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.getAttribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -3408,7 +3408,7 @@ Page.getAttribute(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.hover</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -3472,7 +3472,7 @@ Page.hover(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerHTML</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.innerHTML()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -3509,7 +3509,7 @@ Page.innerHTML(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerText</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.innerText()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -3546,7 +3546,7 @@ Page.innerText(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>page.inputValue</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.inputValue()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -3585,7 +3585,7 @@ Page.inputValue(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isChecked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -3622,7 +3622,7 @@ Page.isChecked(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isDisabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isDisabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3659,7 +3659,7 @@ Page.isDisabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEditable</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isEditable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -3696,7 +3696,7 @@ Page.isEditable(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEnabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isEnabled()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3733,7 +3733,7 @@ Page.isEnabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isHidden</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -3759,7 +3759,7 @@ Page.isHidden(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Page.isHidden()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -3773,7 +3773,7 @@ Page.isHidden(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isVisible</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.isVisible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -3799,7 +3799,7 @@ Page.isVisible(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTimeout` [double] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [Page.isVisible()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -3813,7 +3813,7 @@ Page.isVisible(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.press</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -3877,7 +3877,7 @@ page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("O.png" )));
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.querySelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -3911,7 +3911,7 @@ Page.querySelector(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.querySelectorAll</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -3940,7 +3940,7 @@ Page.querySelectorAll(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.selectOption</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.selectOption()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -4005,7 +4005,7 @@ page.selectOption("select#colors", new String[] {"red", "green", "blue"});
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>page.setChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.setChecked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -4072,7 +4072,7 @@ Page.setChecked(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setInputFiles</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.setInputFiles()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -4124,7 +4124,7 @@ Page.setInputFiles(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.tap</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -4192,7 +4192,7 @@ Page.tap(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.textContent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.textContent()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -4272,7 +4272,7 @@ To press a special key, like `Control` or `ArrowDown`, use [Keyboard.press()](/a
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.uncheck</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [Locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -4388,7 +4388,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForSelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [Locator.waitFor()](/api/class-locator.mdx#locator-wait-for) instead. Read more about [locators](../locators.mdx).
 
@@ -4455,7 +4455,7 @@ public class Example {
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForTimeout</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Never wait for timeout in production. Tests that wait for time are inherently flaky. Use [Locator] actions and web assertions that wait automatically.
 

--- a/nodejs/docs/api/class-androiddevice.mdx
+++ b/nodejs/docs/api/class-androiddevice.mdx
@@ -352,7 +352,7 @@ await androidDevice.launchBrowser(options);
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-video-size"/><a href="#android-device-launch-browser-option-video-size" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use `recordVideo` instead.
     :::
     
@@ -364,7 +364,7 @@ await androidDevice.launchBrowser(options);
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-videos-path"/><a href="#android-device-launch-browser-option-videos-path" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use `recordVideo` instead.
     :::
     

--- a/nodejs/docs/api/class-browser.mdx
+++ b/nodejs/docs/api/class-browser.mdx
@@ -359,7 +359,7 @@ If directly using this method to create [BrowserContext]s, it is best practice t
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-video-size"/><a href="#browser-new-context-option-video-size" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use `recordVideo` instead.
     :::
     
@@ -371,7 +371,7 @@ If directly using this method to create [BrowserContext]s, it is best practice t
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-videos-path"/><a href="#browser-new-context-option-videos-path" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use `recordVideo` instead.
     :::
     
@@ -607,7 +607,7 @@ await browser.newPage(options);
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-video-size"/><a href="#browser-new-page-option-video-size" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use `recordVideo` instead.
     :::
     
@@ -619,7 +619,7 @@ await browser.newPage(options);
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-videos-path"/><a href="#browser-new-page-option-videos-path" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use `recordVideo` instead.
     :::
     

--- a/nodejs/docs/api/class-browsertype.mdx
+++ b/nodejs/docs/api/class-browsertype.mdx
@@ -177,7 +177,7 @@ const browser = await chromium.launch({  // Or 'firefox' or 'webkit'.
     Enable Chromium sandboxing. Defaults to `false`.
   - `devtools` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-devtools"/><a href="#browser-type-launch-option-devtools" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use [debugging tools](../debug.mdx) instead.
     :::
     
@@ -296,7 +296,7 @@ await browserType.launchPersistentContext(userDataDir, options);
     Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about [emulating devices with device scale factor](../emulation.mdx#devices).
   - `devtools` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-devtools"/><a href="#browser-type-launch-persistent-context-option-devtools" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use [debugging tools](../debug.mdx) instead.
     :::
     
@@ -466,7 +466,7 @@ await browserType.launchPersistentContext(userDataDir, options);
     Specific user agent to use in this context.
   - `videoSize` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-video-size"/><a href="#browser-type-launch-persistent-context-option-video-size" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use `recordVideo` instead.
     :::
     
@@ -478,7 +478,7 @@ await browserType.launchPersistentContext(userDataDir, options);
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-videos-path"/><a href="#browser-type-launch-persistent-context-option-videos-path" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use `recordVideo` instead.
     :::
     
@@ -541,7 +541,7 @@ const { chromium } = require('playwright');  // Or 'webkit' or 'firefox'.
     Enable Chromium sandboxing. Defaults to `false`.
   - `devtools` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-server-option-devtools"/><a href="#browser-type-launch-server-option-devtools" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     Use [debugging tools](../debug.mdx) instead.
     :::
     

--- a/nodejs/docs/api/class-elementhandle.mdx
+++ b/nodejs/docs/api/class-elementhandle.mdx
@@ -161,7 +161,7 @@ await elementHandle.waitForElementState(state, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.$</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -190,7 +190,7 @@ await elementHandle.$(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.$$</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -219,7 +219,7 @@ await elementHandle.$$(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.$eval</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -260,7 +260,7 @@ expect(await tweetHandle.$eval('.retweets', node => node.innerText)).toBe('10');
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.$$eval</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [locator.evaluateAll()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -309,7 +309,7 @@ expect(await feedHandle.$$eval('.tweet', nodes =>
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.check</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -367,7 +367,7 @@ await elementHandle.check(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.click</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -435,7 +435,7 @@ await elementHandle.click(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dblclick</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -504,7 +504,7 @@ await elementHandle.dblclick(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dispatchEvent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dispatchEvent()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -558,7 +558,7 @@ await elementHandle.dispatchEvent('dragstart', { dataTransfer });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.fill</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -602,7 +602,7 @@ await elementHandle.fill(value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.focus</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -626,7 +626,7 @@ await elementHandle.focus();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.getAttribute</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.getAttribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -655,7 +655,7 @@ await elementHandle.getAttribute(name);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.hover</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -714,7 +714,7 @@ await elementHandle.hover(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.innerHTML</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.innerHTML()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -738,7 +738,7 @@ await elementHandle.innerHTML();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.innerText</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.innerText()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -762,7 +762,7 @@ await elementHandle.innerText();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>elementHandle.inputValue</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.inputValue()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -795,7 +795,7 @@ await elementHandle.inputValue(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isChecked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -819,7 +819,7 @@ await elementHandle.isChecked();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isDisabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isDisabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -843,7 +843,7 @@ await elementHandle.isDisabled();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isEditable</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isEditable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -867,7 +867,7 @@ await elementHandle.isEditable();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isEnabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isEnabled()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -891,7 +891,7 @@ await elementHandle.isEnabled();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isHidden</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -915,7 +915,7 @@ await elementHandle.isHidden();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isVisible</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isVisible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -939,7 +939,7 @@ await elementHandle.isVisible();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.press</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -991,7 +991,7 @@ await elementHandle.press(key, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.screenshot</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.screenshot()](/api/class-locator.mdx#locator-screenshot) instead. Read more about [locators](../locators.mdx).
 
@@ -1062,7 +1062,7 @@ await elementHandle.screenshot(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.scrollIntoViewIfNeeded</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.scrollIntoViewIfNeeded()](/api/class-locator.mdx#locator-scroll-into-view-if-needed) instead. Read more about [locators](../locators.mdx).
 
@@ -1095,7 +1095,7 @@ await elementHandle.scrollIntoViewIfNeeded(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.selectOption</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.selectOption()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -1156,7 +1156,7 @@ handle.selectOption(['red', 'green', 'blue']);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.selectText</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.selectText()](/api/class-locator.mdx#locator-select-text) instead. Read more about [locators](../locators.mdx).
 
@@ -1192,7 +1192,7 @@ await elementHandle.selectText(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>elementHandle.setChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.setChecked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -1252,7 +1252,7 @@ await elementHandle.setChecked(checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.setInputFiles</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.setInputFiles()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -1298,7 +1298,7 @@ await elementHandle.setInputFiles(files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.tap</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -1361,7 +1361,7 @@ await elementHandle.tap(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.textContent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.textContent()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -1422,7 +1422,7 @@ To press a special key, like `Control` or `ArrowDown`, use [elementHandle.press(
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.uncheck</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -1480,7 +1480,7 @@ await elementHandle.uncheck(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.waitForSelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [locator.waitFor()](/api/class-locator.mdx#locator-wait-for) instead.
 

--- a/nodejs/docs/api/class-frame.mdx
+++ b/nodejs/docs/api/class-frame.mdx
@@ -1061,7 +1061,7 @@ await frame.waitForURL('**/target.html');
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.$</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -1101,7 +1101,7 @@ await frame.$(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.$$</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -1136,7 +1136,7 @@ await frame.$$(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.$eval</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass the actionability checks and therefore can lead to the flaky tests. Use [locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -1181,7 +1181,7 @@ const html = await frame.$eval('.main-container', (e, suffix) => e.outerHTML + s
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.$$eval</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [locator.evaluateAll()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -1220,7 +1220,7 @@ const divsCounts = await frame.$$eval('div', (divs, min) => divs.length >= min, 
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.check</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -1283,7 +1283,7 @@ await frame.check(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.click</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -1356,7 +1356,7 @@ await frame.click(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dblclick</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -1430,7 +1430,7 @@ await frame.dblclick(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dispatchEvent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dispatchEvent()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -1494,7 +1494,7 @@ await frame.dispatchEvent('#source', 'dragstart', { dataTransfer });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.fill</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -1544,7 +1544,7 @@ await frame.fill(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.focus</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -1581,7 +1581,7 @@ await frame.focus(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.getAttribute</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.getAttribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -1621,7 +1621,7 @@ await frame.getAttribute(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.hover</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -1685,7 +1685,7 @@ await frame.hover(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerHTML</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.innerHTML()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -1722,7 +1722,7 @@ await frame.innerHTML(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerText</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.innerText()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -1759,7 +1759,7 @@ await frame.innerText(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>frame.inputValue</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.inputValue()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -1798,7 +1798,7 @@ await frame.inputValue(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isChecked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -1835,7 +1835,7 @@ await frame.isChecked(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isDisabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isDisabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -1872,7 +1872,7 @@ await frame.isDisabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isEditable</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isEditable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -1909,7 +1909,7 @@ await frame.isEditable(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isHidden</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -1935,7 +1935,7 @@ await frame.isHidden(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [frame.isHidden()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -1949,7 +1949,7 @@ await frame.isHidden(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isVisible</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isVisible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -1975,7 +1975,7 @@ await frame.isVisible(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [frame.isVisible()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -1989,7 +1989,7 @@ await frame.isVisible(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.press</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -2045,7 +2045,7 @@ await frame.press(selector, key, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.selectOption</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.selectOption()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -2112,7 +2112,7 @@ frame.selectOption('select#colors', 'red', 'green', 'blue');
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>frame.setChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.setChecked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -2179,7 +2179,7 @@ await frame.setChecked(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.setInputFiles</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.setInputFiles()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -2231,7 +2231,7 @@ await frame.setInputFiles(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.tap</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -2299,7 +2299,7 @@ await frame.tap(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.textContent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.textContent()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -2379,7 +2379,7 @@ To press a special key, like `Control` or `ArrowDown`, use [keyboard.press()](/a
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.uncheck</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -2491,7 +2491,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForSelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [locator.waitFor()](/api/class-locator.mdx#locator-wait-for) instead. Read more about [locators](../locators.mdx).
 
@@ -2553,7 +2553,7 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForTimeout</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Never wait for timeout in production. Tests that wait for time are inherently flaky. Use [Locator] actions and web assertions that wait automatically.
 

--- a/nodejs/docs/api/class-locator.mdx
+++ b/nodejs/docs/api/class-locator.mdx
@@ -44,8 +44,8 @@ for (const li of await page.getByRole('listitem').all())
 
 Returns an array of `node.innerText` values for all matching nodes.
 
-:::caution Asserting text
-If you need to assert text on the page, prefer [expect(locator).toHaveText()](/api/class-locatorassertions.mdx#locator-assertions-to-have-text) with `useInnerText` option to avoid flakiness. See [assertions guide](../test-assertions.mdx) for more details.
+:::warning 1Asserting text
+If you need ato assert text on the page, prefer [expect(locator).toHaveText()](/api/class-locatorassertions.mdx#locator-assertions-to-have-text) with `useInnerText` option to avoid flakiness. See [assertions guide](../test-assertions.mdx) for more details.
 :::
 
 **Usage**
@@ -1469,7 +1469,7 @@ const hidden = await page.getByRole('button').isHidden();
 - `options` [Object] *(optional)*
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -1499,7 +1499,7 @@ const visible = await page.getByRole('button').isVisible();
 - `options` [Object] *(optional)*
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [locator.isVisible()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -2219,7 +2219,7 @@ await orderSent.waitFor();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.elementHandle</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 
@@ -2250,7 +2250,7 @@ await locator.elementHandle(options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.elementHandles</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 

--- a/nodejs/docs/api/class-page.mdx
+++ b/nodejs/docs/api/class-page.mdx
@@ -2663,7 +2663,7 @@ page.on('worker', data => {});
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.$</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2697,7 +2697,7 @@ await page.$(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.$$</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2726,7 +2726,7 @@ await page.$$(selector);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.$eval</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -2771,7 +2771,7 @@ const preloadHrefTS = await page.$eval('link[rel=preload]', (el: HTMLLinkElement
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.$$eval</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [locator.evaluateAll()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -2830,7 +2830,7 @@ page.accessibility
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.check</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -2893,7 +2893,7 @@ await page.check(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.click</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -2966,7 +2966,7 @@ await page.click(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dblclick</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -3040,7 +3040,7 @@ await page.dblclick(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dispatchEvent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dispatchEvent()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -3104,7 +3104,7 @@ await page.dispatchEvent('#source', 'dragstart', { dataTransfer });
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.fill</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -3154,7 +3154,7 @@ await page.fill(selector, value, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.focus</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -3191,7 +3191,7 @@ await page.focus(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.getAttribute</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.getAttribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -3231,7 +3231,7 @@ await page.getAttribute(selector, name, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.hover</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -3295,7 +3295,7 @@ await page.hover(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerHTML</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.innerHTML()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -3332,7 +3332,7 @@ await page.innerHTML(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerText</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.innerText()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -3369,7 +3369,7 @@ await page.innerText(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>page.inputValue</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.inputValue()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -3408,7 +3408,7 @@ await page.inputValue(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isChecked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -3445,7 +3445,7 @@ await page.isChecked(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isDisabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isDisabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3482,7 +3482,7 @@ await page.isDisabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEditable</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isEditable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -3519,7 +3519,7 @@ await page.isEditable(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEnabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isEnabled()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -3556,7 +3556,7 @@ await page.isEnabled(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isHidden</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isHidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -3582,7 +3582,7 @@ await page.isHidden(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [page.isHidden()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
     :::
     
@@ -3596,7 +3596,7 @@ await page.isHidden(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isVisible</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.isVisible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -3622,7 +3622,7 @@ await page.isVisible(selector, options);
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `timeout` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
     
-    :::caution Deprecated
+    :::warning[Deprecated]
     This option is ignored. [page.isVisible()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
     :::
     
@@ -3636,7 +3636,7 @@ await page.isVisible(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.press</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -3701,7 +3701,7 @@ await browser.close();
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.selectOption</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.selectOption()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -3769,7 +3769,7 @@ page.selectOption('select#colors', ['red', 'green', 'blue']);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>page.setChecked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.setChecked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -3836,7 +3836,7 @@ await page.setChecked(selector, checked, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setInputFiles</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.setInputFiles()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -3888,7 +3888,7 @@ await page.setInputFiles(selector, files, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.tap</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -3956,7 +3956,7 @@ await page.tap(selector, options);
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.textContent</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.textContent()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -4036,7 +4036,7 @@ To press a special key, like `Control` or `ArrowDown`, use [keyboard.press()](/a
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.uncheck</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -4148,7 +4148,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForSelector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [locator.waitFor()](/api/class-locator.mdx#locator-wait-for) instead. Read more about [locators](../locators.mdx).
 
@@ -4210,7 +4210,7 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForTimeout</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Never wait for timeout in production. Tests that wait for time are inherently flaky. Use [Locator] actions and web assertions that wait automatically.
 

--- a/nodejs/docs/api/class-test.mdx
+++ b/nodejs/docs/api/class-test.mdx
@@ -1530,7 +1530,7 @@ test('example', async ({ page }) => {
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.10</font><x-search>test.test.describe.parallel</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 See [test.describe.configure()](/api/class-test.mdx#test-describe-configure) for the preferred way of configuring the execution mode.
 
@@ -1588,7 +1588,7 @@ test.describe.parallel(() => {
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.10</font><x-search>test.test.describe.parallel.only</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 See [test.describe.configure()](/api/class-test.mdx#test-describe-configure) for the preferred way of configuring the execution mode.
 
@@ -1644,7 +1644,7 @@ test.describe.parallel.only(() => {
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.10</font><x-search>test.test.describe.serial</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 See [test.describe.configure()](/api/class-test.mdx#test-describe-configure) for the preferred way of configuring the execution mode.
 
@@ -1705,7 +1705,7 @@ test.describe.serial(() => {
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.10</font><x-search>test.test.describe.serial.only</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 See [test.describe.configure()](/api/class-test.mdx#test-describe-configure) for the preferred way of configuring the execution mode.
 

--- a/nodejs/docs/api/class-testconfig.mdx
+++ b/nodejs/docs/api/class-testconfig.mdx
@@ -975,7 +975,7 @@ export default defineConfig({
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.10</font><x-search>testConfig.snapshotDir</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use [testConfig.snapshotPathTemplate](/api/class-testconfig.mdx#test-config-snapshot-path-template) to configure snapshot paths.
 

--- a/python/docs/api/class-browsertype.mdx
+++ b/python/docs/api/class-browsertype.mdx
@@ -229,7 +229,7 @@ browser = await playwright.chromium.launch( # or "firefox" or "webkit".
   Enable Chromium sandboxing. Defaults to `false`.
 - `devtools` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-devtools"/><a href="#browser-type-launch-option-devtools" class="list-anchor">#</a>
   
-  :::caution Deprecated
+  :::warning[Deprecated]
   Use [debugging tools](../debug.mdx) instead.
   :::
   
@@ -344,7 +344,7 @@ browser_type.launch_persistent_context(user_data_dir, **kwargs)
   Specify device scale factor (can be thought of as dpr). Defaults to `1`. Learn more about [emulating devices with device scale factor](../emulation.mdx#devices).
 - `devtools` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-devtools"/><a href="#browser-type-launch-persistent-context-option-devtools" class="list-anchor">#</a>
   
-  :::caution Deprecated
+  :::warning[Deprecated]
   Use [debugging tools](../debug.mdx) instead.
   :::
   

--- a/python/docs/api/class-elementhandle.mdx
+++ b/python/docs/api/class-elementhandle.mdx
@@ -244,7 +244,7 @@ element_handle.wait_for_element_state(state, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.check</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -301,7 +301,7 @@ element_handle.check(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.click</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -368,7 +368,7 @@ element_handle.click(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dblclick</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -436,7 +436,7 @@ element_handle.dblclick(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dispatch_event</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dispatch_event()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -532,7 +532,7 @@ await element_handle.dispatch_event("#source", "dragstart", {"dataTransfer": dat
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.eval_on_selector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -595,7 +595,7 @@ assert await tweet_handle.eval_on_selector(".retweets", "node => node.innerText"
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.eval_on_selector_all</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [locator.evaluate_all()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -663,7 +663,7 @@ assert await feed_handle.eval_on_selector_all(".tweet", "nodes => nodes.map(n =>
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.fill</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -706,7 +706,7 @@ element_handle.fill(value, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.focus</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -730,7 +730,7 @@ element_handle.focus()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.get_attribute</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.get_attribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -759,7 +759,7 @@ element_handle.get_attribute(name)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.hover</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -817,7 +817,7 @@ element_handle.hover(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.inner_html</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.inner_html()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -841,7 +841,7 @@ element_handle.inner_html()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.inner_text</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.inner_text()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -865,7 +865,7 @@ element_handle.inner_text()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>elementHandle.input_value</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.input_value()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -897,7 +897,7 @@ element_handle.input_value(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_checked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_checked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -921,7 +921,7 @@ element_handle.is_checked()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_disabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_disabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -945,7 +945,7 @@ element_handle.is_disabled()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_editable</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_editable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -969,7 +969,7 @@ element_handle.is_editable()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_enabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_enabled()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -993,7 +993,7 @@ element_handle.is_enabled()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_hidden</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_hidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -1017,7 +1017,7 @@ element_handle.is_hidden()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_visible</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_visible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -1041,7 +1041,7 @@ element_handle.is_visible()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.press</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -1092,7 +1092,7 @@ element_handle.press(key, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.query_selector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -1121,7 +1121,7 @@ element_handle.query_selector(selector)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>elementHandle.query_selector_all</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -1150,7 +1150,7 @@ element_handle.query_selector_all(selector)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.screenshot</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.screenshot()](/api/class-locator.mdx#locator-screenshot) instead. Read more about [locators](../locators.mdx).
 
@@ -1220,7 +1220,7 @@ element_handle.screenshot(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.scroll_into_view_if_needed</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.scroll_into_view_if_needed()](/api/class-locator.mdx#locator-scroll-into-view-if-needed) instead. Read more about [locators](../locators.mdx).
 
@@ -1252,7 +1252,7 @@ element_handle.scroll_into_view_if_needed(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.select_option</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.select_option()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -1335,7 +1335,7 @@ await handle.select_option(value=["red", "green", "blue"])
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.select_text</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.select_text()](/api/class-locator.mdx#locator-select-text) instead. Read more about [locators](../locators.mdx).
 
@@ -1370,7 +1370,7 @@ element_handle.select_text(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>elementHandle.set_checked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.set_checked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -1429,7 +1429,7 @@ element_handle.set_checked(checked, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.set_input_files</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.set_input_files()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -1474,7 +1474,7 @@ element_handle.set_input_files(files, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.tap</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -1536,7 +1536,7 @@ element_handle.tap(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.text_content</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.text_content()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -1596,7 +1596,7 @@ To press a special key, like `Control` or `ArrowDown`, use [element_handle.press
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.uncheck</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -1653,7 +1653,7 @@ element_handle.uncheck(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.wait_for_selector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [locator.wait_for()](/api/class-locator.mdx#locator-wait-for) instead.
 

--- a/python/docs/api/class-frame.mdx
+++ b/python/docs/api/class-frame.mdx
@@ -1500,7 +1500,7 @@ frame.url
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.check</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -1562,7 +1562,7 @@ frame.check(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.click</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -1634,7 +1634,7 @@ frame.click(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dblclick</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -1707,7 +1707,7 @@ frame.dblclick(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dispatch_event</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dispatch_event()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -1812,7 +1812,7 @@ await frame.dispatch_event("#source", "dragstart", { "dataTransfer": data_transf
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.eval_on_selector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass the actionability checks and therefore can lead to the flaky tests. Use [locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -1878,7 +1878,7 @@ html = await frame.eval_on_selector(".main-container", "(e, suffix) => e.outerHT
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.eval_on_selector_all</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [locator.evaluate_all()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -2006,7 +2006,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.fill</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -2055,7 +2055,7 @@ frame.fill(selector, value, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.focus</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -2091,7 +2091,7 @@ frame.focus(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.get_attribute</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.get_attribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -2130,7 +2130,7 @@ frame.get_attribute(selector, name, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.hover</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -2193,7 +2193,7 @@ frame.hover(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.inner_html</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.inner_html()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -2229,7 +2229,7 @@ frame.inner_html(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.inner_text</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.inner_text()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -2265,7 +2265,7 @@ frame.inner_text(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>frame.input_value</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.input_value()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -2303,7 +2303,7 @@ frame.input_value(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_checked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_checked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -2339,7 +2339,7 @@ frame.is_checked(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_disabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_disabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -2375,7 +2375,7 @@ frame.is_disabled(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_editable</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_editable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -2411,7 +2411,7 @@ frame.is_editable(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_hidden</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_hidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -2436,7 +2436,7 @@ frame.is_hidden(selector, **kwargs)
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-is-hidden-option-timeout"/><a href="#frame-is-hidden-option-timeout" class="list-anchor">#</a>
   
-  :::caution Deprecated
+  :::warning[Deprecated]
   This option is ignored. [frame.is_hidden()](/api/class-frame.mdx#frame-is-hidden) does not wait for the element to become hidden and returns immediately.
   :::
   
@@ -2450,7 +2450,7 @@ frame.is_hidden(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_visible</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_visible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -2475,7 +2475,7 @@ frame.is_visible(selector, **kwargs)
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-is-visible-option-timeout"/><a href="#frame-is-visible-option-timeout" class="list-anchor">#</a>
   
-  :::caution Deprecated
+  :::warning[Deprecated]
   This option is ignored. [frame.is_visible()](/api/class-frame.mdx#frame-is-visible) does not wait for the element to become visible and returns immediately.
   :::
   
@@ -2489,7 +2489,7 @@ frame.is_visible(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.press</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -2544,7 +2544,7 @@ frame.press(selector, key, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.query_selector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2583,7 +2583,7 @@ frame.query_selector(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>frame.query_selector_all</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [frame.locator()](/api/class-frame.mdx#frame-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -2618,7 +2618,7 @@ frame.query_selector_all(selector)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.select_option</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.select_option()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -2707,7 +2707,7 @@ await frame.select_option("select#colors", value=["red", "green", "blue"])
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>frame.set_checked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.set_checked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -2773,7 +2773,7 @@ frame.set_checked(selector, checked, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.set_input_files</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.set_input_files()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -2824,7 +2824,7 @@ frame.set_input_files(selector, files, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.tap</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -2891,7 +2891,7 @@ frame.tap(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.text_content</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.text_content()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -2969,7 +2969,7 @@ To press a special key, like `Control` or `ArrowDown`, use [keyboard.press()](/a
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.uncheck</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -3031,7 +3031,7 @@ frame.uncheck(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.wait_for_selector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [locator.wait_for()](/api/class-locator.mdx#locator-wait-for) instead. Read more about [locators](../locators.mdx).
 
@@ -3130,7 +3130,7 @@ asyncio.run(main())
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.wait_for_timeout</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Never wait for timeout in production. Tests that wait for time are inherently flaky. Use [Locator] actions and web assertions that wait automatically.
 

--- a/python/docs/api/class-locator.mdx
+++ b/python/docs/api/class-locator.mdx
@@ -65,8 +65,8 @@ for li in await page.get_by_role('listitem').all():
 
 Returns an array of `node.innerText` values for all matching nodes.
 
-:::caution Asserting text
-If you need to assert text on the page, prefer [expect(locator).to_have_text()](/api/class-locatorassertions.mdx#locator-assertions-to-have-text) with `use_inner_text` option to avoid flakiness. See [assertions guide](../test-assertions.mdx) for more details.
+:::warning 1Asserting text
+If you need ato assert text on the page, prefer [expect(locator).to_have_text()](/api/class-locatorassertions.mdx#locator-assertions-to-have-text) with `use_inner_text` option to avoid flakiness. See [assertions guide](../test-assertions.mdx) for more details.
 :::
 
 **Usage**
@@ -2067,7 +2067,7 @@ hidden = await page.get_by_role("button").is_hidden()
 **Arguments**
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-is-hidden-option-timeout"/><a href="#locator-is-hidden-option-timeout" class="list-anchor">#</a>
   
-  :::caution Deprecated
+  :::warning[Deprecated]
   This option is ignored. [locator.is_hidden()](/api/class-locator.mdx#locator-is-hidden) does not wait for the element to become hidden and returns immediately.
   :::
   
@@ -2116,7 +2116,7 @@ visible = await page.get_by_role("button").is_visible()
 **Arguments**
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-is-visible-option-timeout"/><a href="#locator-is-visible-option-timeout" class="list-anchor">#</a>
   
-  :::caution Deprecated
+  :::warning[Deprecated]
   This option is ignored. [locator.is_visible()](/api/class-locator.mdx#locator-is-visible) does not wait for the element to become visible and returns immediately.
   :::
   
@@ -3170,7 +3170,7 @@ locator.page
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.element_handle</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 
@@ -3200,7 +3200,7 @@ locator.element_handle(**kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.14</font><x-search>locator.element_handles</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Always prefer using [Locator]s and web assertions over [ElementHandle]s because latter are inherently racy.
 

--- a/python/docs/api/class-page.mdx
+++ b/python/docs/api/class-page.mdx
@@ -3880,7 +3880,7 @@ page.accessibility
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.check</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.check()](/api/class-locator.mdx#locator-check) instead. Read more about [locators](../locators.mdx).
 
@@ -3942,7 +3942,7 @@ page.check(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.click</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.click()](/api/class-locator.mdx#locator-click) instead. Read more about [locators](../locators.mdx).
 
@@ -4014,7 +4014,7 @@ page.click(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dblclick</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dblclick()](/api/class-locator.mdx#locator-dblclick) instead. Read more about [locators](../locators.mdx).
 
@@ -4087,7 +4087,7 @@ page.dblclick(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dispatch_event</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.dispatch_event()](/api/class-locator.mdx#locator-dispatch-event) instead. Read more about [locators](../locators.mdx).
 
@@ -4192,7 +4192,7 @@ await page.dispatch_event("#source", "dragstart", { "dataTransfer": data_transfe
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.eval_on_selector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 This method does not wait for the element to pass actionability checks and therefore can lead to the flaky tests. Use [locator.evaluate()](/api/class-locator.mdx#locator-evaluate), other [Locator] helper methods or web-first assertions instead.
 
@@ -4256,7 +4256,7 @@ html = await page.eval_on_selector(".main-container", "(e, suffix) => e.outer_ht
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.eval_on_selector_all</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 In most cases, [locator.evaluate_all()](/api/class-locator.mdx#locator-evaluate-all), other [Locator] helper methods and web-first assertions do a better job.
 
@@ -4384,7 +4384,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.fill</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.fill()](/api/class-locator.mdx#locator-fill) instead. Read more about [locators](../locators.mdx).
 
@@ -4433,7 +4433,7 @@ page.fill(selector, value, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.focus</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.focus()](/api/class-locator.mdx#locator-focus) instead. Read more about [locators](../locators.mdx).
 
@@ -4469,7 +4469,7 @@ page.focus(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.get_attribute</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.get_attribute()](/api/class-locator.mdx#locator-get-attribute) instead. Read more about [locators](../locators.mdx).
 
@@ -4508,7 +4508,7 @@ page.get_attribute(selector, name, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.hover</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.hover()](/api/class-locator.mdx#locator-hover) instead. Read more about [locators](../locators.mdx).
 
@@ -4571,7 +4571,7 @@ page.hover(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.inner_html</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.inner_html()](/api/class-locator.mdx#locator-inner-html) instead. Read more about [locators](../locators.mdx).
 
@@ -4607,7 +4607,7 @@ page.inner_html(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.inner_text</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.inner_text()](/api/class-locator.mdx#locator-inner-text) instead. Read more about [locators](../locators.mdx).
 
@@ -4643,7 +4643,7 @@ page.inner_text(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.13</font><x-search>page.input_value</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.input_value()](/api/class-locator.mdx#locator-input-value) instead. Read more about [locators](../locators.mdx).
 
@@ -4681,7 +4681,7 @@ page.input_value(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_checked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_checked()](/api/class-locator.mdx#locator-is-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -4717,7 +4717,7 @@ page.is_checked(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_disabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_disabled()](/api/class-locator.mdx#locator-is-disabled) instead. Read more about [locators](../locators.mdx).
 
@@ -4753,7 +4753,7 @@ page.is_disabled(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_editable</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_editable()](/api/class-locator.mdx#locator-is-editable) instead. Read more about [locators](../locators.mdx).
 
@@ -4789,7 +4789,7 @@ page.is_editable(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_enabled</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_enabled()](/api/class-locator.mdx#locator-is-enabled) instead. Read more about [locators](../locators.mdx).
 
@@ -4825,7 +4825,7 @@ page.is_enabled(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_hidden</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_hidden()](/api/class-locator.mdx#locator-is-hidden) instead. Read more about [locators](../locators.mdx).
 
@@ -4850,7 +4850,7 @@ page.is_hidden(selector, **kwargs)
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-is-hidden-option-timeout"/><a href="#page-is-hidden-option-timeout" class="list-anchor">#</a>
   
-  :::caution Deprecated
+  :::warning[Deprecated]
   This option is ignored. [page.is_hidden()](/api/class-page.mdx#page-is-hidden) does not wait for the element to become hidden and returns immediately.
   :::
   
@@ -4864,7 +4864,7 @@ page.is_hidden(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_visible</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.is_visible()](/api/class-locator.mdx#locator-is-visible) instead. Read more about [locators](../locators.mdx).
 
@@ -4889,7 +4889,7 @@ page.is_visible(selector, **kwargs)
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `timeout` [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-is-visible-option-timeout"/><a href="#page-is-visible-option-timeout" class="list-anchor">#</a>
   
-  :::caution Deprecated
+  :::warning[Deprecated]
   This option is ignored. [page.is_visible()](/api/class-page.mdx#page-is-visible) does not wait for the element to become visible and returns immediately.
   :::
   
@@ -4903,7 +4903,7 @@ page.is_visible(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.press</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.press()](/api/class-locator.mdx#locator-press) instead. Read more about [locators](../locators.mdx).
 
@@ -4995,7 +4995,7 @@ await browser.close()
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.query_selector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -5028,7 +5028,7 @@ page.query_selector(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.9</font><x-search>page.query_selector_all</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [page.locator()](/api/class-page.mdx#page-locator) instead. Read more about [locators](../locators.mdx).
 
@@ -5057,7 +5057,7 @@ page.query_selector_all(selector)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.select_option</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.select_option()](/api/class-locator.mdx#locator-select-option) instead. Read more about [locators](../locators.mdx).
 
@@ -5146,7 +5146,7 @@ await page.select_option("select#colors", value=["red", "green", "blue"])
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.15</font><x-search>page.set_checked</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.set_checked()](/api/class-locator.mdx#locator-set-checked) instead. Read more about [locators](../locators.mdx).
 
@@ -5212,7 +5212,7 @@ page.set_checked(selector, checked, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.set_input_files</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.set_input_files()](/api/class-locator.mdx#locator-set-input-files) instead. Read more about [locators](../locators.mdx).
 
@@ -5263,7 +5263,7 @@ page.set_input_files(selector, files, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.tap</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.tap()](/api/class-locator.mdx#locator-tap) instead. Read more about [locators](../locators.mdx).
 
@@ -5330,7 +5330,7 @@ page.tap(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.text_content</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.text_content()](/api/class-locator.mdx#locator-text-content) instead. Read more about [locators](../locators.mdx).
 
@@ -5408,7 +5408,7 @@ To press a special key, like `Control` or `ArrowDown`, use [keyboard.press()](/a
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.uncheck</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use locator-based [locator.uncheck()](/api/class-locator.mdx#locator-uncheck) instead. Read more about [locators](../locators.mdx).
 
@@ -5470,7 +5470,7 @@ page.uncheck(selector, **kwargs)
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.wait_for_selector</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Use web assertions that assert visibility or a locator-based [locator.wait_for()](/api/class-locator.mdx#locator-wait-for) instead. Read more about [locators](../locators.mdx).
 
@@ -5569,7 +5569,7 @@ asyncio.run(main())
 
 <font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.wait_for_timeout</x-search>
 
-:::caution Discouraged
+:::warning[Discouraged]
 
 Never wait for timeout in production. Tests that wait for time are inherently flaky. Use [Locator] actions and web assertions that wait automatically.
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -281,7 +281,7 @@ ${this.documentation.renderLinksInText(member.deprecated)}
         if (member.discouraged) {
           sections.deprecation.push({
             type: 'text',
-            text: `:::caution Discouraged
+            text: `:::warning[Discouraged]
 
 ${this.documentation.renderLinksInText(member.discouraged)}
 
@@ -530,7 +530,7 @@ import HTMLCard from '@site/src/components/HTMLCard';`);
     if (member.deprecated && direction === 'in') {
       children.push({
         type: 'text',
-        text: `:::caution Deprecated
+        text: `:::warning[Deprecated]
 ${this.documentation.renderLinksInText(member.deprecated)}
 :::
 `
@@ -540,7 +540,7 @@ ${this.documentation.renderLinksInText(member.deprecated)}
     if (member.discouraged && direction === 'in') {
       children.push({
         type: 'text',
-        text: `:::caution Discouraged
+        text: `:::warning[Discouraged]
 ${this.documentation.renderLinksInText(member.discouraged)}
 :::
 `


### PR DESCRIPTION
`:::caution` is deprecated since v3 of Docusaurus and they also have a new way of specifying a custom [Admonitors title](https://docusaurus.io/docs/markdown-features/admonitions#specifying-title). Old one is [best-effort](https://docusaurus.io/docs/markdown-features/admonitions#specifying-title).

See https://github.com/facebook/docusaurus/pull/9308

Demo: https://delightful-forest-0a29f6210-1333.centralus.azurestaticapps.net/docs/next/api/class-browsertype#browser-type-launch

