### PR TITLE
fix: treat long in Node.js as number

### DIFF
--- a/src/format_js.js
+++ b/src/format_js.js
@@ -89,6 +89,7 @@ class JavaScriptFormatter {
     switch (text) {
       case 'int': return '[number]';
       case 'float': return '[number]';
+      case 'long': return '[number]';
       case 'path': return '[string]';
       case 'any': return '[Object]';
     }


### PR DESCRIPTION
Fixes https://playwright.dev/docs/api/class-clock#clock-fast-forward-option-ticks