### PR TITLE
fix: release note link for videos with two versions

### DIFF
--- a/src/components/VideoCards/index.tsx
+++ b/src/components/VideoCards/index.tsx
@@ -19,8 +19,9 @@ import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import LiteYouTube from '@site/src/components/LiteYouTube';
 import styles from './styles.module.css';
+import { Video } from '@site/src/data/types';
 
-function VideoCards({ videos }) {
+function VideoCards({ videos }: { videos: Video[] }) {
   return (
     <section className="margin-top--lg margin-bottom--xl">
       <div className="container">
@@ -34,7 +35,12 @@ function VideoCards({ videos }) {
   );
 }
 
-function VideoCard({ video }) {
+function videoToReleasePageAnchor(video: Video) {
+  const versions = video.version.split(' & ');
+  return `version-${versions[versions.length - 1].replace('.', '')}`;
+}
+
+function VideoCard({ video }: { video: Video }) {
   return (
     <li key={video.title} className="card shadow--md">
       <div className={styles.videoCardVideo}>
@@ -64,10 +70,7 @@ function VideoCard({ video }) {
         {video.version ? (
           <div className={styles.videoCardHeader}>
             <Link
-              href={`/docs/release-notes#version-${video.version.replace(
-                '.',
-                ''
-              )}`}
+              href={`/docs/release-notes#${videoToReleasePageAnchor(video)}`}
             >
               <h4 className={styles.videoCardTitle}>
                 Playwright v{video.version}

--- a/src/data/conference-videos.tsx
+++ b/src/data/conference-videos.tsx
@@ -1,4 +1,6 @@
-const conferenceVideos = [
+import { Video } from './types';
+
+const conferenceVideos: Video[] = [
   {
     title: "Playwright : l'outil qui va révolutionner les tests end-to-end",
     id: 'fQ4LICkmG9I',

--- a/src/data/learn-videos.tsx
+++ b/src/data/learn-videos.tsx
@@ -1,4 +1,6 @@
-const learnVideos = [
+import { Video } from './types';
+
+const learnVideos: Video[] = [
   {
     title: 'How to Run Tests in Playwright with the VS Code Extension',
     description: '',

--- a/src/data/release-videos.tsx
+++ b/src/data/release-videos.tsx
@@ -1,4 +1,6 @@
-const releaseVideos = [
+import { Video } from './types';
+
+const releaseVideos: Video[] = [
   {
     version: '1.45',
     id: "54_aC-rVKHg",

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,7 +1,7 @@
 export type Video = {
   version?: string;
   speakers?: string[];
-  id: string;
+  id?: string;
   title?: string;
   description?: string;
   highlights?: string[];
@@ -11,4 +11,5 @@ export type Video = {
   src?: string;
   conference?: string;
   host?: string;
+  language?: string;
 };

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,0 +1,14 @@
+export type Video = {
+  version?: string;
+  speakers?: string[];
+  id: string;
+  title?: string;
+  description?: string;
+  highlights?: string[];
+  year?: string;
+  thumbnail?: string;
+  url?: string;
+  src?: string;
+  conference?: string;
+  host?: string;
+};


### PR DESCRIPTION
When release videos were specified with two versions [here](https://github.com/microsoft/playwright.dev/blob/f591850f3decde10860ba389ce71fbfd55bb438c/src/data/release-videos.tsx#L13), the anchor link wasn't generated correctly and it was yielding to [this](https://github.com/microsoft/playwright.dev/actions/runs/9954951874/job/27501690410#step:4:771) warning / user facing UX issue.