### PR TITLE
turn "Added in: v1.8" into "Added before v1.9"

### DIFF
--- a/dotnet/docs/api/class-accessibility.mdx
+++ b/dotnet/docs/api/class-accessibility.mdx
@@ -22,7 +22,7 @@ Most of the accessibility tree gets filtered out when converting from internal b
 
 ### SnapshotAsync {#accessibility-snapshot}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>accessibility.SnapshotAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>accessibility.SnapshotAsync</x-search>
 
 :::warning Deprecated
 

--- a/dotnet/docs/api/class-browser.mdx
+++ b/dotnet/docs/api/class-browser.mdx
@@ -45,7 +45,7 @@ Browser.BrowserType
 
 ### CloseAsync {#browser-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.CloseAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.CloseAsync</x-search>
 
 In case this browser is obtained using [BrowserType.LaunchAsync()](/api/class-browsertype.mdx#browser-type-launch), closes the browser and all of its pages (if any were opened).
 
@@ -76,7 +76,7 @@ await Browser.CloseAsync(options);
 
 ### Contexts {#browser-contexts}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.Contexts</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.Contexts</x-search>
 
 Returns an array of all open browser contexts. In a newly created browser, this will return zero browser contexts.
 
@@ -97,7 +97,7 @@ System.Console.WriteLine(browser.Contexts.Count); // prints "1"
 
 ### IsConnected {#browser-is-connected}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.IsConnected</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.IsConnected</x-search>
 
 Indicates that the browser is connected.
 
@@ -135,7 +135,7 @@ await Browser.NewBrowserCDPSessionAsync();
 
 ### NewContextAsync {#browser-new-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.NewContextAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.NewContextAsync</x-search>
 
 Creates a new browser context. It won't share cookies/cache with other browser contexts.
 
@@ -360,7 +360,7 @@ await browser.CloseAsync();
 
 ### NewPageAsync {#browser-new-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.NewPageAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.NewPageAsync</x-search>
 
 Creates a new page in a new browser context. Closing this page will close the context as well.
 
@@ -573,7 +573,7 @@ await Browser.NewPageAsync(options);
 
 ### Version {#browser-version}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.Version</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.Version</x-search>
 
 Returns the browser version.
 
@@ -592,7 +592,7 @@ Browser.Version
 
 ### event Disconnected {#browser-event-disconnected}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.event Disconnected</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.event Disconnected</x-search>
 
 Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
 * Browser application is closed or crashed.

--- a/dotnet/docs/api/class-browsercontext.mdx
+++ b/dotnet/docs/api/class-browsercontext.mdx
@@ -33,7 +33,7 @@ await context.CloseAsync();
 
 ### AddCookiesAsync {#browser-context-add-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.AddCookiesAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.AddCookiesAsync</x-search>
 
 Adds cookies into this browser context. All pages within this context will have these cookies installed. Cookies can be obtained via [BrowserContext.CookiesAsync()](/api/class-browsercontext.mdx#browser-context-cookies).
 
@@ -80,7 +80,7 @@ await context.AddCookiesAsync(new[] { cookie1, cookie2 });
 
 ### AddInitScriptAsync {#browser-context-add-init-script}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.AddInitScriptAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.AddInitScriptAsync</x-search>
 
 Adds a script which would be evaluated in one of the following scenarios:
 * Whenever a page is created in the browser context or is navigated.
@@ -138,7 +138,7 @@ BrowserContext.BackgroundPages
 
 ### Browser {#browser-context-browser}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.Browser</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.Browser</x-search>
 
 Returns the browser instance of the context. If it was launched as a persistent context null gets returned.
 
@@ -155,7 +155,7 @@ BrowserContext.Browser
 
 ### ClearCookiesAsync {#browser-context-clear-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.ClearCookiesAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.ClearCookiesAsync</x-search>
 
 Removes cookies from context. Accepts optional filter.
 
@@ -188,7 +188,7 @@ await context.ClearCookiesAsync(new() { Name = "session-id", Domain = "my-origin
 
 ### ClearPermissionsAsync {#browser-context-clear-permissions}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.ClearPermissionsAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.ClearPermissionsAsync</x-search>
 
 Clears all permission overrides for the browser context.
 
@@ -210,7 +210,7 @@ await context.ClearPermissionsAsync();
 
 ### CloseAsync {#browser-context-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.CloseAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.CloseAsync</x-search>
 
 Closes the browser context. All the pages that belong to the browser context will be closed.
 
@@ -237,7 +237,7 @@ await BrowserContext.CloseAsync(options);
 
 ### CookiesAsync {#browser-context-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.CookiesAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.CookiesAsync</x-search>
 
 If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those URLs are returned.
 
@@ -282,7 +282,7 @@ await BrowserContext.CookiesAsync(urls);
 
 ### ExposeBindingAsync {#browser-context-expose-binding}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.ExposeBindingAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.ExposeBindingAsync</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in every page in the context. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`. If the `callback` returns a [Promise], it will be awaited.
 
@@ -337,7 +337,7 @@ await page.GetByRole(AriaRole.Button).ClickAsync();
 
 ### ExposeFunctionAsync {#browser-context-expose-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.ExposeFunctionAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.ExposeFunctionAsync</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in every page in the context. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`.
 
@@ -399,7 +399,7 @@ class BrowserContextExamples
 
 ### GrantPermissionsAsync {#browser-context-grant-permissions}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.GrantPermissionsAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.GrantPermissionsAsync</x-search>
 
 Grants specified permissions to the browser context. Only grants corresponding permissions to the given origin if specified.
 
@@ -467,7 +467,7 @@ await BrowserContext.NewCDPSessionAsync(page);
 
 ### NewPageAsync {#browser-context-new-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.NewPageAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.NewPageAsync</x-search>
 
 Creates a new page in the browser context.
 
@@ -484,7 +484,7 @@ await BrowserContext.NewPageAsync();
 
 ### Pages {#browser-context-pages}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.Pages</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.Pages</x-search>
 
 Returns all open pages in the context.
 
@@ -501,7 +501,7 @@ BrowserContext.Pages
 
 ### RouteAsync {#browser-context-route}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.RouteAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.RouteAsync</x-search>
 
 Routing provides the capability to modify network requests that are made by any page in the browser context. Once route is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
 
@@ -722,7 +722,7 @@ await BrowserContext.WaitForPageAsync(action, options);
 
 ### SetDefaultNavigationTimeout {#browser-context-set-default-navigation-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.SetDefaultNavigationTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.SetDefaultNavigationTimeout</x-search>
 
 This setting will change the default maximum navigation time for the following methods and related shortcuts:
 * [Page.GoBackAsync()](/api/class-page.mdx#page-go-back)
@@ -751,7 +751,7 @@ BrowserContext.SetDefaultNavigationTimeout(timeout);
 
 ### SetDefaultTimeout {#browser-context-set-default-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.SetDefaultTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.SetDefaultTimeout</x-search>
 
 This setting will change the default maximum time for all the methods accepting `timeout` option.
 
@@ -774,7 +774,7 @@ BrowserContext.SetDefaultTimeout(timeout);
 
 ### SetExtraHTTPHeadersAsync {#browser-context-set-extra-http-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.SetExtraHTTPHeadersAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.SetExtraHTTPHeadersAsync</x-search>
 
 The extra HTTP headers will be sent with every request initiated by any page in the context. These headers are merged with page-specific extra HTTP headers set with [Page.SetExtraHTTPHeadersAsync()](/api/class-page.mdx#page-set-extra-http-headers). If page overrides a particular header, page-specific header value will be used instead of the browser context header value.
 
@@ -800,7 +800,7 @@ await BrowserContext.SetExtraHTTPHeadersAsync(headers);
 
 ### SetGeolocationAsync {#browser-context-set-geolocation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.SetGeolocationAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.SetGeolocationAsync</x-search>
 
 Sets the context's geolocation. Passing `null` or `undefined` emulates position unavailable.
 
@@ -837,7 +837,7 @@ Consider using [BrowserContext.GrantPermissionsAsync()](/api/class-browsercontex
 
 ### SetOfflineAsync {#browser-context-set-offline}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.SetOfflineAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.SetOfflineAsync</x-search>
 
 **Usage**
 
@@ -857,7 +857,7 @@ await BrowserContext.SetOfflineAsync(offline);
 
 ### StorageStateAsync {#browser-context-storage-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.StorageStateAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.StorageStateAsync</x-search>
 
 Returns storage state for this browser context, contains current cookies and local storage snapshot.
 
@@ -880,7 +880,7 @@ await BrowserContext.StorageStateAsync(options);
 
 ### UnrouteAsync {#browser-context-unroute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.UnrouteAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.UnrouteAsync</x-search>
 
 Removes a route created with [BrowserContext.RouteAsync()](/api/class-browsercontext.mdx#browser-context-route). When `handler` is not specified, removes all routes for the `url`.
 
@@ -1013,7 +1013,7 @@ BrowserContext.BackgroundPage += async (_, page) => {};
 
 ### event Close {#browser-context-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.event Close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.event Close</x-search>
 
 Emitted when Browser context gets closed. This might happen because of one of the following:
 * Browser context is closed.
@@ -1082,7 +1082,7 @@ When no [Page.Dialog](/api/class-page.mdx#page-event-dialog) or [BrowserContext.
 
 ### event Page {#browser-context-event-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.event Page</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.event Page</x-search>
 
 The event is emitted when a new Page is created in the BrowserContext. The page may still be loading. The event will also fire for popup pages. See also [Page.Popup](/api/class-page.mdx#page-event-popup) to receive events about popups relevant to a specific page.
 

--- a/dotnet/docs/api/class-browsertype.mdx
+++ b/dotnet/docs/api/class-browsertype.mdx
@@ -35,7 +35,7 @@ class BrowserTypeExamples
 
 ### ConnectAsync {#browser-type-connect}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.ConnectAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.ConnectAsync</x-search>
 
 This method attaches Playwright to an existing browser instance. When connecting to another browser launched via `BrowserType.launchServer` in Node.js, the major and minor version needs to match the client version (1.2.3 → is compatible with 1.2.x).
 
@@ -120,7 +120,7 @@ var page = defaultContext.Pages[0];
 
 ### ExecutablePath {#browser-type-executable-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.ExecutablePath</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.ExecutablePath</x-search>
 
 A path where Playwright expects to find a bundled browser executable.
 
@@ -137,7 +137,7 @@ BrowserType.ExecutablePath
 
 ### LaunchAsync {#browser-type-launch}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.LaunchAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.LaunchAsync</x-search>
 
 Returns the browser instance.
 
@@ -242,7 +242,7 @@ var browser = await playwright.Chromium.LaunchAsync(new() {
 
 ### LaunchPersistentContextAsync {#browser-type-launch-persistent-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.LaunchPersistentContextAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.LaunchPersistentContextAsync</x-search>
 
 Returns the persistent browser context instance.
 
@@ -507,7 +507,7 @@ await BrowserType.LaunchPersistentContextAsync(userDataDir, options);
 
 ### Name {#browser-type-name}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.Name</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.Name</x-search>
 
 Returns browser name. For example: `'chromium'`, `'webkit'` or `'firefox'`.
 

--- a/dotnet/docs/api/class-cdpsession.mdx
+++ b/dotnet/docs/api/class-cdpsession.mdx
@@ -33,7 +33,7 @@ await client.SendAsync("Animation.setPlaybackRate", new() { { "playbackRate", pl
 
 ### DetachAsync {#cdp-session-detach}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>cdpSession.DetachAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>cdpSession.DetachAsync</x-search>
 
 Detaches the CDPSession from the target. Once detached, the CDPSession object won't emit any events and can't be used to send messages.
 
@@ -72,7 +72,7 @@ CdpSession.Event(eventName);
 
 ### SendAsync {#cdp-session-send}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>cdpSession.SendAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>cdpSession.SendAsync</x-search>
 
 **Usage**
 

--- a/dotnet/docs/api/class-consolemessage.mdx
+++ b/dotnet/docs/api/class-consolemessage.mdx
@@ -36,7 +36,7 @@ await message.Args.ElementAt(1).JsonValueAsync<int>(); // 42
 
 ### Args {#console-message-args}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.Args</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.Args</x-search>
 
 List of arguments passed to a `console` function call. See also [Page.Console](/api/class-page.mdx#page-event-console).
 
@@ -53,7 +53,7 @@ ConsoleMessage.Args
 
 ### Location {#console-message-location}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.Location</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.Location</x-search>
 
 URL of the resource followed by 0-based line and column numbers in the resource formatted as `URL:line:column`.
 
@@ -87,7 +87,7 @@ ConsoleMessage.Page
 
 ### Text {#console-message-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.Text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.Text</x-search>
 
 The text of the console message.
 
@@ -104,7 +104,7 @@ ConsoleMessage.Text
 
 ### Type {#console-message-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.Type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.Type</x-search>
 
 One of the following values: `'log'`, `'debug'`, `'info'`, `'error'`, `'warning'`, `'dir'`, `'dirxml'`, `'table'`, `'trace'`, `'clear'`, `'startGroup'`, `'startGroupCollapsed'`, `'endGroup'`, `'assert'`, `'profile'`, `'profileEnd'`, `'count'`, `'timeEnd'`.
 

--- a/dotnet/docs/api/class-dialog.mdx
+++ b/dotnet/docs/api/class-dialog.mdx
@@ -45,7 +45,7 @@ Dialogs are dismissed automatically, unless there is a [Page.Dialog](/api/class-
 
 ### AcceptAsync {#dialog-accept}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.AcceptAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.AcceptAsync</x-search>
 
 Returns when the dialog has been accepted.
 
@@ -67,7 +67,7 @@ await Dialog.AcceptAsync(promptText);
 
 ### DefaultValue {#dialog-default-value}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.DefaultValue</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.DefaultValue</x-search>
 
 If dialog is prompt, returns default prompt value. Otherwise, returns empty string.
 
@@ -84,7 +84,7 @@ Dialog.DefaultValue
 
 ### DismissAsync {#dialog-dismiss}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.DismissAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.DismissAsync</x-search>
 
 Returns when the dialog has been dismissed.
 
@@ -101,7 +101,7 @@ await Dialog.DismissAsync();
 
 ### Message {#dialog-message}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.Message</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.Message</x-search>
 
 A message displayed in the dialog.
 
@@ -135,7 +135,7 @@ Dialog.Page
 
 ### Type {#dialog-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.Type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.Type</x-search>
 
 Returns dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prompt`.
 

--- a/dotnet/docs/api/class-download.mdx
+++ b/dotnet/docs/api/class-download.mdx
@@ -47,7 +47,7 @@ await Download.CancelAsync();
 
 ### CreateReadStreamAsync {#download-create-read-stream}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.CreateReadStreamAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.CreateReadStreamAsync</x-search>
 
 Returns a readable stream for a successful download, or throws for a failed/canceled download.
 
@@ -64,7 +64,7 @@ await Download.CreateReadStreamAsync();
 
 ### DeleteAsync {#download-delete}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.DeleteAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.DeleteAsync</x-search>
 
 Deletes the downloaded file. Will wait for the download to finish if necessary.
 
@@ -81,7 +81,7 @@ await Download.DeleteAsync();
 
 ### FailureAsync {#download-failure}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.FailureAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.FailureAsync</x-search>
 
 Returns download error if any. Will wait for the download to finish if necessary.
 
@@ -115,7 +115,7 @@ Download.Page
 
 ### PathAsync {#download-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.PathAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.PathAsync</x-search>
 
 Returns path to the downloaded file for a successful download, or throws for a failed/canceled download. The method will wait for the download to finish if necessary. The method throws when connected remotely.
 
@@ -134,7 +134,7 @@ await Download.PathAsync();
 
 ### SaveAsAsync {#download-save-as}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.SaveAsAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.SaveAsAsync</x-search>
 
 Copy the download to a user-specified path. It is safe to call this method while the download is still in progress. Will wait for the download to finish if necessary.
 
@@ -156,7 +156,7 @@ await download.SaveAsAsync("/path/to/save/at/" + download.SuggestedFilename);
 
 ### SuggestedFilename {#download-suggested-filename}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.SuggestedFilename</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.SuggestedFilename</x-search>
 
 Returns suggested filename for this download. It is typically computed by the browser from the [`Content-Disposition`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) response header or the `download` attribute. See the spec on [whatwg](https://html.spec.whatwg.org/#downloading-resources). Different browsers can use different logic for computing it.
 
@@ -173,7 +173,7 @@ Download.SuggestedFilename
 
 ### Url {#download-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.Url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.Url</x-search>
 
 Returns downloaded url.
 

--- a/dotnet/docs/api/class-elementhandle.mdx
+++ b/dotnet/docs/api/class-elementhandle.mdx
@@ -48,7 +48,7 @@ await locator.ClickAsync();
 
 ### BoundingBoxAsync {#element-handle-bounding-box}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.BoundingBoxAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.BoundingBoxAsync</x-search>
 
 This method returns the bounding box of the element, or `null` if the element is not visible. The bounding box is calculated relative to the main frame viewport - which is usually the same as the browser window.
 
@@ -84,7 +84,7 @@ await page.Mouse.ClickAsync(box.X + box.Width / 2, box.Y + box.Height / 2);
 
 ### ContentFrameAsync {#element-handle-content-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.ContentFrameAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.ContentFrameAsync</x-search>
 
 Returns the content frame for element handles referencing iframe nodes, or `null` otherwise
 
@@ -101,7 +101,7 @@ await ElementHandle.ContentFrameAsync();
 
 ### OwnerFrameAsync {#element-handle-owner-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.OwnerFrameAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.OwnerFrameAsync</x-search>
 
 Returns the frame containing the given element.
 
@@ -118,7 +118,7 @@ await ElementHandle.OwnerFrameAsync();
 
 ### WaitForElementStateAsync {#element-handle-wait-for-element-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.WaitForElementStateAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.WaitForElementStateAsync</x-search>
 
 Returns when the element satisfies the `state`.
 
@@ -156,7 +156,7 @@ await ElementHandle.WaitForElementStateAsync(state, options);
 
 ### CheckAsync {#element-handle-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.CheckAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.CheckAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -217,7 +217,7 @@ await ElementHandle.CheckAsync(options);
 
 ### ClickAsync {#element-handle-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.ClickAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.ClickAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -289,7 +289,7 @@ await ElementHandle.ClickAsync(options);
 
 ### DblClickAsync {#element-handle-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.DblClickAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.DblClickAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -361,7 +361,7 @@ await ElementHandle.DblClickAsync(options);
 
 ### DispatchEventAsync {#element-handle-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.DispatchEventAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.DispatchEventAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -505,7 +505,7 @@ Assert.AreEqual(new [] { "Hello!", "Hi!" }, await feedHandle.EvalOnSelectorAllAs
 
 ### FillAsync {#element-handle-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.FillAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.FillAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -553,7 +553,7 @@ await ElementHandle.FillAsync(value, options);
 
 ### FocusAsync {#element-handle-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.FocusAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.FocusAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -577,7 +577,7 @@ await ElementHandle.FocusAsync();
 
 ### GetAttributeAsync {#element-handle-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.GetAttributeAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.GetAttributeAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -606,7 +606,7 @@ await ElementHandle.GetAttributeAsync(name);
 
 ### HoverAsync {#element-handle-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.HoverAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.HoverAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -668,7 +668,7 @@ await ElementHandle.HoverAsync(options);
 
 ### InnerHTMLAsync {#element-handle-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.InnerHTMLAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.InnerHTMLAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -692,7 +692,7 @@ await ElementHandle.InnerHTMLAsync();
 
 ### InnerTextAsync {#element-handle-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.InnerTextAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.InnerTextAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -748,7 +748,7 @@ await ElementHandle.InputValueAsync(options);
 
 ### IsCheckedAsync {#element-handle-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsCheckedAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.IsCheckedAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -772,7 +772,7 @@ await ElementHandle.IsCheckedAsync();
 
 ### IsDisabledAsync {#element-handle-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsDisabledAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.IsDisabledAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -796,7 +796,7 @@ await ElementHandle.IsDisabledAsync();
 
 ### IsEditableAsync {#element-handle-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsEditableAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.IsEditableAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -820,7 +820,7 @@ await ElementHandle.IsEditableAsync();
 
 ### IsEnabledAsync {#element-handle-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsEnabledAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.IsEnabledAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -844,7 +844,7 @@ await ElementHandle.IsEnabledAsync();
 
 ### IsHiddenAsync {#element-handle-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsHiddenAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.IsHiddenAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -868,7 +868,7 @@ await ElementHandle.IsHiddenAsync();
 
 ### IsVisibleAsync {#element-handle-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.IsVisibleAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.IsVisibleAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -892,7 +892,7 @@ await ElementHandle.IsVisibleAsync();
 
 ### PressAsync {#element-handle-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.PressAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.PressAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1006,7 +1006,7 @@ await ElementHandle.QuerySelectorAllAsync(selector);
 
 ### ScreenshotAsync {#element-handle-screenshot}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.ScreenshotAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.ScreenshotAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1076,7 +1076,7 @@ await ElementHandle.ScreenshotAsync(options);
 
 ### ScrollIntoViewIfNeededAsync {#element-handle-scroll-into-view-if-needed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.ScrollIntoViewIfNeededAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.ScrollIntoViewIfNeededAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1110,7 +1110,7 @@ await ElementHandle.ScrollIntoViewIfNeededAsync(options);
 
 ### SelectOptionAsync {#element-handle-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.SelectOptionAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.SelectOptionAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1179,7 +1179,7 @@ await handle.SelectOptionAsync(new[] {
 
 ### SelectTextAsync {#element-handle-select-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.SelectTextAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.SelectTextAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1277,7 +1277,7 @@ await ElementHandle.SetCheckedAsync(checked, options);
 
 ### SetInputFilesAsync {#element-handle-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.SetInputFilesAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.SetInputFilesAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1327,7 +1327,7 @@ await ElementHandle.SetInputFilesAsync(files, options);
 
 ### TapAsync {#element-handle-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.TapAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.TapAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1393,7 +1393,7 @@ await ElementHandle.TapAsync(options);
 
 ### TextContentAsync {#element-handle-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.TextContentAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.TextContentAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1417,7 +1417,7 @@ await ElementHandle.TextContentAsync();
 
 ### TypeAsync {#element-handle-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.TypeAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.TypeAsync</x-search>
 
 :::warning Deprecated
 
@@ -1459,7 +1459,7 @@ To press a special key, like `Control` or `ArrowDown`, use [ElementHandle.PressA
 
 ### UncheckAsync {#element-handle-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.UncheckAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.UncheckAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1520,7 +1520,7 @@ await ElementHandle.UncheckAsync(options);
 
 ### WaitForSelectorAsync {#element-handle-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.WaitForSelectorAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.WaitForSelectorAsync</x-search>
 
 :::warning[Discouraged]
 

--- a/dotnet/docs/api/class-filechooser.mdx
+++ b/dotnet/docs/api/class-filechooser.mdx
@@ -24,7 +24,7 @@ await fileChooser.SetFilesAsync("temp.txt");
 
 ### Element {#file-chooser-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.Element</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.Element</x-search>
 
 Returns input element associated with this file chooser.
 
@@ -41,7 +41,7 @@ FileChooser.Element
 
 ### IsMultiple {#file-chooser-is-multiple}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.IsMultiple</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.IsMultiple</x-search>
 
 Returns whether this file chooser accepts multiple files.
 
@@ -58,7 +58,7 @@ FileChooser.IsMultiple
 
 ### Page {#file-chooser-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.Page</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.Page</x-search>
 
 Returns page this file chooser belongs to.
 
@@ -75,7 +75,7 @@ FileChooser.Page
 
 ### SetFilesAsync {#file-chooser-set-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.SetFilesAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.SetFilesAsync</x-search>
 
 Sets the value of the file input this chooser is associated with. If some of the `filePaths` are relative paths, then they are resolved relative to the current working directory. For empty array, clears the selected files.
 

--- a/dotnet/docs/api/class-frame.mdx
+++ b/dotnet/docs/api/class-frame.mdx
@@ -49,7 +49,7 @@ class FrameExamples
 
 ### AddScriptTagAsync {#frame-add-script-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.AddScriptTagAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.AddScriptTagAsync</x-search>
 
 Returns the added tag when the script's onload fires or when the script content was injected into frame.
 
@@ -83,7 +83,7 @@ await Frame.AddScriptTagAsync(options);
 
 ### AddStyleTagAsync {#frame-add-style-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.AddStyleTagAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.AddStyleTagAsync</x-search>
 
 Returns the added tag when the stylesheet's onload fires or when the CSS content was injected into frame.
 
@@ -114,7 +114,7 @@ await Frame.AddStyleTagAsync(options);
 
 ### ChildFrames {#frame-child-frames}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.ChildFrames</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.ChildFrames</x-search>
 
 **Usage**
 
@@ -129,7 +129,7 @@ Frame.ChildFrames
 
 ### ContentAsync {#frame-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.ContentAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.ContentAsync</x-search>
 
 Gets the full HTML contents of the frame, including the doctype.
 
@@ -206,7 +206,7 @@ await Frame.DragAndDropAsync(source, target, options);
 
 ### EvaluateAsync {#frame-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.EvaluateAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.EvaluateAsync</x-search>
 
 Returns the return value of `expression`.
 
@@ -250,7 +250,7 @@ await bodyHandle.DisposeAsync();
 
 ### EvaluateHandleAsync {#frame-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.EvaluateHandleAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.EvaluateHandleAsync</x-search>
 
 Returns the return value of `expression` as a [JSHandle].
 
@@ -295,7 +295,7 @@ await resultHandle.DisposeAsync();
 
 ### FrameElementAsync {#frame-frame-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.FrameElementAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.FrameElementAsync</x-search>
 
 Returns the `frame` or `iframe` element handle which corresponds to this frame.
 
@@ -670,7 +670,7 @@ await Expect(Page.GetByTitle("Issues count")).toHaveText("25 issues");
 
 ### GotoAsync {#frame-goto}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.GotoAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.GotoAsync</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
@@ -723,7 +723,7 @@ await Frame.GotoAsync(url, options);
 
 ### IsDetached {#frame-is-detached}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsDetached</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.IsDetached</x-search>
 
 Returns `true` if the frame has been detached, or `false` otherwise.
 
@@ -740,7 +740,7 @@ Frame.IsDetached
 
 ### IsEnabledAsync {#frame-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsEnabledAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.IsEnabledAsync</x-search>
 
 Returns whether the element is [enabled](../actionability.mdx#enabled).
 
@@ -814,7 +814,7 @@ Frame.Locator(selector, options);
 
 ### Name {#frame-name}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.Name</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.Name</x-search>
 
 Returns frame's name attribute as specified in the tag.
 
@@ -837,7 +837,7 @@ Frame.Name
 
 ### Page {#frame-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.Page</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.Page</x-search>
 
 Returns the page containing this frame.
 
@@ -854,7 +854,7 @@ Frame.Page
 
 ### ParentFrame {#frame-parent-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.ParentFrame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.ParentFrame</x-search>
 
 Parent frame, if any. Detached frames and main frames return `null`.
 
@@ -871,7 +871,7 @@ Frame.ParentFrame
 
 ### SetContentAsync {#frame-set-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.SetContentAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.SetContentAsync</x-search>
 
 This method internally calls [document.write()](https://developer.mozilla.org/en-US/docs/Web/API/Document/write), inheriting all its specific characteristics and behaviors.
 
@@ -904,7 +904,7 @@ await Frame.SetContentAsync(html, options);
 
 ### TitleAsync {#frame-title}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.TitleAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.TitleAsync</x-search>
 
 Returns the page title.
 
@@ -921,7 +921,7 @@ await Frame.TitleAsync();
 
 ### Url {#frame-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.Url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.Url</x-search>
 
 Returns frame's url.
 
@@ -938,7 +938,7 @@ Frame.Url
 
 ### WaitForFunctionAsync {#frame-wait-for-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.WaitForFunctionAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.WaitForFunctionAsync</x-search>
 
 Returns when the `expression` returns a truthy value, returns that value.
 
@@ -992,7 +992,7 @@ await page.MainFrame.WaitForFunctionAsync("selector => !!document.querySelector(
 
 ### WaitForLoadStateAsync {#frame-wait-for-load-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.WaitForLoadStateAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.WaitForLoadStateAsync</x-search>
 
 Waits for the required load state to be reached.
 
@@ -1064,7 +1064,7 @@ await frame.WaitForURLAsync("**/target.html");
 
 ### CheckAsync {#frame-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.CheckAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.CheckAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1130,7 +1130,7 @@ await Frame.CheckAsync(selector, options);
 
 ### ClickAsync {#frame-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.ClickAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.ClickAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1207,7 +1207,7 @@ await Frame.ClickAsync(selector, options);
 
 ### DblClickAsync {#frame-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.DblClickAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.DblClickAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1284,7 +1284,7 @@ await Frame.DblClickAsync(selector, options);
 
 ### DispatchEventAsync {#frame-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.DispatchEventAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.DispatchEventAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1432,7 +1432,7 @@ var divsCount = await frame.EvalOnSelectorAllAsync<bool>("div", "(divs, min) => 
 
 ### FillAsync {#frame-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.FillAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.FillAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1486,7 +1486,7 @@ await Frame.FillAsync(selector, value, options);
 
 ### FocusAsync {#frame-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.FocusAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.FocusAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1522,7 +1522,7 @@ await Frame.FocusAsync(selector, options);
 
 ### GetAttributeAsync {#frame-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.GetAttributeAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.GetAttributeAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1561,7 +1561,7 @@ await Frame.GetAttributeAsync(selector, name, options);
 
 ### HoverAsync {#frame-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.HoverAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.HoverAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1628,7 +1628,7 @@ await Frame.HoverAsync(selector, options);
 
 ### InnerHTMLAsync {#frame-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.InnerHTMLAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.InnerHTMLAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1664,7 +1664,7 @@ await Frame.InnerHTMLAsync(selector, options);
 
 ### InnerTextAsync {#frame-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.InnerTextAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.InnerTextAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1738,7 +1738,7 @@ await Frame.InputValueAsync(selector, options);
 
 ### IsCheckedAsync {#frame-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsCheckedAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.IsCheckedAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1774,7 +1774,7 @@ await Frame.IsCheckedAsync(selector, options);
 
 ### IsDisabledAsync {#frame-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsDisabledAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.IsDisabledAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1810,7 +1810,7 @@ await Frame.IsDisabledAsync(selector, options);
 
 ### IsEditableAsync {#frame-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsEditableAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.IsEditableAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1846,7 +1846,7 @@ await Frame.IsEditableAsync(selector, options);
 
 ### IsHiddenAsync {#frame-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsHiddenAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.IsHiddenAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1885,7 +1885,7 @@ await Frame.IsHiddenAsync(selector, options);
 
 ### IsVisibleAsync {#frame-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.IsVisibleAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.IsVisibleAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -1924,7 +1924,7 @@ await Frame.IsVisibleAsync(selector, options);
 
 ### PressAsync {#frame-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.PressAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.PressAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -2058,7 +2058,7 @@ await Frame.QuerySelectorAllAsync(selector);
 
 ### RunAndWaitForNavigationAsync {#frame-wait-for-navigation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.RunAndWaitForNavigationAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.RunAndWaitForNavigationAsync</x-search>
 
 :::warning Deprecated
 
@@ -2113,7 +2113,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 ### WaitForNavigationAsync {#frame-wait-for-navigation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.WaitForNavigationAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.WaitForNavigationAsync</x-search>
 
 :::warning Deprecated
 
@@ -2165,7 +2165,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 ### SelectOptionAsync {#frame-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.SelectOptionAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.SelectOptionAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -2305,7 +2305,7 @@ await Frame.SetCheckedAsync(selector, checked, options);
 
 ### SetInputFilesAsync {#frame-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.SetInputFilesAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.SetInputFilesAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -2361,7 +2361,7 @@ await Frame.SetInputFilesAsync(selector, files, options);
 
 ### TapAsync {#frame-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.TapAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.TapAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -2432,7 +2432,7 @@ await Frame.TapAsync(selector, options);
 
 ### TextContentAsync {#frame-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.TextContentAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.TextContentAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -2468,7 +2468,7 @@ await Frame.TextContentAsync(selector, options);
 
 ### TypeAsync {#frame-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.TypeAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.TypeAsync</x-search>
 
 :::warning Deprecated
 
@@ -2516,7 +2516,7 @@ To press a special key, like `Control` or `ArrowDown`, use [Keyboard.PressAsync(
 
 ### UncheckAsync {#frame-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.UncheckAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.UncheckAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -2582,7 +2582,7 @@ await Frame.UncheckAsync(selector, options);
 
 ### WaitForSelectorAsync {#frame-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.WaitForSelectorAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.WaitForSelectorAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -2652,7 +2652,7 @@ class FrameExamples
 
 ### WaitForTimeoutAsync {#frame-wait-for-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.WaitForTimeoutAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.WaitForTimeoutAsync</x-search>
 
 :::warning[Discouraged]
 

--- a/dotnet/docs/api/class-jshandle.mdx
+++ b/dotnet/docs/api/class-jshandle.mdx
@@ -24,7 +24,7 @@ JSHandle instances can be used as an argument in [Page.EvalOnSelectorAsync()](/a
 
 ### AsElement {#js-handle-as-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.AsElement</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.AsElement</x-search>
 
 Returns either `null` or the object handle itself, if the object handle is an instance of [ElementHandle].
 
@@ -41,7 +41,7 @@ JsHandle.AsElement();
 
 ### DisposeAsync {#js-handle-dispose}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.DisposeAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.DisposeAsync</x-search>
 
 The `jsHandle.dispose` method stops referencing the element handle.
 
@@ -58,7 +58,7 @@ await JsHandle.DisposeAsync();
 
 ### EvaluateAsync {#js-handle-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.EvaluateAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.EvaluateAsync</x-search>
 
 Returns the return value of `expression`.
 
@@ -88,7 +88,7 @@ Assert.AreEqual("10 retweets", await tweetHandle.EvaluateAsync("node => node.inn
 
 ### EvaluateHandleAsync {#js-handle-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.EvaluateHandleAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.EvaluateHandleAsync</x-search>
 
 Returns the return value of `expression` as a [JSHandle].
 
@@ -121,7 +121,7 @@ await JsHandle.EvaluateHandleAsync(expression, arg);
 
 ### GetPropertiesAsync {#js-handle-get-properties}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.GetPropertiesAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.GetPropertiesAsync</x-search>
 
 The method returns a map with **own property names** as keys and JSHandle instances for the property values.
 
@@ -142,7 +142,7 @@ await handle.DisposeAsync();
 
 ### GetPropertyAsync {#js-handle-get-property}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.GetPropertyAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.GetPropertyAsync</x-search>
 
 Fetches a single property from the referenced object.
 
@@ -164,7 +164,7 @@ await JsHandle.GetPropertyAsync(propertyName);
 
 ### JsonValueAsync {#js-handle-json-value}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.JsonValueAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.JsonValueAsync</x-search>
 
 Returns a JSON representation of the object. If the object has a `toJSON` function, it **will not be called**.
 

--- a/dotnet/docs/api/class-keyboard.mdx
+++ b/dotnet/docs/api/class-keyboard.mdx
@@ -51,7 +51,7 @@ await page.Keyboard.PressAsync("Meta+A");
 
 ### DownAsync {#keyboard-down}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.DownAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.DownAsync</x-search>
 
 Dispatches a `keydown` event.
 
@@ -91,7 +91,7 @@ await Keyboard.DownAsync(key);
 
 ### InsertTextAsync {#keyboard-insert-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.InsertTextAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.InsertTextAsync</x-search>
 
 Dispatches only `input` event, does not emit the `keydown`, `keyup` or `keypress` events.
 
@@ -117,7 +117,7 @@ Modifier keys DO NOT effect `keyboard.insertText`. Holding down `Shift` will not
 
 ### PressAsync {#keyboard-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.PressAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.PressAsync</x-search>
 
 :::tip
 In most cases, you should use [Locator.PressAsync()](/api/class-locator.mdx#locator-press) instead.
@@ -166,7 +166,7 @@ Shortcut for [Keyboard.DownAsync()](/api/class-keyboard.mdx#keyboard-down) and [
 
 ### TypeAsync {#keyboard-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.TypeAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.TypeAsync</x-search>
 
 :::caution
 In most cases, you should use [Locator.FillAsync()](/api/class-locator.mdx#locator-fill) instead. You only need to press keys one by one if there is special keyboard handling on the page - in this case use [Locator.PressSequentiallyAsync()](/api/class-locator.mdx#locator-press-sequentially).
@@ -207,7 +207,7 @@ For characters that are not on a US keyboard, only an `input` event will be sent
 
 ### UpAsync {#keyboard-up}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.UpAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.UpAsync</x-search>
 
 Dispatches a `keyup` event.
 

--- a/dotnet/docs/api/class-mouse.mdx
+++ b/dotnet/docs/api/class-mouse.mdx
@@ -28,7 +28,7 @@ await Page.Mouse.UpAsync();
 
 ### ClickAsync {#mouse-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.ClickAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.ClickAsync</x-search>
 
 Shortcut for [Mouse.MoveAsync()](/api/class-mouse.mdx#mouse-move), [Mouse.DownAsync()](/api/class-mouse.mdx#mouse-down), [Mouse.UpAsync()](/api/class-mouse.mdx#mouse-up).
 
@@ -63,7 +63,7 @@ await Mouse.ClickAsync(x, y, options);
 
 ### DblClickAsync {#mouse-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.DblClickAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.DblClickAsync</x-search>
 
 Shortcut for [Mouse.MoveAsync()](/api/class-mouse.mdx#mouse-move), [Mouse.DownAsync()](/api/class-mouse.mdx#mouse-down), [Mouse.UpAsync()](/api/class-mouse.mdx#mouse-up), [Mouse.DownAsync()](/api/class-mouse.mdx#mouse-down) and [Mouse.UpAsync()](/api/class-mouse.mdx#mouse-up).
 
@@ -95,7 +95,7 @@ await Mouse.DblClickAsync(x, y, options);
 
 ### DownAsync {#mouse-down}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.DownAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.DownAsync</x-search>
 
 Dispatches a `mousedown` event.
 
@@ -121,7 +121,7 @@ await Mouse.DownAsync(options);
 
 ### MoveAsync {#mouse-move}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.MoveAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.MoveAsync</x-search>
 
 Dispatches a `mousemove` event.
 
@@ -150,7 +150,7 @@ await Mouse.MoveAsync(x, y, options);
 
 ### UpAsync {#mouse-up}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.UpAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.UpAsync</x-search>
 
 Dispatches a `mouseup` event.
 

--- a/dotnet/docs/api/class-page.mdx
+++ b/dotnet/docs/api/class-page.mdx
@@ -56,7 +56,7 @@ page.Load -= PageLoadHandler;
 
 ### AddInitScriptAsync {#page-add-init-script}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.AddInitScriptAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.AddInitScriptAsync</x-search>
 
 Adds a script which would be evaluated in one of the following scenarios:
 * Whenever the page is navigated.
@@ -181,7 +181,7 @@ await page.AddLocatorHandlerAsync(page.GetByText("Sign up to the newsletter"), a
 
 ### AddScriptTagAsync {#page-add-script-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.AddScriptTagAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.AddScriptTagAsync</x-search>
 
 Adds a `<script>` tag into the page with the desired url or content. Returns the added tag when the script's onload fires or when the script content was injected into frame.
 
@@ -213,7 +213,7 @@ await Page.AddScriptTagAsync(options);
 
 ### AddStyleTagAsync {#page-add-style-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.AddStyleTagAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.AddStyleTagAsync</x-search>
 
 Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<style type="text/css">` tag with the content. Returns the added tag when the stylesheet's onload fires or when the CSS content was injected into frame.
 
@@ -242,7 +242,7 @@ await Page.AddStyleTagAsync(options);
 
 ### BringToFrontAsync {#page-bring-to-front}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.BringToFrontAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.BringToFrontAsync</x-search>
 
 Brings page to front (activates tab).
 
@@ -259,7 +259,7 @@ await Page.BringToFrontAsync();
 
 ### CloseAsync {#page-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.CloseAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.CloseAsync</x-search>
 
 If `runBeforeUnload` is `false`, does not run any unload handlers and waits for the page to be closed. If `runBeforeUnload` is `true` the method will run unload handlers, but will **not** wait for the page to close.
 
@@ -291,7 +291,7 @@ await Page.CloseAsync(options);
 
 ### ContentAsync {#page-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.ContentAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.ContentAsync</x-search>
 
 Gets the full HTML contents of the page, including the doctype.
 
@@ -308,7 +308,7 @@ await Page.ContentAsync();
 
 ### Context {#page-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.Context</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.Context</x-search>
 
 Get the browser context that the page belongs to.
 
@@ -393,7 +393,7 @@ await Page.DragAndDropAsync("#source", "#target", new()
 
 ### EmulateMediaAsync {#page-emulate-media}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.EmulateMediaAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.EmulateMediaAsync</x-search>
 
 This method changes the `CSS media type` through the `media` argument, and/or the `'prefers-colors-scheme'` media feature, using the `colorScheme` argument.
 
@@ -448,7 +448,7 @@ await page.EvaluateAsync("matchMedia('(prefers-color-scheme: no-preference)').ma
 
 ### EvaluateAsync {#page-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.EvaluateAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.EvaluateAsync</x-search>
 
 Returns the value of the `expression` invocation.
 
@@ -494,7 +494,7 @@ await bodyHandle.DisposeAsync();
 
 ### EvaluateHandleAsync {#page-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.EvaluateHandleAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.EvaluateHandleAsync</x-search>
 
 Returns the value of the `expression` invocation as a [JSHandle].
 
@@ -539,7 +539,7 @@ await resultHandle.DisposeAsync();
 
 ### ExposeBindingAsync {#page-expose-binding}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.ExposeBindingAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.ExposeBindingAsync</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in this page. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`. If the `callback` returns a [Promise], it will be awaited.
 
@@ -608,7 +608,7 @@ class PageExamples
 
 ### ExposeFunctionAsync {#page-expose-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.ExposeFunctionAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.ExposeFunctionAsync</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in the page. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`.
 
@@ -676,7 +676,7 @@ class PageExamples
 
 ### Frame {#page-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.Frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.Frame</x-search>
 
 Returns frame matching the specified criteria. Either `name` or `url` must be specified.
 
@@ -749,7 +749,7 @@ await locator.ClickAsync();
 
 ### Frames {#page-frames}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.Frames</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.Frames</x-search>
 
 An array of all frames attached to the page.
 
@@ -1093,7 +1093,7 @@ await Expect(Page.GetByTitle("Issues count")).toHaveText("25 issues");
 
 ### GoBackAsync {#page-go-back}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.GoBackAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.GoBackAsync</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. If cannot go back, returns `null`.
 
@@ -1125,7 +1125,7 @@ await Page.GoBackAsync(options);
 
 ### GoForwardAsync {#page-go-forward}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.GoForwardAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.GoForwardAsync</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. If cannot go forward, returns `null`.
 
@@ -1157,7 +1157,7 @@ await Page.GoForwardAsync(options);
 
 ### GotoAsync {#page-goto}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.GotoAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.GotoAsync</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the first non-redirect response.
 
@@ -1210,7 +1210,7 @@ await Page.GotoAsync(url, options);
 
 ### IsClosed {#page-is-closed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsClosed</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.IsClosed</x-search>
 
 Indicates that the page has been closed.
 
@@ -1270,7 +1270,7 @@ Page.Locator(selector, options);
 
 ### MainFrame {#page-main-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.MainFrame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.MainFrame</x-search>
 
 The page's main frame. Page is guaranteed to have a main frame which persists during navigations.
 
@@ -1287,7 +1287,7 @@ Page.MainFrame
 
 ### OpenerAsync {#page-opener}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.OpenerAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.OpenerAsync</x-search>
 
 Returns the opener for popup pages and `null` for others. If the opener has been closed already the returns `null`.
 
@@ -1327,7 +1327,7 @@ await Page.PauseAsync();
 
 ### PdfAsync {#page-pdf}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.PdfAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.PdfAsync</x-search>
 
 Returns the PDF buffer.
 
@@ -1451,7 +1451,7 @@ The `format` options are:
 
 ### ReloadAsync {#page-reload}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.ReloadAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.ReloadAsync</x-search>
 
 This method reloads the current page, in the same way as if the user had triggered a browser refresh. Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
@@ -1503,7 +1503,7 @@ await Page.RemoveLocatorHandlerAsync(locator);
 
 ### RouteAsync {#page-route}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.RouteAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.RouteAsync</x-search>
 
 Routing provides the capability to modify network requests that are made by a page.
 
@@ -1840,7 +1840,7 @@ await Page.WaitForPopupAsync(action, options);
 
 ### RunAndWaitForRequestAsync {#page-wait-for-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.RunAndWaitForRequestAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.RunAndWaitForRequestAsync</x-search>
 
 Waits for the matching request and returns it. See [waiting for event](../events.mdx#waiting-for-event) for more details about events.
 
@@ -1879,7 +1879,7 @@ await page.RunAndWaitForRequestAsync(async () =>
 
 ### WaitForRequestAsync {#page-wait-for-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.WaitForRequestAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.WaitForRequestAsync</x-search>
 
 Waits for the matching request and returns it. See [waiting for event](../events.mdx#waiting-for-event) for more details about events.
 
@@ -1970,7 +1970,7 @@ await Page.WaitForRequestFinishedAsync(action, options);
 
 ### RunAndWaitForResponseAsync {#page-wait-for-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.RunAndWaitForResponseAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.RunAndWaitForResponseAsync</x-search>
 
 Returns the matched response. See [waiting for event](../events.mdx#waiting-for-event) for more details about events.
 
@@ -2009,7 +2009,7 @@ await page.RunAndWaitForResponseAsync(async () =>
 
 ### WaitForResponseAsync {#page-wait-for-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.WaitForResponseAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.WaitForResponseAsync</x-search>
 
 Returns the matched response. See [waiting for event](../events.mdx#waiting-for-event) for more details about events.
 
@@ -2155,7 +2155,7 @@ await Page.WaitForWorkerAsync(action, options);
 
 ### ScreenshotAsync {#page-screenshot}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.ScreenshotAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.ScreenshotAsync</x-search>
 
 Returns the buffer with the captured screenshot.
 
@@ -2232,7 +2232,7 @@ await Page.ScreenshotAsync(options);
 
 ### SetContentAsync {#page-set-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.SetContentAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.SetContentAsync</x-search>
 
 This method internally calls [document.write()](https://developer.mozilla.org/en-US/docs/Web/API/Document/write), inheriting all its specific characteristics and behaviors.
 
@@ -2265,7 +2265,7 @@ await Page.SetContentAsync(html, options);
 
 ### SetDefaultNavigationTimeout {#page-set-default-navigation-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.SetDefaultNavigationTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.SetDefaultNavigationTimeout</x-search>
 
 This setting will change the default maximum navigation time for the following methods and related shortcuts:
 * [Page.GoBackAsync()](/api/class-page.mdx#page-go-back)
@@ -2295,7 +2295,7 @@ Page.SetDefaultNavigationTimeout(timeout);
 
 ### SetDefaultTimeout {#page-set-default-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.SetDefaultTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.SetDefaultTimeout</x-search>
 
 This setting will change the default maximum time for all the methods accepting `timeout` option.
 
@@ -2318,7 +2318,7 @@ Page.SetDefaultTimeout(timeout);
 
 ### SetExtraHTTPHeadersAsync {#page-set-extra-http-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.SetExtraHTTPHeadersAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.SetExtraHTTPHeadersAsync</x-search>
 
 The extra HTTP headers will be sent with every request the page initiates.
 
@@ -2344,7 +2344,7 @@ await Page.SetExtraHTTPHeadersAsync(headers);
 
 ### SetViewportSizeAsync {#page-set-viewport-size}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.SetViewportSizeAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.SetViewportSizeAsync</x-search>
 
 In the case of multiple pages in a single browser, each page can have its own viewport size. However, [Browser.NewContextAsync()](/api/class-browser.mdx#browser-new-context) allows to set viewport size (and more) for all pages in the context at once.
 
@@ -2369,7 +2369,7 @@ await page.GotoAsync("https://www.microsoft.com");
 
 ### TitleAsync {#page-title}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.TitleAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.TitleAsync</x-search>
 
 Returns the page's title.
 
@@ -2386,7 +2386,7 @@ await Page.TitleAsync();
 
 ### UnrouteAsync {#page-unroute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.UnrouteAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.UnrouteAsync</x-search>
 
 Removes a route created with [Page.RouteAsync()](/api/class-page.mdx#page-route). When `handler` is not specified, removes all routes for the `url`.
 
@@ -2437,7 +2437,7 @@ await Page.UnrouteAllAsync(options);
 
 ### Url {#page-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.Url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.Url</x-search>
 
 **Usage**
 
@@ -2452,7 +2452,7 @@ Page.Url
 
 ### Video {#page-video}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.Video</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.Video</x-search>
 
 Video object associated with this page.
 
@@ -2469,7 +2469,7 @@ Page.Video
 
 ### ViewportSize {#page-viewport-size}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.ViewportSize</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.ViewportSize</x-search>
 
 **Usage**
 
@@ -2490,7 +2490,7 @@ Page.ViewportSize
 
 ### WaitForFunctionAsync {#page-wait-for-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.WaitForFunctionAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.WaitForFunctionAsync</x-search>
 
 Returns when the `expression` returns a truthy value. It resolves to a JSHandle of the truthy value.
 
@@ -2544,7 +2544,7 @@ await page.WaitForFunctionAsync("selector => !!document.querySelector(selector)"
 
 ### WaitForLoadStateAsync {#page-wait-for-load-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.WaitForLoadStateAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.WaitForLoadStateAsync</x-search>
 
 Returns when the required load state has been reached.
 
@@ -2624,7 +2624,7 @@ await page.WaitForURLAsync("**/target.html");
 
 ### Workers {#page-workers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.Workers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.Workers</x-search>
 
 This method returns all of the dedicated [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) associated with the page.
 
@@ -2681,7 +2681,7 @@ Page.Clock
 
 ### Keyboard {#page-keyboard}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.Keyboard</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.Keyboard</x-search>
 
 **Usage**
 
@@ -2696,7 +2696,7 @@ Page.Keyboard
 
 ### Mouse {#page-mouse}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.Mouse</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.Mouse</x-search>
 
 **Usage**
 
@@ -2711,7 +2711,7 @@ Page.Mouse
 
 ### Touchscreen {#page-touchscreen}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.Touchscreen</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.Touchscreen</x-search>
 
 **Usage**
 
@@ -2728,7 +2728,7 @@ Page.Touchscreen
 
 ### event Close {#page-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.event Close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.event Close</x-search>
 
 Emitted when the page closes.
 
@@ -2745,7 +2745,7 @@ Page.Close += async (_, page) => {};
 
 ### event Console {#page-event-console}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.event Console</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.event Console</x-search>
 
 Emitted when JavaScript within the page calls one of console API methods, e.g. `console.log` or `console.dir`.
 
@@ -2770,7 +2770,7 @@ await page.EvaluateAsync("console.log('hello', 5, { foo: 'bar' })");
 
 ### event Crash {#page-event-crash}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.event Crash</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.event Crash</x-search>
 
 Emitted when the page crashes. Browser pages might crash if they try to allocate too much memory. When the page crashes, ongoing and subsequent operations will throw.
 
@@ -2800,7 +2800,7 @@ Page.Crash += async (_, page) => {};
 
 ### event Dialog {#page-event-dialog}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.event Dialog</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.event Dialog</x-search>
 
 Emitted when a JavaScript dialog appears, such as `alert`, `prompt`, `confirm` or `beforeunload`. Listener **must** either [Dialog.AcceptAsync()](/api/class-dialog.mdx#dialog-accept) or [Dialog.DismissAsync()](/api/class-dialog.mdx#dialog-dismiss) the dialog - otherwise the page will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the dialog, and actions like click will never finish.
 
@@ -2841,7 +2841,7 @@ Page.DOMContentLoaded += async (_, page) => {};
 
 ### event Download {#page-event-download}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.event Download</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.event Download</x-search>
 
 Emitted when attachment download started. User can access basic file operations on downloaded content via the passed [Download] instance.
 
@@ -2933,7 +2933,7 @@ Page.FrameNavigated += async (_, frame) => {};
 
 ### event Load {#page-event-load}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.event Load</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.event Load</x-search>
 
 Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched.
 
@@ -2975,7 +2975,7 @@ Page.PageError += async (_, value) => {};
 
 ### event Popup {#page-event-popup}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.event Popup</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.event Popup</x-search>
 
 Emitted when the page opens a new tab or window. This event is emitted in addition to the [BrowserContext.Page](/api/class-browsercontext.mdx#browser-context-event-page), but only for popups relevant to this page.
 
@@ -3006,7 +3006,7 @@ Page.Popup += async (_, page) => {};
 
 ### event Request {#page-event-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.event Request</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.event Request</x-search>
 
 Emitted when a page issues a request. The [request] object is read-only. In order to intercept and mutate requests, see [Page.RouteAsync()](/api/class-page.mdx#page-route) or [BrowserContext.RouteAsync()](/api/class-browsercontext.mdx#browser-context-route).
 
@@ -3061,7 +3061,7 @@ Page.RequestFinished += async (_, request) => {};
 
 ### event Response {#page-event-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.event Response</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.event Response</x-search>
 
 Emitted when [response] status and headers are received for a request. For a successful response, the sequence of events is `request`, `response` and `requestfinished`.
 
@@ -3095,7 +3095,7 @@ Page.WebSocket += async (_, webSocket) => {};
 
 ### event Worker {#page-event-worker}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.event Worker</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.event Worker</x-search>
 
 Emitted when a dedicated [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) is spawned by the page.
 
@@ -3114,7 +3114,7 @@ Page.Worker += async (_, worker) => {};
 
 ### Accessibility {#page-accessibility}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.Accessibility</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.Accessibility</x-search>
 
 :::warning Deprecated
 
@@ -3136,7 +3136,7 @@ Page.Accessibility
 
 ### CheckAsync {#page-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.CheckAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.CheckAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3202,7 +3202,7 @@ await Page.CheckAsync(selector, options);
 
 ### ClickAsync {#page-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.ClickAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.ClickAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3279,7 +3279,7 @@ await Page.ClickAsync(selector, options);
 
 ### DblClickAsync {#page-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.DblClickAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.DblClickAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3356,7 +3356,7 @@ await Page.DblClickAsync(selector, options);
 
 ### DispatchEventAsync {#page-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.DispatchEventAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.DispatchEventAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3499,7 +3499,7 @@ var divsCount = await page.EvalOnSelectorAllAsync<bool>("div", "(divs, min) => d
 
 ### FillAsync {#page-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.FillAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.FillAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3553,7 +3553,7 @@ await Page.FillAsync(selector, value, options);
 
 ### FocusAsync {#page-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.FocusAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.FocusAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3589,7 +3589,7 @@ await Page.FocusAsync(selector, options);
 
 ### GetAttributeAsync {#page-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.GetAttributeAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.GetAttributeAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3628,7 +3628,7 @@ await Page.GetAttributeAsync(selector, name, options);
 
 ### HoverAsync {#page-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.HoverAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.HoverAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3695,7 +3695,7 @@ await Page.HoverAsync(selector, options);
 
 ### InnerHTMLAsync {#page-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.InnerHTMLAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.InnerHTMLAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3731,7 +3731,7 @@ await Page.InnerHTMLAsync(selector, options);
 
 ### InnerTextAsync {#page-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.InnerTextAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.InnerTextAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3805,7 +3805,7 @@ await Page.InputValueAsync(selector, options);
 
 ### IsCheckedAsync {#page-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsCheckedAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.IsCheckedAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3841,7 +3841,7 @@ await Page.IsCheckedAsync(selector, options);
 
 ### IsDisabledAsync {#page-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsDisabledAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.IsDisabledAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3877,7 +3877,7 @@ await Page.IsDisabledAsync(selector, options);
 
 ### IsEditableAsync {#page-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsEditableAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.IsEditableAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3913,7 +3913,7 @@ await Page.IsEditableAsync(selector, options);
 
 ### IsEnabledAsync {#page-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsEnabledAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.IsEnabledAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3949,7 +3949,7 @@ await Page.IsEnabledAsync(selector, options);
 
 ### IsHiddenAsync {#page-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsHiddenAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.IsHiddenAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -3988,7 +3988,7 @@ await Page.IsHiddenAsync(selector, options);
 
 ### IsVisibleAsync {#page-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.IsVisibleAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.IsVisibleAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -4027,7 +4027,7 @@ await Page.IsVisibleAsync(selector, options);
 
 ### PressAsync {#page-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.PressAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.PressAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -4158,7 +4158,7 @@ await Page.QuerySelectorAllAsync(selector);
 
 ### RunAndWaitForNavigationAsync {#page-wait-for-navigation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.RunAndWaitForNavigationAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.RunAndWaitForNavigationAsync</x-search>
 
 :::warning Deprecated
 
@@ -4213,7 +4213,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 ### WaitForNavigationAsync {#page-wait-for-navigation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.WaitForNavigationAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.WaitForNavigationAsync</x-search>
 
 :::warning Deprecated
 
@@ -4265,7 +4265,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 ### SelectOptionAsync {#page-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.SelectOptionAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.SelectOptionAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -4405,7 +4405,7 @@ await Page.SetCheckedAsync(selector, checked, options);
 
 ### SetInputFilesAsync {#page-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.SetInputFilesAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.SetInputFilesAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -4461,7 +4461,7 @@ await Page.SetInputFilesAsync(selector, files, options);
 
 ### TapAsync {#page-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.TapAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.TapAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -4532,7 +4532,7 @@ await Page.TapAsync(selector, options);
 
 ### TextContentAsync {#page-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.TextContentAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.TextContentAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -4568,7 +4568,7 @@ await Page.TextContentAsync(selector, options);
 
 ### TypeAsync {#page-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.TypeAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.TypeAsync</x-search>
 
 :::warning Deprecated
 
@@ -4616,7 +4616,7 @@ To press a special key, like `Control` or `ArrowDown`, use [Keyboard.PressAsync(
 
 ### UncheckAsync {#page-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.UncheckAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.UncheckAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -4682,7 +4682,7 @@ await Page.UncheckAsync(selector, options);
 
 ### WaitForSelectorAsync {#page-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.WaitForSelectorAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.WaitForSelectorAsync</x-search>
 
 :::warning[Discouraged]
 
@@ -4754,7 +4754,7 @@ class FrameExamples
 
 ### WaitForTimeoutAsync {#page-wait-for-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.WaitForTimeoutAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.WaitForTimeoutAsync</x-search>
 
 :::warning[Discouraged]
 

--- a/dotnet/docs/api/class-playwright.mdx
+++ b/dotnet/docs/api/class-playwright.mdx
@@ -51,7 +51,7 @@ Playwright.APIRequest
 
 ### Chromium {#playwright-chromium}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.Chromium</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.Chromium</x-search>
 
 This object can be used to launch or connect to Chromium, returning instances of [Browser].
 
@@ -68,7 +68,7 @@ Playwright.Chromium
 
 ### Devices {#playwright-devices}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.Devices</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.Devices</x-search>
 
 Returns a dictionary of devices to be used with [Browser.NewContextAsync()](/api/class-browser.mdx#browser-new-context) or [Browser.NewPageAsync()](/api/class-browser.mdx#browser-new-page).
 
@@ -104,7 +104,7 @@ Playwright.Devices
 
 ### Firefox {#playwright-firefox}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.Firefox</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.Firefox</x-search>
 
 This object can be used to launch or connect to Firefox, returning instances of [Browser].
 
@@ -121,7 +121,7 @@ Playwright.Firefox
 
 ### Selectors {#playwright-selectors}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.Selectors</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.Selectors</x-search>
 
 Selectors can be used to install custom selector engines. See [extensibility](../extensibility.mdx) for more information.
 
@@ -138,7 +138,7 @@ Playwright.Selectors
 
 ### Webkit {#playwright-webkit}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.Webkit</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.Webkit</x-search>
 
 This object can be used to launch or connect to WebKit, returning instances of [Browser].
 

--- a/dotnet/docs/api/class-request.mdx
+++ b/dotnet/docs/api/class-request.mdx
@@ -44,7 +44,7 @@ await Request.AllHeadersAsync();
 
 ### Failure {#request-failure}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.Failure</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.Failure</x-search>
 
 The method returns `null` unless this request has failed, as reported by `requestfailed` event.
 
@@ -66,7 +66,7 @@ page.RequestFailed += (_, request) =>
 
 ### Frame {#request-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.Frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.Frame</x-search>
 
 Returns the [Frame] that initiated this request.
 
@@ -113,7 +113,7 @@ await Request.HeaderValueAsync(name);
 
 ### Headers {#request-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.Headers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.Headers</x-search>
 
 An object with the request HTTP headers. The header names are lower-cased. Note that this method does not return security-related headers, including cookie-related ones. You can use [Request.AllHeadersAsync()](/api/class-request.mdx#request-all-headers) for complete list of headers that include `cookie` information.
 
@@ -153,7 +153,7 @@ await Request.HeadersArrayAsync();
 
 ### IsNavigationRequest {#request-is-navigation-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.IsNavigationRequest</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.IsNavigationRequest</x-search>
 
 Whether this request is driving frame's navigation.
 
@@ -172,7 +172,7 @@ Request.IsNavigationRequest
 
 ### Method {#request-method}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.Method</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.Method</x-search>
 
 Request's method (GET, POST, etc.)
 
@@ -189,7 +189,7 @@ Request.Method
 
 ### PostData {#request-post-data}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.PostData</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.PostData</x-search>
 
 Request's post body, if any.
 
@@ -206,7 +206,7 @@ Request.PostData
 
 ### PostDataBuffer {#request-post-data-buffer}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.PostDataBuffer</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.PostDataBuffer</x-search>
 
 Request's post body in a binary form, if any.
 
@@ -242,7 +242,7 @@ Request.PostDataJSON
 
 ### RedirectedFrom {#request-redirected-from}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.RedirectedFrom</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.RedirectedFrom</x-search>
 
 Request that was redirected by the server to this one, if any.
 
@@ -271,7 +271,7 @@ Console.WriteLine(response.Request.RedirectedFrom?.Url); // null
 
 ### RedirectedTo {#request-redirected-to}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.RedirectedTo</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.RedirectedTo</x-search>
 
 New request issued by the browser if the server responded with redirect.
 
@@ -290,7 +290,7 @@ Console.WriteLine(request.RedirectedFrom?.RedirectedTo == request); // True
 
 ### ResourceType {#request-resource-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.ResourceType</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.ResourceType</x-search>
 
 Contains the request's resource type as it was perceived by the rendering engine. ResourceType will be one of the following: `document`, `stylesheet`, `image`, `media`, `font`, `script`, `texttrack`, `xhr`, `fetch`, `eventsource`, `websocket`, `manifest`, `other`.
 
@@ -307,7 +307,7 @@ Request.ResourceType
 
 ### ResponseAsync {#request-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.ResponseAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.ResponseAsync</x-search>
 
 Returns the matching [Response] object, or `null` if the response was not received due to error.
 
@@ -353,7 +353,7 @@ await Request.SizesAsync();
 
 ### Timing {#request-timing}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.Timing</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.Timing</x-search>
 
 Returns resource timing information for given request. Most of the timing values become available upon the response, `responseEnd` becomes available when request finishes. Find more information at [Resource Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming).
 
@@ -401,7 +401,7 @@ Console.WriteLine(request.Timing.ResponseEnd);
 
 ### Url {#request-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.Url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.Url</x-search>
 
 URL of the request.
 

--- a/dotnet/docs/api/class-response.mdx
+++ b/dotnet/docs/api/class-response.mdx
@@ -33,7 +33,7 @@ await Response.AllHeadersAsync();
 
 ### BodyAsync {#response-body}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.BodyAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.BodyAsync</x-search>
 
 Returns the buffer with response body.
 
@@ -50,7 +50,7 @@ await Response.BodyAsync();
 
 ### FinishedAsync {#response-finished}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.FinishedAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.FinishedAsync</x-search>
 
 Waits for this response to finish, returns always `null`.
 
@@ -67,7 +67,7 @@ await Response.FinishedAsync();
 
 ### Frame {#response-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.Frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.Frame</x-search>
 
 Returns the [Frame] that initiated this response.
 
@@ -145,7 +145,7 @@ await Response.HeaderValuesAsync(name);
 
 ### Headers {#response-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.Headers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.Headers</x-search>
 
 An object with the response HTTP headers. The header names are lower-cased. Note that this method does not return security-related headers, including cookie-related ones. You can use [Response.AllHeadersAsync()](/api/class-response.mdx#response-all-headers) for complete list of headers that include `cookie` information.
 
@@ -185,7 +185,7 @@ await Response.HeadersArrayAsync();
 
 ### JsonAsync {#response-json}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.JsonAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.JsonAsync</x-search>
 
 Returns the JSON representation of response body.
 
@@ -204,7 +204,7 @@ await Response.JsonAsync();
 
 ### Ok {#response-ok}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.Ok</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.Ok</x-search>
 
 Contains a boolean stating whether the response was successful (status in the range 200-299) or not.
 
@@ -221,7 +221,7 @@ Response.Ok
 
 ### Request {#response-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.Request</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.Request</x-search>
 
 Returns the matching [Request] object.
 
@@ -292,7 +292,7 @@ await Response.ServerAddrAsync();
 
 ### Status {#response-status}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.Status</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.Status</x-search>
 
 Contains the status code of the response (e.g., 200 for a success).
 
@@ -309,7 +309,7 @@ Response.Status
 
 ### StatusText {#response-status-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.StatusText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.StatusText</x-search>
 
 Contains the status text of the response (e.g. usually an "OK" for a success).
 
@@ -326,7 +326,7 @@ Response.StatusText
 
 ### TextAsync {#response-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.TextAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.TextAsync</x-search>
 
 Returns the text representation of response body.
 
@@ -343,7 +343,7 @@ await Response.TextAsync();
 
 ### Url {#response-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.Url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.Url</x-search>
 
 Contains the URL of the response.
 

--- a/dotnet/docs/api/class-route.mdx
+++ b/dotnet/docs/api/class-route.mdx
@@ -18,7 +18,7 @@ Learn more about [networking](../network.mdx).
 
 ### AbortAsync {#route-abort}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.AbortAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.AbortAsync</x-search>
 
 Aborts the route's request.
 
@@ -54,7 +54,7 @@ await Route.AbortAsync(errorCode);
 
 ### ContinueAsync {#route-continue}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.ContinueAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.ContinueAsync</x-search>
 
 Continues route's request with optional overrides.
 
@@ -226,7 +226,7 @@ Note that `headers` option will apply to the fetched request as well as any redi
 
 ### FulfillAsync {#route-fulfill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.FulfillAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.FulfillAsync</x-search>
 
 Fulfills route's request with given response.
 
@@ -283,7 +283,7 @@ await page.RouteAsync("**/xhr_endpoint", route => route.FulfillAsync(new() { Pat
 
 ### Request {#route-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.Request</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.Request</x-search>
 
 A request to be routed.
 

--- a/dotnet/docs/api/class-selectors.mdx
+++ b/dotnet/docs/api/class-selectors.mdx
@@ -16,7 +16,7 @@ Selectors can be used to install custom selector engines. See [extensibility](..
 
 ### RegisterAsync {#selectors-register}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>selectors.RegisterAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>selectors.RegisterAsync</x-search>
 
 Selectors must be registered before creating the page.
 

--- a/dotnet/docs/api/class-touchscreen.mdx
+++ b/dotnet/docs/api/class-touchscreen.mdx
@@ -16,7 +16,7 @@ The Touchscreen class operates in main-frame CSS pixels relative to the top-left
 
 ### TapAsync {#touchscreen-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>touchscreen.TapAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>touchscreen.TapAsync</x-search>
 
 Dispatches a `touchstart` and `touchend` event with a single touch at the position (`x`,`y`).
 

--- a/dotnet/docs/api/class-video.mdx
+++ b/dotnet/docs/api/class-video.mdx
@@ -37,7 +37,7 @@ await Video.DeleteAsync();
 
 ### PathAsync {#video-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>video.PathAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>video.PathAsync</x-search>
 
 Returns the file system path this video will be recorded to. The video is guaranteed to be written to the filesystem upon closing the browser context. This method throws when connected remotely.
 

--- a/dotnet/docs/api/class-websocket.mdx
+++ b/dotnet/docs/api/class-websocket.mdx
@@ -16,7 +16,7 @@ The [WebSocket] class represents websocket connections in the page.
 
 ### IsClosed {#web-socket-is-closed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.IsClosed</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.IsClosed</x-search>
 
 Indicates that the web socket has been closed.
 
@@ -33,7 +33,7 @@ WebSocket.IsClosed
 
 ### Url {#web-socket-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.Url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.Url</x-search>
 
 Contains the URL of the WebSocket.
 
@@ -52,7 +52,7 @@ WebSocket.Url
 
 ### event Close {#web-socket-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.event Close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.event Close</x-search>
 
 Fired when the websocket closes.
 

--- a/dotnet/docs/api/class-worker.mdx
+++ b/dotnet/docs/api/class-worker.mdx
@@ -30,7 +30,7 @@ foreach(var pageWorker in page.Workers)
 
 ### EvaluateAsync {#worker-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.EvaluateAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.EvaluateAsync</x-search>
 
 Returns the return value of `expression`.
 
@@ -59,7 +59,7 @@ await Worker.EvaluateAsync(expression, arg);
 
 ### EvaluateHandleAsync {#worker-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.EvaluateHandleAsync</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.EvaluateHandleAsync</x-search>
 
 Returns the return value of `expression` as a [JSHandle].
 
@@ -88,7 +88,7 @@ await Worker.EvaluateHandleAsync(expression, arg);
 
 ### Url {#worker-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.Url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.Url</x-search>
 
 **Usage**
 
@@ -105,7 +105,7 @@ Worker.Url
 
 ### event Close {#worker-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.event Close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.event Close</x-search>
 
 Emitted when this dedicated [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) is terminated.
 

--- a/java/docs/api/class-browser.mdx
+++ b/java/docs/api/class-browser.mdx
@@ -49,7 +49,7 @@ Browser.browserType();
 
 ### close {#browser-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.close</x-search>
 
 In case this browser is obtained using [BrowserType.launch()](/api/class-browsertype.mdx#browser-type-launch), closes the browser and all of its pages (if any were opened).
 
@@ -81,7 +81,7 @@ Browser.close(options);
 
 ### contexts {#browser-contexts}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.contexts</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.contexts</x-search>
 
 Returns an array of all open browser contexts. In a newly created browser, this will return zero browser contexts.
 
@@ -101,7 +101,7 @@ System.out.println(browser.contexts().size()); // prints "1"
 
 ### isConnected {#browser-is-connected}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.isConnected</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.isConnected</x-search>
 
 Indicates that the browser is connected.
 
@@ -139,7 +139,7 @@ Browser.newBrowserCDPSession();
 
 ### newContext {#browser-new-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.newContext</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.newContext</x-search>
 
 Creates a new browser context. It won't share cookies/cache with other browser contexts.
 
@@ -363,7 +363,7 @@ browser.close();
 
 ### newPage {#browser-new-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.newPage</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.newPage</x-search>
 
 Creates a new page in a new browser context. Closing this page will close the context as well.
 
@@ -637,7 +637,7 @@ Browser.stopTracing();
 
 ### version {#browser-version}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.version</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.version</x-search>
 
 Returns the browser version.
 
@@ -656,7 +656,7 @@ Browser.version();
 
 ### onDisconnected(handler) {#browser-event-disconnected}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.onDisconnected(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.onDisconnected(handler)</x-search>
 
 Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
 * Browser application is closed or crashed.

--- a/java/docs/api/class-browsercontext.mdx
+++ b/java/docs/api/class-browsercontext.mdx
@@ -30,7 +30,7 @@ context.close();
 
 ### addCookies {#browser-context-add-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.addCookies</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.addCookies</x-search>
 
 Adds cookies into this browser context. All pages within this context will have these cookies installed. Cookies can be obtained via [BrowserContext.cookies()](/api/class-browsercontext.mdx#browser-context-cookies).
 
@@ -77,7 +77,7 @@ browserContext.addCookies(Arrays.asList(cookieObject1, cookieObject2));
 
 ### addInitScript {#browser-context-add-init-script}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.addInitScript</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.addInitScript</x-search>
 
 Adds a script which would be evaluated in one of the following scenarios:
 * Whenever a page is created in the browser context or is navigated.
@@ -136,7 +136,7 @@ BrowserContext.backgroundPages();
 
 ### browser {#browser-context-browser}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.browser</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.browser</x-search>
 
 Returns the browser instance of the context. If it was launched as a persistent context null gets returned.
 
@@ -153,7 +153,7 @@ BrowserContext.browser();
 
 ### clearCookies {#browser-context-clear-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.clearCookies</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.clearCookies</x-search>
 
 Removes cookies from context. Accepts optional filter.
 
@@ -188,7 +188,7 @@ context.clearCookies(new BrowserContext.ClearCookiesOptions()
 
 ### clearPermissions {#browser-context-clear-permissions}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.clearPermissions</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.clearPermissions</x-search>
 
 Clears all permission overrides for the browser context.
 
@@ -208,7 +208,7 @@ context.clearPermissions();
 
 ### close {#browser-context-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.close</x-search>
 
 Closes the browser context. All the pages that belong to the browser context will be closed.
 
@@ -236,7 +236,7 @@ BrowserContext.close(options);
 
 ### cookies {#browser-context-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.cookies</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.cookies</x-search>
 
 If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those URLs are returned.
 
@@ -282,7 +282,7 @@ BrowserContext.cookies(urls);
 
 ### exposeBinding {#browser-context-expose-binding}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.exposeBinding</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.exposeBinding</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in every page in the context. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`. If the `callback` returns a [Promise], it will be awaited.
 
@@ -342,7 +342,7 @@ public class Example {
 
 ### exposeFunction {#browser-context-expose-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.exposeFunction</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.exposeFunction</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in every page in the context. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`.
 
@@ -407,7 +407,7 @@ public class Example {
 
 ### grantPermissions {#browser-context-grant-permissions}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.grantPermissions</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.grantPermissions</x-search>
 
 Grants specified permissions to the browser context. Only grants corresponding permissions to the given origin if specified.
 
@@ -476,7 +476,7 @@ BrowserContext.newCDPSession(page);
 
 ### newPage {#browser-context-new-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.newPage</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.newPage</x-search>
 
 Creates a new page in the browser context.
 
@@ -493,7 +493,7 @@ BrowserContext.newPage();
 
 ### pages {#browser-context-pages}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.pages</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.pages</x-search>
 
 Returns all open pages in the context.
 
@@ -510,7 +510,7 @@ BrowserContext.pages();
 
 ### route {#browser-context-route}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.route</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.route</x-search>
 
 Routing provides the capability to modify network requests that are made by any page in the browser context. Once route is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
 
@@ -621,7 +621,7 @@ BrowserContext.routeFromHAR(har, options);
 
 ### setDefaultNavigationTimeout {#browser-context-set-default-navigation-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setDefaultNavigationTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.setDefaultNavigationTimeout</x-search>
 
 This setting will change the default maximum navigation time for the following methods and related shortcuts:
 * [Page.goBack()](/api/class-page.mdx#page-go-back)
@@ -650,7 +650,7 @@ BrowserContext.setDefaultNavigationTimeout(timeout);
 
 ### setDefaultTimeout {#browser-context-set-default-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setDefaultTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.setDefaultTimeout</x-search>
 
 This setting will change the default maximum time for all the methods accepting `timeout` option.
 
@@ -673,7 +673,7 @@ BrowserContext.setDefaultTimeout(timeout);
 
 ### setExtraHTTPHeaders {#browser-context-set-extra-http-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setExtraHTTPHeaders</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.setExtraHTTPHeaders</x-search>
 
 The extra HTTP headers will be sent with every request initiated by any page in the context. These headers are merged with page-specific extra HTTP headers set with [Page.setExtraHTTPHeaders()](/api/class-page.mdx#page-set-extra-http-headers). If page overrides a particular header, page-specific header value will be used instead of the browser context header value.
 
@@ -699,7 +699,7 @@ BrowserContext.setExtraHTTPHeaders(headers);
 
 ### setGeolocation {#browser-context-set-geolocation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setGeolocation</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.setGeolocation</x-search>
 
 Sets the context's geolocation. Passing `null` or `undefined` emulates position unavailable.
 
@@ -732,7 +732,7 @@ Consider using [BrowserContext.grantPermissions()](/api/class-browsercontext.mdx
 
 ### setOffline {#browser-context-set-offline}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setOffline</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.setOffline</x-search>
 
 **Usage**
 
@@ -752,7 +752,7 @@ BrowserContext.setOffline(offline);
 
 ### storageState {#browser-context-storage-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.storageState</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.storageState</x-search>
 
 Returns storage state for this browser context, contains current cookies and local storage snapshot.
 
@@ -776,7 +776,7 @@ BrowserContext.storageState(options);
 
 ### unroute {#browser-context-unroute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.unroute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.unroute</x-search>
 
 Removes a route created with [BrowserContext.route()](/api/class-browsercontext.mdx#browser-context-route). When `handler` is not specified, removes all routes for the `url`.
 
@@ -995,7 +995,7 @@ BrowserContext.onBackgroundPage(handler)
 
 ### onClose(handler) {#browser-context-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.onClose(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.onClose(handler)</x-search>
 
 Emitted when Browser context gets closed. This might happen because of one of the following:
 * Browser context is closed.
@@ -1061,7 +1061,7 @@ When no [Page.onDialog(handler)](/api/class-page.mdx#page-event-dialog) or [Brow
 
 ### onPage(handler) {#browser-context-event-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.onPage(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.onPage(handler)</x-search>
 
 The event is emitted when a new Page is created in the BrowserContext. The page may still be loading. The event will also fire for popup pages. See also [Page.onPopup(handler)](/api/class-page.mdx#page-event-popup) to receive events about popups relevant to a specific page.
 

--- a/java/docs/api/class-browsertype.mdx
+++ b/java/docs/api/class-browsertype.mdx
@@ -33,7 +33,7 @@ public class Example {
 
 ### connect {#browser-type-connect}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.connect</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.connect</x-search>
 
 This method attaches Playwright to an existing browser instance. When connecting to another browser launched via `BrowserType.launchServer` in Node.js, the major and minor version needs to match the client version (1.2.3 → is compatible with 1.2.x).
 
@@ -119,7 +119,7 @@ Page page = defaultContext.pages().get(0);
 
 ### executablePath {#browser-type-executable-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.executablePath</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.executablePath</x-search>
 
 A path where Playwright expects to find a bundled browser executable.
 
@@ -136,7 +136,7 @@ BrowserType.executablePath();
 
 ### launch {#browser-type-launch}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.launch</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.launch</x-search>
 
 Returns the browser instance.
 
@@ -241,7 +241,7 @@ Browser browser = chromium.launch(new BrowserType.LaunchOptions()
 
 ### launchPersistentContext {#browser-type-launch-persistent-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.launchPersistentContext</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.launchPersistentContext</x-search>
 
 Returns the persistent browser context instance.
 
@@ -507,7 +507,7 @@ BrowserType.launchPersistentContext(userDataDir, options);
 
 ### name {#browser-type-name}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.name</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.name</x-search>
 
 Returns browser name. For example: `'chromium'`, `'webkit'` or `'firefox'`.
 

--- a/java/docs/api/class-cdpsession.mdx
+++ b/java/docs/api/class-cdpsession.mdx
@@ -37,7 +37,7 @@ client.send("Animation.setPlaybackRate", params);
 
 ### detach {#cdp-session-detach}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>cdpSession.detach</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>cdpSession.detach</x-search>
 
 Detaches the CDPSession from the target. Once detached, the CDPSession object won't emit any events and can't be used to send messages.
 
@@ -98,7 +98,7 @@ CDPSession.on(eventName, handler);
 
 ### send {#cdp-session-send}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>cdpSession.send</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>cdpSession.send</x-search>
 
 **Usage**
 

--- a/java/docs/api/class-consolemessage.mdx
+++ b/java/docs/api/class-consolemessage.mdx
@@ -37,7 +37,7 @@ msg.args().get(1).jsonValue() // 42
 
 ### args {#console-message-args}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.args</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.args</x-search>
 
 List of arguments passed to a `console` function call. See also [Page.onConsoleMessage(handler)](/api/class-page.mdx#page-event-console).
 
@@ -54,7 +54,7 @@ ConsoleMessage.args();
 
 ### location {#console-message-location}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.location</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.location</x-search>
 
 URL of the resource followed by 0-based line and column numbers in the resource formatted as `URL:line:column`.
 
@@ -88,7 +88,7 @@ ConsoleMessage.page();
 
 ### text {#console-message-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.text</x-search>
 
 The text of the console message.
 
@@ -105,7 +105,7 @@ ConsoleMessage.text();
 
 ### type {#console-message-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.type</x-search>
 
 One of the following values: `'log'`, `'debug'`, `'info'`, `'error'`, `'warning'`, `'dir'`, `'dirxml'`, `'table'`, `'trace'`, `'clear'`, `'startGroup'`, `'startGroupCollapsed'`, `'endGroup'`, `'assert'`, `'profile'`, `'profileEnd'`, `'count'`, `'timeEnd'`.
 

--- a/java/docs/api/class-dialog.mdx
+++ b/java/docs/api/class-dialog.mdx
@@ -42,7 +42,7 @@ Dialogs are dismissed automatically, unless there is a [Page.onDialog(handler)](
 
 ### accept {#dialog-accept}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.accept</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.accept</x-search>
 
 Returns when the dialog has been accepted.
 
@@ -65,7 +65,7 @@ Dialog.accept(promptText);
 
 ### defaultValue {#dialog-default-value}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.defaultValue</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.defaultValue</x-search>
 
 If dialog is prompt, returns default prompt value. Otherwise, returns empty string.
 
@@ -82,7 +82,7 @@ Dialog.defaultValue();
 
 ### dismiss {#dialog-dismiss}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.dismiss</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.dismiss</x-search>
 
 Returns when the dialog has been dismissed.
 
@@ -99,7 +99,7 @@ Dialog.dismiss();
 
 ### message {#dialog-message}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.message</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.message</x-search>
 
 A message displayed in the dialog.
 
@@ -133,7 +133,7 @@ Dialog.page();
 
 ### type {#dialog-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.type</x-search>
 
 Returns dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prompt`.
 

--- a/java/docs/api/class-download.mdx
+++ b/java/docs/api/class-download.mdx
@@ -48,7 +48,7 @@ Download.cancel();
 
 ### createReadStream {#download-create-read-stream}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.createReadStream</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.createReadStream</x-search>
 
 Returns a readable stream for a successful download, or throws for a failed/canceled download.
 
@@ -65,7 +65,7 @@ Download.createReadStream();
 
 ### delete {#download-delete}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.delete</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.delete</x-search>
 
 Deletes the downloaded file. Will wait for the download to finish if necessary.
 
@@ -82,7 +82,7 @@ Download.delete();
 
 ### failure {#download-failure}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.failure</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.failure</x-search>
 
 Returns download error if any. Will wait for the download to finish if necessary.
 
@@ -116,7 +116,7 @@ Download.page();
 
 ### path {#download-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.path</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.path</x-search>
 
 Returns path to the downloaded file for a successful download, or throws for a failed/canceled download. The method will wait for the download to finish if necessary. The method throws when connected remotely.
 
@@ -135,7 +135,7 @@ Download.path();
 
 ### saveAs {#download-save-as}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.saveAs</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.saveAs</x-search>
 
 Copy the download to a user-specified path. It is safe to call this method while the download is still in progress. Will wait for the download to finish if necessary.
 
@@ -157,7 +157,7 @@ download.saveAs(Paths.get("/path/to/save/at/", download.suggestedFilename()));
 
 ### suggestedFilename {#download-suggested-filename}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.suggestedFilename</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.suggestedFilename</x-search>
 
 Returns suggested filename for this download. It is typically computed by the browser from the [`Content-Disposition`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) response header or the `download` attribute. See the spec on [whatwg](https://html.spec.whatwg.org/#downloading-resources). Different browsers can use different logic for computing it.
 
@@ -174,7 +174,7 @@ Download.suggestedFilename();
 
 ### url {#download-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.url</x-search>
 
 Returns downloaded url.
 

--- a/java/docs/api/class-elementhandle.mdx
+++ b/java/docs/api/class-elementhandle.mdx
@@ -48,7 +48,7 @@ locator.click();
 
 ### boundingBox {#element-handle-bounding-box}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.boundingBox</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.boundingBox</x-search>
 
 This method returns the bounding box of the element, or `null` if the element is not visible. The bounding box is calculated relative to the main frame viewport - which is usually the same as the browser window.
 
@@ -84,7 +84,7 @@ page.mouse().click(box.x + box.width / 2, box.y + box.height / 2);
 
 ### contentFrame {#element-handle-content-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.contentFrame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.contentFrame</x-search>
 
 Returns the content frame for element handles referencing iframe nodes, or `null` otherwise
 
@@ -101,7 +101,7 @@ ElementHandle.contentFrame();
 
 ### ownerFrame {#element-handle-owner-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.ownerFrame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.ownerFrame</x-search>
 
 Returns the frame containing the given element.
 
@@ -118,7 +118,7 @@ ElementHandle.ownerFrame();
 
 ### waitForElementState {#element-handle-wait-for-element-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.waitForElementState</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.waitForElementState</x-search>
 
 Returns when the element satisfies the `state`.
 
@@ -157,7 +157,7 @@ ElementHandle.waitForElementState(state, options);
 
 ### check {#element-handle-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.check</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.check</x-search>
 
 :::warning[Discouraged]
 
@@ -219,7 +219,7 @@ ElementHandle.check(options);
 
 ### click {#element-handle-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.click</x-search>
 
 :::warning[Discouraged]
 
@@ -292,7 +292,7 @@ ElementHandle.click(options);
 
 ### dblclick {#element-handle-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.dblclick</x-search>
 
 :::warning[Discouraged]
 
@@ -365,7 +365,7 @@ ElementHandle.dblclick(options);
 
 ### dispatchEvent {#element-handle-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dispatchEvent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.dispatchEvent</x-search>
 
 :::warning[Discouraged]
 
@@ -509,7 +509,7 @@ assertEquals(Arrays.asList("Hello!", "Hi!"), feedHandle.evalOnSelectorAll(".twee
 
 ### fill {#element-handle-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.fill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.fill</x-search>
 
 :::warning[Discouraged]
 
@@ -558,7 +558,7 @@ ElementHandle.fill(value, options);
 
 ### focus {#element-handle-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.focus</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.focus</x-search>
 
 :::warning[Discouraged]
 
@@ -582,7 +582,7 @@ ElementHandle.focus();
 
 ### getAttribute {#element-handle-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.getAttribute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.getAttribute</x-search>
 
 :::warning[Discouraged]
 
@@ -611,7 +611,7 @@ ElementHandle.getAttribute(name);
 
 ### hover {#element-handle-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.hover</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.hover</x-search>
 
 :::warning[Discouraged]
 
@@ -674,7 +674,7 @@ ElementHandle.hover(options);
 
 ### innerHTML {#element-handle-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.innerHTML</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.innerHTML</x-search>
 
 :::warning[Discouraged]
 
@@ -698,7 +698,7 @@ ElementHandle.innerHTML();
 
 ### innerText {#element-handle-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.innerText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.innerText</x-search>
 
 :::warning[Discouraged]
 
@@ -755,7 +755,7 @@ ElementHandle.inputValue(options);
 
 ### isChecked {#element-handle-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isChecked</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isChecked</x-search>
 
 :::warning[Discouraged]
 
@@ -779,7 +779,7 @@ ElementHandle.isChecked();
 
 ### isDisabled {#element-handle-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isDisabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isDisabled</x-search>
 
 :::warning[Discouraged]
 
@@ -803,7 +803,7 @@ ElementHandle.isDisabled();
 
 ### isEditable {#element-handle-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isEditable</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isEditable</x-search>
 
 :::warning[Discouraged]
 
@@ -827,7 +827,7 @@ ElementHandle.isEditable();
 
 ### isEnabled {#element-handle-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isEnabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isEnabled</x-search>
 
 :::warning[Discouraged]
 
@@ -851,7 +851,7 @@ ElementHandle.isEnabled();
 
 ### isHidden {#element-handle-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isHidden</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isHidden</x-search>
 
 :::warning[Discouraged]
 
@@ -875,7 +875,7 @@ ElementHandle.isHidden();
 
 ### isVisible {#element-handle-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isVisible</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isVisible</x-search>
 
 :::warning[Discouraged]
 
@@ -899,7 +899,7 @@ ElementHandle.isVisible();
 
 ### press {#element-handle-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.press</x-search>
 
 :::warning[Discouraged]
 
@@ -1014,7 +1014,7 @@ ElementHandle.querySelectorAll(selector);
 
 ### screenshot {#element-handle-screenshot}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.screenshot</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.screenshot</x-search>
 
 :::warning[Discouraged]
 
@@ -1085,7 +1085,7 @@ ElementHandle.screenshot(options);
 
 ### scrollIntoViewIfNeeded {#element-handle-scroll-into-view-if-needed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.scrollIntoViewIfNeeded</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.scrollIntoViewIfNeeded</x-search>
 
 :::warning[Discouraged]
 
@@ -1120,7 +1120,7 @@ ElementHandle.scrollIntoViewIfNeeded(options);
 
 ### selectOption {#element-handle-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.selectOption</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.selectOption</x-search>
 
 :::warning[Discouraged]
 
@@ -1184,7 +1184,7 @@ handle.selectOption(new String[] {"red", "green", "blue"});
 
 ### selectText {#element-handle-select-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.selectText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.selectText</x-search>
 
 :::warning[Discouraged]
 
@@ -1284,7 +1284,7 @@ ElementHandle.setChecked(checked, options);
 
 ### setInputFiles {#element-handle-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.setInputFiles</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.setInputFiles</x-search>
 
 :::warning[Discouraged]
 
@@ -1335,7 +1335,7 @@ ElementHandle.setInputFiles(files, options);
 
 ### tap {#element-handle-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.tap</x-search>
 
 :::warning[Discouraged]
 
@@ -1402,7 +1402,7 @@ ElementHandle.tap(options);
 
 ### textContent {#element-handle-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.textContent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.textContent</x-search>
 
 :::warning[Discouraged]
 
@@ -1426,7 +1426,7 @@ ElementHandle.textContent();
 
 ### type {#element-handle-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.type</x-search>
 
 :::warning Deprecated
 
@@ -1468,7 +1468,7 @@ To press a special key, like `Control` or `ArrowDown`, use [ElementHandle.press(
 
 ### uncheck {#element-handle-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.uncheck</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.uncheck</x-search>
 
 :::warning[Discouraged]
 
@@ -1530,7 +1530,7 @@ ElementHandle.uncheck(options);
 
 ### waitForSelector {#element-handle-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.waitForSelector</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.waitForSelector</x-search>
 
 :::warning[Discouraged]
 

--- a/java/docs/api/class-filechooser.mdx
+++ b/java/docs/api/class-filechooser.mdx
@@ -21,7 +21,7 @@ fileChooser.setFiles(Paths.get("myfile.pdf"));
 
 ### element {#file-chooser-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.element</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.element</x-search>
 
 Returns input element associated with this file chooser.
 
@@ -38,7 +38,7 @@ FileChooser.element();
 
 ### isMultiple {#file-chooser-is-multiple}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.isMultiple</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.isMultiple</x-search>
 
 Returns whether this file chooser accepts multiple files.
 
@@ -55,7 +55,7 @@ FileChooser.isMultiple();
 
 ### page {#file-chooser-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.page</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.page</x-search>
 
 Returns page this file chooser belongs to.
 
@@ -72,7 +72,7 @@ FileChooser.page();
 
 ### setFiles {#file-chooser-set-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.setFiles</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.setFiles</x-search>
 
 Sets the value of the file input this chooser is associated with. If some of the `filePaths` are relative paths, then they are resolved relative to the current working directory. For empty array, clears the selected files.
 

--- a/java/docs/api/class-frame.mdx
+++ b/java/docs/api/class-frame.mdx
@@ -46,7 +46,7 @@ public class Example {
 
 ### addScriptTag {#frame-add-script-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.addScriptTag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.addScriptTag</x-search>
 
 Returns the added tag when the script's onload fires or when the script content was injected into frame.
 
@@ -81,7 +81,7 @@ Frame.addScriptTag(options);
 
 ### addStyleTag {#frame-add-style-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.addStyleTag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.addStyleTag</x-search>
 
 Returns the added tag when the stylesheet's onload fires or when the CSS content was injected into frame.
 
@@ -113,7 +113,7 @@ Frame.addStyleTag(options);
 
 ### childFrames {#frame-child-frames}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.childFrames</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.childFrames</x-search>
 
 **Usage**
 
@@ -128,7 +128,7 @@ Frame.childFrames();
 
 ### content {#frame-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.content</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.content</x-search>
 
 Gets the full HTML contents of the frame, including the doctype.
 
@@ -206,7 +206,7 @@ Frame.dragAndDrop(source, target, options);
 
 ### evaluate {#frame-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.evaluate</x-search>
 
 Returns the return value of `expression`.
 
@@ -252,7 +252,7 @@ bodyHandle.dispose();
 
 ### evaluateHandle {#frame-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.evaluateHandle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.evaluateHandle</x-search>
 
 Returns the return value of `expression` as a [JSHandle].
 
@@ -297,7 +297,7 @@ resultHandle.dispose();
 
 ### frameElement {#frame-frame-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.frameElement</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.frameElement</x-search>
 
 Returns the `frame` or `iframe` element handle which corresponds to this frame.
 
@@ -670,7 +670,7 @@ assertThat(page.getByTitle("Issues count")).hasText("25 issues");
 
 ### isDetached {#frame-is-detached}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isDetached</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isDetached</x-search>
 
 Returns `true` if the frame has been detached, or `false` otherwise.
 
@@ -687,7 +687,7 @@ Frame.isDetached();
 
 ### isEnabled {#frame-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isEnabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isEnabled</x-search>
 
 Returns whether the element is [enabled](../actionability.mdx#enabled).
 
@@ -763,7 +763,7 @@ Frame.locator(selector, options);
 
 ### name {#frame-name}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.name</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.name</x-search>
 
 Returns frame's name attribute as specified in the tag.
 
@@ -786,7 +786,7 @@ Frame.name();
 
 ### navigate {#frame-goto}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.navigate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.navigate</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
@@ -840,7 +840,7 @@ Frame.navigate(url, options);
 
 ### page {#frame-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.page</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.page</x-search>
 
 Returns the page containing this frame.
 
@@ -857,7 +857,7 @@ Frame.page();
 
 ### parentFrame {#frame-parent-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.parentFrame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.parentFrame</x-search>
 
 Parent frame, if any. Detached frames and main frames return `null`.
 
@@ -874,7 +874,7 @@ Frame.parentFrame();
 
 ### setContent {#frame-set-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.setContent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.setContent</x-search>
 
 This method internally calls [document.write()](https://developer.mozilla.org/en-US/docs/Web/API/Document/write), inheriting all its specific characteristics and behaviors.
 
@@ -908,7 +908,7 @@ Frame.setContent(html, options);
 
 ### title {#frame-title}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.title</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.title</x-search>
 
 Returns the page title.
 
@@ -925,7 +925,7 @@ Frame.title();
 
 ### url {#frame-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.url</x-search>
 
 Returns frame's url.
 
@@ -942,7 +942,7 @@ Frame.url();
 
 ### waitForFunction {#frame-wait-for-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForFunction</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.waitForFunction</x-search>
 
 Returns when the `expression` returns a truthy value, returns that value.
 
@@ -996,7 +996,7 @@ frame.waitForFunction("selector => !!document.querySelector(selector)", selector
 
 ### waitForLoadState {#frame-wait-for-load-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForLoadState</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.waitForLoadState</x-search>
 
 Waits for the required load state to be reached.
 
@@ -1068,7 +1068,7 @@ frame.waitForURL("**/target.html");
 
 ### check {#frame-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.check</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.check</x-search>
 
 :::warning[Discouraged]
 
@@ -1135,7 +1135,7 @@ Frame.check(selector, options);
 
 ### click {#frame-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.click</x-search>
 
 :::warning[Discouraged]
 
@@ -1213,7 +1213,7 @@ Frame.click(selector, options);
 
 ### dblclick {#frame-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.dblclick</x-search>
 
 :::warning[Discouraged]
 
@@ -1291,7 +1291,7 @@ Frame.dblclick(selector, options);
 
 ### dispatchEvent {#frame-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dispatchEvent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.dispatchEvent</x-search>
 
 :::warning[Discouraged]
 
@@ -1441,7 +1441,7 @@ boolean divsCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => div
 
 ### fill {#frame-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.fill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.fill</x-search>
 
 :::warning[Discouraged]
 
@@ -1496,7 +1496,7 @@ Frame.fill(selector, value, options);
 
 ### focus {#frame-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.focus</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.focus</x-search>
 
 :::warning[Discouraged]
 
@@ -1533,7 +1533,7 @@ Frame.focus(selector, options);
 
 ### getAttribute {#frame-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.getAttribute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.getAttribute</x-search>
 
 :::warning[Discouraged]
 
@@ -1573,7 +1573,7 @@ Frame.getAttribute(selector, name, options);
 
 ### hover {#frame-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.hover</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.hover</x-search>
 
 :::warning[Discouraged]
 
@@ -1641,7 +1641,7 @@ Frame.hover(selector, options);
 
 ### innerHTML {#frame-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerHTML</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.innerHTML</x-search>
 
 :::warning[Discouraged]
 
@@ -1678,7 +1678,7 @@ Frame.innerHTML(selector, options);
 
 ### innerText {#frame-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.innerText</x-search>
 
 :::warning[Discouraged]
 
@@ -1754,7 +1754,7 @@ Frame.inputValue(selector, options);
 
 ### isChecked {#frame-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isChecked</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isChecked</x-search>
 
 :::warning[Discouraged]
 
@@ -1791,7 +1791,7 @@ Frame.isChecked(selector, options);
 
 ### isDisabled {#frame-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isDisabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isDisabled</x-search>
 
 :::warning[Discouraged]
 
@@ -1828,7 +1828,7 @@ Frame.isDisabled(selector, options);
 
 ### isEditable {#frame-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isEditable</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isEditable</x-search>
 
 :::warning[Discouraged]
 
@@ -1865,7 +1865,7 @@ Frame.isEditable(selector, options);
 
 ### isHidden {#frame-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isHidden</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isHidden</x-search>
 
 :::warning[Discouraged]
 
@@ -1905,7 +1905,7 @@ Frame.isHidden(selector, options);
 
 ### isVisible {#frame-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isVisible</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isVisible</x-search>
 
 :::warning[Discouraged]
 
@@ -1945,7 +1945,7 @@ Frame.isVisible(selector, options);
 
 ### press {#frame-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.press</x-search>
 
 :::warning[Discouraged]
 
@@ -2081,7 +2081,7 @@ Frame.querySelectorAll(selector);
 
 ### selectOption {#frame-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.selectOption</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.selectOption</x-search>
 
 :::warning[Discouraged]
 
@@ -2222,7 +2222,7 @@ Frame.setChecked(selector, checked, options);
 
 ### setInputFiles {#frame-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.setInputFiles</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.setInputFiles</x-search>
 
 :::warning[Discouraged]
 
@@ -2279,7 +2279,7 @@ Frame.setInputFiles(selector, files, options);
 
 ### tap {#frame-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.tap</x-search>
 
 :::warning[Discouraged]
 
@@ -2351,7 +2351,7 @@ Frame.tap(selector, options);
 
 ### textContent {#frame-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.textContent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.textContent</x-search>
 
 :::warning[Discouraged]
 
@@ -2388,7 +2388,7 @@ Frame.textContent(selector, options);
 
 ### type {#frame-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.type</x-search>
 
 :::warning Deprecated
 
@@ -2436,7 +2436,7 @@ To press a special key, like `Control` or `ArrowDown`, use [Keyboard.press()](/a
 
 ### uncheck {#frame-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.uncheck</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.uncheck</x-search>
 
 :::warning[Discouraged]
 
@@ -2503,7 +2503,7 @@ Frame.uncheck(selector, options);
 
 ### waitForNavigation {#frame-wait-for-navigation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForNavigation</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.waitForNavigation</x-search>
 
 :::warning Deprecated
 
@@ -2556,7 +2556,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 ### waitForSelector {#frame-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForSelector</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.waitForSelector</x-search>
 
 :::warning[Discouraged]
 
@@ -2623,7 +2623,7 @@ public class Example {
 
 ### waitForTimeout {#frame-wait-for-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.waitForTimeout</x-search>
 
 :::warning[Discouraged]
 

--- a/java/docs/api/class-jshandle.mdx
+++ b/java/docs/api/class-jshandle.mdx
@@ -25,7 +25,7 @@ JSHandle instances can be used as an argument in [Page.evalOnSelector()](/api/cl
 
 ### asElement {#js-handle-as-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.asElement</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.asElement</x-search>
 
 Returns either `null` or the object handle itself, if the object handle is an instance of [ElementHandle].
 
@@ -42,7 +42,7 @@ JSHandle.asElement();
 
 ### dispose {#js-handle-dispose}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.dispose</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.dispose</x-search>
 
 The `jsHandle.dispose` method stops referencing the element handle.
 
@@ -59,7 +59,7 @@ JSHandle.dispose();
 
 ### evaluate {#js-handle-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.evaluate</x-search>
 
 Returns the return value of `expression`.
 
@@ -89,7 +89,7 @@ assertEquals("10 retweets", tweetHandle.evaluate("node => node.innerText"));
 
 ### evaluateHandle {#js-handle-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.evaluateHandle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.evaluateHandle</x-search>
 
 Returns the return value of `expression` as a [JSHandle].
 
@@ -123,7 +123,7 @@ JSHandle.evaluateHandle(expression, arg);
 
 ### getProperties {#js-handle-get-properties}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.getProperties</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.getProperties</x-search>
 
 The method returns a map with **own property names** as keys and JSHandle instances for the property values.
 
@@ -144,7 +144,7 @@ handle.dispose();
 
 ### getProperty {#js-handle-get-property}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.getProperty</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.getProperty</x-search>
 
 Fetches a single property from the referenced object.
 
@@ -166,7 +166,7 @@ JSHandle.getProperty(propertyName);
 
 ### jsonValue {#js-handle-json-value}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.jsonValue</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.jsonValue</x-search>
 
 Returns a JSON representation of the object. If the object has a `toJSON` function, it **will not be called**.
 

--- a/java/docs/api/class-keyboard.mdx
+++ b/java/docs/api/class-keyboard.mdx
@@ -48,7 +48,7 @@ page.keyboard().press("Meta+A");
 
 ### down {#keyboard-down}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.down</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.down</x-search>
 
 Dispatches a `keydown` event.
 
@@ -88,7 +88,7 @@ Keyboard.down(key);
 
 ### insertText {#keyboard-insert-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.insertText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.insertText</x-search>
 
 Dispatches only `input` event, does not emit the `keydown`, `keyup` or `keypress` events.
 
@@ -114,7 +114,7 @@ Modifier keys DO NOT effect `keyboard.insertText`. Holding down `Shift` will not
 
 ### press {#keyboard-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.press</x-search>
 
 :::tip
 In most cases, you should use [Locator.press()](/api/class-locator.mdx#locator-press) instead.
@@ -164,7 +164,7 @@ Shortcut for [Keyboard.down()](/api/class-keyboard.mdx#keyboard-down) and [Keybo
 
 ### type {#keyboard-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.type</x-search>
 
 :::caution
 In most cases, you should use [Locator.fill()](/api/class-locator.mdx#locator-fill) instead. You only need to press keys one by one if there is special keyboard handling on the page - in this case use [Locator.pressSequentially()](/api/class-locator.mdx#locator-press-sequentially).
@@ -207,7 +207,7 @@ For characters that are not on a US keyboard, only an `input` event will be sent
 
 ### up {#keyboard-up}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.up</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.up</x-search>
 
 Dispatches a `keyup` event.
 

--- a/java/docs/api/class-mouse.mdx
+++ b/java/docs/api/class-mouse.mdx
@@ -29,7 +29,7 @@ page.mouse().up();
 
 ### click {#mouse-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.click</x-search>
 
 Shortcut for [Mouse.move()](/api/class-mouse.mdx#mouse-move), [Mouse.down()](/api/class-mouse.mdx#mouse-down), [Mouse.up()](/api/class-mouse.mdx#mouse-up).
 
@@ -65,7 +65,7 @@ Mouse.click(x, y, options);
 
 ### dblclick {#mouse-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.dblclick</x-search>
 
 Shortcut for [Mouse.move()](/api/class-mouse.mdx#mouse-move), [Mouse.down()](/api/class-mouse.mdx#mouse-down), [Mouse.up()](/api/class-mouse.mdx#mouse-up), [Mouse.down()](/api/class-mouse.mdx#mouse-down) and [Mouse.up()](/api/class-mouse.mdx#mouse-up).
 
@@ -98,7 +98,7 @@ Mouse.dblclick(x, y, options);
 
 ### down {#mouse-down}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.down</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.down</x-search>
 
 Dispatches a `mousedown` event.
 
@@ -125,7 +125,7 @@ Mouse.down(options);
 
 ### move {#mouse-move}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.move</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.move</x-search>
 
 Dispatches a `mousemove` event.
 
@@ -155,7 +155,7 @@ Mouse.move(x, y, options);
 
 ### up {#mouse-up}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.up</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.up</x-search>
 
 Dispatches a `mouseup` event.
 

--- a/java/docs/api/class-page.mdx
+++ b/java/docs/api/class-page.mdx
@@ -55,7 +55,7 @@ page.offRequest(logRequest);
 
 ### addInitScript {#page-add-init-script}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.addInitScript</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.addInitScript</x-search>
 
 Adds a script which would be evaluated in one of the following scenarios:
 * Whenever the page is navigated.
@@ -181,7 +181,7 @@ page.addLocatorHandler(page.getByLabel("Close"), locator => {
 
 ### addScriptTag {#page-add-script-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.addScriptTag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.addScriptTag</x-search>
 
 Adds a `<script>` tag into the page with the desired url or content. Returns the added tag when the script's onload fires or when the script content was injected into frame.
 
@@ -214,7 +214,7 @@ Page.addScriptTag(options);
 
 ### addStyleTag {#page-add-style-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.addStyleTag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.addStyleTag</x-search>
 
 Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<style type="text/css">` tag with the content. Returns the added tag when the stylesheet's onload fires or when the CSS content was injected into frame.
 
@@ -244,7 +244,7 @@ Page.addStyleTag(options);
 
 ### bringToFront {#page-bring-to-front}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.bringToFront</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.bringToFront</x-search>
 
 Brings page to front (activates tab).
 
@@ -261,7 +261,7 @@ Page.bringToFront();
 
 ### close {#page-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.close</x-search>
 
 If `runBeforeUnload` is `false`, does not run any unload handlers and waits for the page to be closed. If `runBeforeUnload` is `true` the method will run unload handlers, but will **not** wait for the page to close.
 
@@ -294,7 +294,7 @@ Page.close(options);
 
 ### content {#page-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.content</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.content</x-search>
 
 Gets the full HTML contents of the page, including the doctype.
 
@@ -311,7 +311,7 @@ Page.content();
 
 ### context {#page-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.context</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.context</x-search>
 
 Get the browser context that the page belongs to.
 
@@ -393,7 +393,7 @@ page.dragAndDrop("#source", '#target', new Page.DragAndDropOptions()
 
 ### emulateMedia {#page-emulate-media}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.emulateMedia</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.emulateMedia</x-search>
 
 This method changes the `CSS media type` through the `media` argument, and/or the `'prefers-colors-scheme'` media feature, using the `colorScheme` argument.
 
@@ -450,7 +450,7 @@ page.evaluate("() => matchMedia('(prefers-color-scheme: no-preference)').matches
 
 ### evaluate {#page-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.evaluate</x-search>
 
 Returns the value of the `expression` invocation.
 
@@ -498,7 +498,7 @@ bodyHandle.dispose();
 
 ### evaluateHandle {#page-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.evaluateHandle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.evaluateHandle</x-search>
 
 Returns the value of the `expression` invocation as a [JSHandle].
 
@@ -543,7 +543,7 @@ resultHandle.dispose();
 
 ### exposeBinding {#page-expose-binding}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.exposeBinding</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.exposeBinding</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in this page. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`. If the `callback` returns a [Promise], it will be awaited.
 
@@ -607,7 +607,7 @@ public class Example {
 
 ### exposeFunction {#page-expose-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.exposeFunction</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.exposeFunction</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in the page. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`.
 
@@ -676,7 +676,7 @@ public class Example {
 
 ### frame {#page-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.frame</x-search>
 
 Returns frame matching the specified criteria. Either `name` or `url` must be specified.
 
@@ -749,7 +749,7 @@ locator.click();
 
 ### frames {#page-frames}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.frames</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.frames</x-search>
 
 An array of all frames attached to the page.
 
@@ -1091,7 +1091,7 @@ assertThat(page.getByTitle("Issues count")).hasText("25 issues");
 
 ### goBack {#page-go-back}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.goBack</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.goBack</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. If cannot go back, returns `null`.
 
@@ -1124,7 +1124,7 @@ Page.goBack(options);
 
 ### goForward {#page-go-forward}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.goForward</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.goForward</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. If cannot go forward, returns `null`.
 
@@ -1157,7 +1157,7 @@ Page.goForward(options);
 
 ### isClosed {#page-is-closed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isClosed</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isClosed</x-search>
 
 Indicates that the page has been closed.
 
@@ -1218,7 +1218,7 @@ Page.locator(selector, options);
 
 ### mainFrame {#page-main-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.mainFrame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.mainFrame</x-search>
 
 The page's main frame. Page is guaranteed to have a main frame which persists during navigations.
 
@@ -1235,7 +1235,7 @@ Page.mainFrame();
 
 ### navigate {#page-goto}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.navigate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.navigate</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the first non-redirect response.
 
@@ -1339,7 +1339,7 @@ Page.onceDialog(handler);
 
 ### opener {#page-opener}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.opener</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.opener</x-search>
 
 Returns the opener for popup pages and `null` for others. If the opener has been closed already the returns `null`.
 
@@ -1379,7 +1379,7 @@ Page.pause();
 
 ### pdf {#page-pdf}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.pdf</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.pdf</x-search>
 
 Returns the PDF buffer.
 
@@ -1503,7 +1503,7 @@ The `format` options are:
 
 ### reload {#page-reload}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.reload</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.reload</x-search>
 
 This method reloads the current page, in the same way as if the user had triggered a browser refresh. Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
@@ -1556,7 +1556,7 @@ Page.removeLocatorHandler(locator);
 
 ### route {#page-route}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.route</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.route</x-search>
 
 Routing provides the capability to modify network requests that are made by a page.
 
@@ -1675,7 +1675,7 @@ Page.routeFromHAR(har, options);
 
 ### screenshot {#page-screenshot}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.screenshot</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.screenshot</x-search>
 
 Returns the buffer with the captured screenshot.
 
@@ -1753,7 +1753,7 @@ Page.screenshot(options);
 
 ### setContent {#page-set-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setContent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setContent</x-search>
 
 This method internally calls [document.write()](https://developer.mozilla.org/en-US/docs/Web/API/Document/write), inheriting all its specific characteristics and behaviors.
 
@@ -1787,7 +1787,7 @@ Page.setContent(html, options);
 
 ### setDefaultNavigationTimeout {#page-set-default-navigation-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setDefaultNavigationTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setDefaultNavigationTimeout</x-search>
 
 This setting will change the default maximum navigation time for the following methods and related shortcuts:
 * [Page.goBack()](/api/class-page.mdx#page-go-back)
@@ -1817,7 +1817,7 @@ Page.setDefaultNavigationTimeout(timeout);
 
 ### setDefaultTimeout {#page-set-default-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setDefaultTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setDefaultTimeout</x-search>
 
 This setting will change the default maximum time for all the methods accepting `timeout` option.
 
@@ -1840,7 +1840,7 @@ Page.setDefaultTimeout(timeout);
 
 ### setExtraHTTPHeaders {#page-set-extra-http-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setExtraHTTPHeaders</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setExtraHTTPHeaders</x-search>
 
 The extra HTTP headers will be sent with every request the page initiates.
 
@@ -1866,7 +1866,7 @@ Page.setExtraHTTPHeaders(headers);
 
 ### setViewportSize {#page-set-viewport-size}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setViewportSize</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setViewportSize</x-search>
 
 In the case of multiple pages in a single browser, each page can have its own viewport size. However, [Browser.newContext()](/api/class-browser.mdx#browser-new-context) allows to set viewport size (and more) for all pages in the context at once.
 
@@ -1891,7 +1891,7 @@ page.navigate("https://example.com");
 
 ### title {#page-title}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.title</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.title</x-search>
 
 Returns the page's title.
 
@@ -1908,7 +1908,7 @@ Page.title();
 
 ### unroute {#page-unroute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.unroute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.unroute</x-search>
 
 Removes a route created with [Page.route()](/api/class-page.mdx#page-route). When `handler` is not specified, removes all routes for the `url`.
 
@@ -1951,7 +1951,7 @@ Page.unrouteAll();
 
 ### url {#page-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.url</x-search>
 
 **Usage**
 
@@ -1966,7 +1966,7 @@ Page.url();
 
 ### video {#page-video}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.video</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.video</x-search>
 
 Video object associated with this page.
 
@@ -1983,7 +1983,7 @@ Page.video();
 
 ### viewportSize {#page-viewport-size}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.viewportSize</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.viewportSize</x-search>
 
 **Usage**
 
@@ -2152,7 +2152,7 @@ Page.waitForFileChooser(callback, options);
 
 ### waitForFunction {#page-wait-for-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForFunction</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForFunction</x-search>
 
 Returns when the `expression` returns a truthy value. It resolves to a JSHandle of the truthy value.
 
@@ -2206,7 +2206,7 @@ page.waitForFunction("selector => !!document.querySelector(selector)", selector)
 
 ### waitForLoadState {#page-wait-for-load-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForLoadState</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForLoadState</x-search>
 
 Returns when the required load state has been reached.
 
@@ -2281,7 +2281,7 @@ Page.waitForPopup(callback, options);
 
 ### waitForRequest {#page-wait-for-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForRequest</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForRequest</x-search>
 
 Waits for the matching request and returns it. See [waiting for event](../events.mdx#waiting-for-event) for more details about events.
 
@@ -2350,7 +2350,7 @@ Page.waitForRequestFinished(callback, options);
 
 ### waitForResponse {#page-wait-for-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForResponse</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForResponse</x-search>
 
 Returns the matched response. See [waiting for event](../events.mdx#waiting-for-event) for more details about events.
 
@@ -2483,7 +2483,7 @@ Page.waitForWorker(callback, options);
 
 ### workers {#page-workers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.workers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.workers</x-search>
 
 This method returns all of the dedicated [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) associated with the page.
 
@@ -2523,7 +2523,7 @@ Page.clock()
 
 ### keyboard() {#page-keyboard}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.keyboard()</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.keyboard()</x-search>
 
 **Usage**
 
@@ -2538,7 +2538,7 @@ Page.keyboard()
 
 ### mouse() {#page-mouse}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.mouse()</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.mouse()</x-search>
 
 **Usage**
 
@@ -2570,7 +2570,7 @@ Page.request()
 
 ### touchscreen() {#page-touchscreen}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.touchscreen()</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.touchscreen()</x-search>
 
 **Usage**
 
@@ -2587,7 +2587,7 @@ Page.touchscreen()
 
 ### onClose(handler) {#page-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.onClose(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.onClose(handler)</x-search>
 
 Emitted when the page closes.
 
@@ -2604,7 +2604,7 @@ Page.onClose(handler)
 
 ### onConsoleMessage(handler) {#page-event-console}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.onConsoleMessage(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.onConsoleMessage(handler)</x-search>
 
 Emitted when JavaScript within the page calls one of console API methods, e.g. `console.log` or `console.dir`.
 
@@ -2627,7 +2627,7 @@ page.evaluate("() => console.log('hello', 5, { foo: 'bar' })");
 
 ### onCrash(handler) {#page-event-crash}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.onCrash(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.onCrash(handler)</x-search>
 
 Emitted when the page crashes. Browser pages might crash if they try to allocate too much memory. When the page crashes, ongoing and subsequent operations will throw.
 
@@ -2657,7 +2657,7 @@ Page.onCrash(handler)
 
 ### onDialog(handler) {#page-event-dialog}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.onDialog(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.onDialog(handler)</x-search>
 
 Emitted when a JavaScript dialog appears, such as `alert`, `prompt`, `confirm` or `beforeunload`. Listener **must** either [Dialog.accept()](/api/class-dialog.mdx#dialog-accept) or [Dialog.dismiss()](/api/class-dialog.mdx#dialog-dismiss) the dialog - otherwise the page will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the dialog, and actions like click will never finish.
 
@@ -2697,7 +2697,7 @@ Page.onDOMContentLoaded(handler)
 
 ### onDownload(handler) {#page-event-download}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.onDownload(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.onDownload(handler)</x-search>
 
 Emitted when attachment download started. User can access basic file operations on downloaded content via the passed [Download] instance.
 
@@ -2788,7 +2788,7 @@ Page.onFrameNavigated(handler)
 
 ### onLoad(handler) {#page-event-load}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.onLoad(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.onLoad(handler)</x-search>
 
 Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched.
 
@@ -2832,7 +2832,7 @@ Page.onPageError(handler)
 
 ### onPopup(handler) {#page-event-popup}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.onPopup(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.onPopup(handler)</x-search>
 
 Emitted when the page opens a new tab or window. This event is emitted in addition to the [BrowserContext.onPage(handler)](/api/class-browsercontext.mdx#browser-context-event-page), but only for popups relevant to this page.
 
@@ -2862,7 +2862,7 @@ Page.onPopup(handler)
 
 ### onRequest(handler) {#page-event-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.onRequest(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.onRequest(handler)</x-search>
 
 Emitted when a page issues a request. The [request] object is read-only. In order to intercept and mutate requests, see [Page.route()](/api/class-page.mdx#page-route) or [BrowserContext.route()](/api/class-browsercontext.mdx#browser-context-route).
 
@@ -2923,7 +2923,7 @@ Page.onRequestFinished(handler)
 
 ### onResponse(handler) {#page-event-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.onResponse(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.onResponse(handler)</x-search>
 
 Emitted when [response] status and headers are received for a request. For a successful response, the sequence of events is `request`, `response` and `requestfinished`.
 
@@ -2957,7 +2957,7 @@ Page.onWebSocket(handler)
 
 ### onWorker(handler) {#page-event-worker}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.onWorker(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.onWorker(handler)</x-search>
 
 Emitted when a dedicated [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) is spawned by the page.
 
@@ -2976,7 +2976,7 @@ Page.onWorker(handler)
 
 ### check {#page-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.check</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.check</x-search>
 
 :::warning[Discouraged]
 
@@ -3043,7 +3043,7 @@ Page.check(selector, options);
 
 ### click {#page-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.click</x-search>
 
 :::warning[Discouraged]
 
@@ -3121,7 +3121,7 @@ Page.click(selector, options);
 
 ### dblclick {#page-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.dblclick</x-search>
 
 :::warning[Discouraged]
 
@@ -3199,7 +3199,7 @@ Page.dblclick(selector, options);
 
 ### dispatchEvent {#page-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dispatchEvent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.dispatchEvent</x-search>
 
 :::warning[Discouraged]
 
@@ -3345,7 +3345,7 @@ boolean divCounts = (boolean) page.evalOnSelectorAll("div", "(divs, min) => divs
 
 ### fill {#page-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.fill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.fill</x-search>
 
 :::warning[Discouraged]
 
@@ -3400,7 +3400,7 @@ Page.fill(selector, value, options);
 
 ### focus {#page-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.focus</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.focus</x-search>
 
 :::warning[Discouraged]
 
@@ -3437,7 +3437,7 @@ Page.focus(selector, options);
 
 ### getAttribute {#page-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.getAttribute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.getAttribute</x-search>
 
 :::warning[Discouraged]
 
@@ -3477,7 +3477,7 @@ Page.getAttribute(selector, name, options);
 
 ### hover {#page-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.hover</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.hover</x-search>
 
 :::warning[Discouraged]
 
@@ -3545,7 +3545,7 @@ Page.hover(selector, options);
 
 ### innerHTML {#page-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerHTML</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.innerHTML</x-search>
 
 :::warning[Discouraged]
 
@@ -3582,7 +3582,7 @@ Page.innerHTML(selector, options);
 
 ### innerText {#page-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.innerText</x-search>
 
 :::warning[Discouraged]
 
@@ -3658,7 +3658,7 @@ Page.inputValue(selector, options);
 
 ### isChecked {#page-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isChecked</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isChecked</x-search>
 
 :::warning[Discouraged]
 
@@ -3695,7 +3695,7 @@ Page.isChecked(selector, options);
 
 ### isDisabled {#page-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isDisabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isDisabled</x-search>
 
 :::warning[Discouraged]
 
@@ -3732,7 +3732,7 @@ Page.isDisabled(selector, options);
 
 ### isEditable {#page-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEditable</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isEditable</x-search>
 
 :::warning[Discouraged]
 
@@ -3769,7 +3769,7 @@ Page.isEditable(selector, options);
 
 ### isEnabled {#page-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEnabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isEnabled</x-search>
 
 :::warning[Discouraged]
 
@@ -3806,7 +3806,7 @@ Page.isEnabled(selector, options);
 
 ### isHidden {#page-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isHidden</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isHidden</x-search>
 
 :::warning[Discouraged]
 
@@ -3846,7 +3846,7 @@ Page.isHidden(selector, options);
 
 ### isVisible {#page-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isVisible</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isVisible</x-search>
 
 :::warning[Discouraged]
 
@@ -3886,7 +3886,7 @@ Page.isVisible(selector, options);
 
 ### press {#page-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.press</x-search>
 
 :::warning[Discouraged]
 
@@ -4018,7 +4018,7 @@ Page.querySelectorAll(selector);
 
 ### selectOption {#page-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.selectOption</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.selectOption</x-search>
 
 :::warning[Discouraged]
 
@@ -4159,7 +4159,7 @@ Page.setChecked(selector, checked, options);
 
 ### setInputFiles {#page-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setInputFiles</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setInputFiles</x-search>
 
 :::warning[Discouraged]
 
@@ -4216,7 +4216,7 @@ Page.setInputFiles(selector, files, options);
 
 ### tap {#page-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.tap</x-search>
 
 :::warning[Discouraged]
 
@@ -4288,7 +4288,7 @@ Page.tap(selector, options);
 
 ### textContent {#page-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.textContent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.textContent</x-search>
 
 :::warning[Discouraged]
 
@@ -4325,7 +4325,7 @@ Page.textContent(selector, options);
 
 ### type {#page-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.type</x-search>
 
 :::warning Deprecated
 
@@ -4373,7 +4373,7 @@ To press a special key, like `Control` or `ArrowDown`, use [Keyboard.press()](/a
 
 ### uncheck {#page-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.uncheck</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.uncheck</x-search>
 
 :::warning[Discouraged]
 
@@ -4440,7 +4440,7 @@ Page.uncheck(selector, options);
 
 ### waitForNavigation {#page-wait-for-navigation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForNavigation</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForNavigation</x-search>
 
 :::warning Deprecated
 
@@ -4493,7 +4493,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 ### waitForSelector {#page-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForSelector</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForSelector</x-search>
 
 :::warning[Discouraged]
 
@@ -4560,7 +4560,7 @@ public class Example {
 
 ### waitForTimeout {#page-wait-for-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForTimeout</x-search>
 
 :::warning[Discouraged]
 

--- a/java/docs/api/class-playwright.mdx
+++ b/java/docs/api/class-playwright.mdx
@@ -81,7 +81,7 @@ Playwright.create(options);
 
 ### chromium() {#playwright-chromium}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.chromium()</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.chromium()</x-search>
 
 This object can be used to launch or connect to Chromium, returning instances of [Browser].
 
@@ -98,7 +98,7 @@ Playwright.chromium()
 
 ### firefox() {#playwright-firefox}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.firefox()</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.firefox()</x-search>
 
 This object can be used to launch or connect to Firefox, returning instances of [Browser].
 
@@ -132,7 +132,7 @@ Playwright.request()
 
 ### selectors() {#playwright-selectors}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.selectors()</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.selectors()</x-search>
 
 Selectors can be used to install custom selector engines. See [extensibility](../extensibility.mdx) for more information.
 
@@ -149,7 +149,7 @@ Playwright.selectors()
 
 ### webkit() {#playwright-webkit}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.webkit()</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.webkit()</x-search>
 
 This object can be used to launch or connect to WebKit, returning instances of [Browser].
 

--- a/java/docs/api/class-request.mdx
+++ b/java/docs/api/class-request.mdx
@@ -44,7 +44,7 @@ Request.allHeaders();
 
 ### failure {#request-failure}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.failure</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.failure</x-search>
 
 The method returns `null` unless this request has failed, as reported by `requestfailed` event.
 
@@ -65,7 +65,7 @@ page.onRequestFailed(request -> {
 
 ### frame {#request-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.frame</x-search>
 
 Returns the [Frame] that initiated this request.
 
@@ -112,7 +112,7 @@ Request.headerValue(name);
 
 ### headers {#request-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.headers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.headers</x-search>
 
 An object with the request HTTP headers. The header names are lower-cased. Note that this method does not return security-related headers, including cookie-related ones. You can use [Request.allHeaders()](/api/class-request.mdx#request-all-headers) for complete list of headers that include `cookie` information.
 
@@ -152,7 +152,7 @@ Request.headersArray();
 
 ### isNavigationRequest {#request-is-navigation-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.isNavigationRequest</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.isNavigationRequest</x-search>
 
 Whether this request is driving frame's navigation.
 
@@ -171,7 +171,7 @@ Request.isNavigationRequest();
 
 ### method {#request-method}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.method</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.method</x-search>
 
 Request's method (GET, POST, etc.)
 
@@ -188,7 +188,7 @@ Request.method();
 
 ### postData {#request-post-data}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.postData</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.postData</x-search>
 
 Request's post body, if any.
 
@@ -205,7 +205,7 @@ Request.postData();
 
 ### postDataBuffer {#request-post-data-buffer}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.postDataBuffer</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.postDataBuffer</x-search>
 
 Request's post body in a binary form, if any.
 
@@ -222,7 +222,7 @@ Request.postDataBuffer();
 
 ### redirectedFrom {#request-redirected-from}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.redirectedFrom</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.redirectedFrom</x-search>
 
 Request that was redirected by the server to this one, if any.
 
@@ -251,7 +251,7 @@ System.out.println(response.request().redirectedFrom()); // null
 
 ### redirectedTo {#request-redirected-to}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.redirectedTo</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.redirectedTo</x-search>
 
 New request issued by the browser if the server responded with redirect.
 
@@ -270,7 +270,7 @@ System.out.println(request.redirectedFrom().redirectedTo() == request); // true
 
 ### resourceType {#request-resource-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.resourceType</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.resourceType</x-search>
 
 Contains the request's resource type as it was perceived by the rendering engine. ResourceType will be one of the following: `document`, `stylesheet`, `image`, `media`, `font`, `script`, `texttrack`, `xhr`, `fetch`, `eventsource`, `websocket`, `manifest`, `other`.
 
@@ -287,7 +287,7 @@ Request.resourceType();
 
 ### response {#request-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.response</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.response</x-search>
 
 Returns the matching [Response] object, or `null` if the response was not received due to error.
 
@@ -333,7 +333,7 @@ Request.sizes();
 
 ### timing {#request-timing}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.timing</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.timing</x-search>
 
 Returns resource timing information for given request. Most of the timing values become available upon the response, `responseEnd` becomes available when request finishes. Find more information at [Resource Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming).
 
@@ -381,7 +381,7 @@ page.navigate("http://example.com");
 
 ### url {#request-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.url</x-search>
 
 URL of the request.
 

--- a/java/docs/api/class-response.mdx
+++ b/java/docs/api/class-response.mdx
@@ -33,7 +33,7 @@ Response.allHeaders();
 
 ### body {#response-body}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.body</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.body</x-search>
 
 Returns the buffer with response body.
 
@@ -50,7 +50,7 @@ Response.body();
 
 ### finished {#response-finished}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.finished</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.finished</x-search>
 
 Waits for this response to finish, returns always `null`.
 
@@ -67,7 +67,7 @@ Response.finished();
 
 ### frame {#response-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.frame</x-search>
 
 Returns the [Frame] that initiated this response.
 
@@ -145,7 +145,7 @@ Response.headerValues(name);
 
 ### headers {#response-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.headers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.headers</x-search>
 
 An object with the response HTTP headers. The header names are lower-cased. Note that this method does not return security-related headers, including cookie-related ones. You can use [Response.allHeaders()](/api/class-response.mdx#response-all-headers) for complete list of headers that include `cookie` information.
 
@@ -185,7 +185,7 @@ Response.headersArray();
 
 ### ok {#response-ok}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.ok</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.ok</x-search>
 
 Contains a boolean stating whether the response was successful (status in the range 200-299) or not.
 
@@ -202,7 +202,7 @@ Response.ok();
 
 ### request {#response-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.request</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.request</x-search>
 
 Returns the matching [Request] object.
 
@@ -273,7 +273,7 @@ Response.serverAddr();
 
 ### status {#response-status}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.status</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.status</x-search>
 
 Contains the status code of the response (e.g., 200 for a success).
 
@@ -290,7 +290,7 @@ Response.status();
 
 ### statusText {#response-status-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.statusText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.statusText</x-search>
 
 Contains the status text of the response (e.g. usually an "OK" for a success).
 
@@ -307,7 +307,7 @@ Response.statusText();
 
 ### text {#response-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.text</x-search>
 
 Returns the text representation of response body.
 
@@ -324,7 +324,7 @@ Response.text();
 
 ### url {#response-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.url</x-search>
 
 Contains the URL of the response.
 

--- a/java/docs/api/class-route.mdx
+++ b/java/docs/api/class-route.mdx
@@ -18,7 +18,7 @@ Learn more about [networking](../network.mdx).
 
 ### abort {#route-abort}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.abort</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.abort</x-search>
 
 Aborts the route's request.
 
@@ -189,7 +189,7 @@ Note that `headers` option will apply to the fetched request as well as any redi
 
 ### fulfill {#route-fulfill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.fulfill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.fulfill</x-search>
 
 Fulfills route's request with given response.
 
@@ -244,7 +244,7 @@ page.route("**/xhr_endpoint", route -> route.fulfill(
 
 ### request {#route-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.request</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.request</x-search>
 
 A request to be routed.
 
@@ -261,7 +261,7 @@ Route.request();
 
 ### resume {#route-continue}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.resume</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.resume</x-search>
 
 Continues route's request with optional overrides.
 

--- a/java/docs/api/class-selectors.mdx
+++ b/java/docs/api/class-selectors.mdx
@@ -16,7 +16,7 @@ Selectors can be used to install custom selector engines. See [extensibility](..
 
 ### register {#selectors-register}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>selectors.register</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>selectors.register</x-search>
 
 Selectors must be registered before creating the page.
 

--- a/java/docs/api/class-touchscreen.mdx
+++ b/java/docs/api/class-touchscreen.mdx
@@ -16,7 +16,7 @@ The Touchscreen class operates in main-frame CSS pixels relative to the top-left
 
 ### tap {#touchscreen-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>touchscreen.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>touchscreen.tap</x-search>
 
 Dispatches a `touchstart` and `touchend` event with a single touch at the position (`x`,`y`).
 

--- a/java/docs/api/class-video.mdx
+++ b/java/docs/api/class-video.mdx
@@ -37,7 +37,7 @@ Video.delete();
 
 ### path {#video-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>video.path</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>video.path</x-search>
 
 Returns the file system path this video will be recorded to. The video is guaranteed to be written to the filesystem upon closing the browser context. This method throws when connected remotely.
 

--- a/java/docs/api/class-websocket.mdx
+++ b/java/docs/api/class-websocket.mdx
@@ -16,7 +16,7 @@ The [WebSocket] class represents websocket connections in the page.
 
 ### isClosed {#web-socket-is-closed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.isClosed</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.isClosed</x-search>
 
 Indicates that the web socket has been closed.
 
@@ -33,7 +33,7 @@ WebSocket.isClosed();
 
 ### url {#web-socket-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.url</x-search>
 
 Contains the URL of the WebSocket.
 
@@ -112,7 +112,7 @@ WebSocket.waitForFrameSent(callback, options);
 
 ### onClose(handler) {#web-socket-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.onClose(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.onClose(handler)</x-search>
 
 Fired when the websocket closes.
 

--- a/java/docs/api/class-worker.mdx
+++ b/java/docs/api/class-worker.mdx
@@ -26,7 +26,7 @@ for (Worker worker : page.workers())
 
 ### evaluate {#worker-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.evaluate</x-search>
 
 Returns the return value of `expression`.
 
@@ -56,7 +56,7 @@ Worker.evaluate(expression, arg);
 
 ### evaluateHandle {#worker-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.evaluateHandle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.evaluateHandle</x-search>
 
 Returns the return value of `expression` as a [JSHandle].
 
@@ -86,7 +86,7 @@ Worker.evaluateHandle(expression, arg);
 
 ### url {#worker-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.url</x-search>
 
 **Usage**
 
@@ -130,7 +130,7 @@ Worker.waitForClose(callback, options);
 
 ### onClose(handler) {#worker-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.onClose(handler)</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.onClose(handler)</x-search>
 
 Emitted when this dedicated [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) is terminated.
 

--- a/nodejs/docs/api/class-accessibility.mdx
+++ b/nodejs/docs/api/class-accessibility.mdx
@@ -22,7 +22,7 @@ Most of the accessibility tree gets filtered out when converting from internal b
 
 ### snapshot {#accessibility-snapshot}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>accessibility.snapshot</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>accessibility.snapshot</x-search>
 
 :::warning Deprecated
 

--- a/nodejs/docs/api/class-browser.mdx
+++ b/nodejs/docs/api/class-browser.mdx
@@ -45,7 +45,7 @@ browser.browserType();
 
 ### close {#browser-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.close</x-search>
 
 In case this browser is obtained using [browserType.launch()](/api/class-browsertype.mdx#browser-type-launch), closes the browser and all of its pages (if any were opened).
 
@@ -77,7 +77,7 @@ await browser.close(options);
 
 ### contexts {#browser-contexts}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.contexts</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.contexts</x-search>
 
 Returns an array of all open browser contexts. In a newly created browser, this will return zero browser contexts.
 
@@ -98,7 +98,7 @@ console.log(browser.contexts().length); // prints `1`
 
 ### isConnected {#browser-is-connected}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.isConnected</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.isConnected</x-search>
 
 Indicates that the browser is connected.
 
@@ -136,7 +136,7 @@ await browser.newBrowserCDPSession();
 
 ### newContext {#browser-new-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.newContext</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.newContext</x-search>
 
 Creates a new browser context. It won't share cookies/cache with other browser contexts.
 
@@ -430,7 +430,7 @@ If directly using this method to create [BrowserContext]s, it is best practice t
 
 ### newPage {#browser-new-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.newPage</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.newPage</x-search>
 
 Creates a new page in a new browser context. Closing this page will close the context as well.
 
@@ -771,7 +771,7 @@ await browser.stopTracing();
 
 ### version {#browser-version}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.version</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.version</x-search>
 
 Returns the browser version.
 
@@ -790,7 +790,7 @@ browser.version();
 
 ### on('disconnected') {#browser-event-disconnected}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.on('disconnected')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.on('disconnected')</x-search>
 
 Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
 * Browser application is closed or crashed.

--- a/nodejs/docs/api/class-browsercontext.mdx
+++ b/nodejs/docs/api/class-browsercontext.mdx
@@ -31,7 +31,7 @@ await context.close();
 
 ### addCookies {#browser-context-add-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.addCookies</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.addCookies</x-search>
 
 Adds cookies into this browser context. All pages within this context will have these cookies installed. Cookies can be obtained via [browserContext.cookies()](/api/class-browsercontext.mdx#browser-context-cookies).
 
@@ -78,7 +78,7 @@ await browserContext.addCookies([cookieObject1, cookieObject2]);
 
 ### addInitScript {#browser-context-add-init-script}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.addInitScript</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.addInitScript</x-search>
 
 Adds a script which would be evaluated in one of the following scenarios:
 * Whenever a page is created in the browser context or is navigated.
@@ -148,7 +148,7 @@ browserContext.backgroundPages();
 
 ### browser {#browser-context-browser}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.browser</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.browser</x-search>
 
 Returns the browser instance of the context. If it was launched as a persistent context null gets returned.
 
@@ -165,7 +165,7 @@ browserContext.browser();
 
 ### clearCookies {#browser-context-clear-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.clearCookies</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.clearCookies</x-search>
 
 Removes cookies from context. Accepts optional filter.
 
@@ -199,7 +199,7 @@ await context.clearCookies({ name: 'session-id', domain: 'my-origin.com' });
 
 ### clearPermissions {#browser-context-clear-permissions}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.clearPermissions</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.clearPermissions</x-search>
 
 Clears all permission overrides for the browser context.
 
@@ -219,7 +219,7 @@ context.clearPermissions();
 
 ### close {#browser-context-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.close</x-search>
 
 Closes the browser context. All the pages that belong to the browser context will be closed.
 
@@ -247,7 +247,7 @@ await browserContext.close(options);
 
 ### cookies {#browser-context-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.cookies</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.cookies</x-search>
 
 If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those URLs are returned.
 
@@ -293,7 +293,7 @@ await browserContext.cookies(urls);
 
 ### exposeBinding {#browser-context-expose-binding}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.exposeBinding</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.exposeBinding</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in every page in the context. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`. If the `callback` returns a [Promise], it will be awaited.
 
@@ -350,7 +350,7 @@ const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
 
 ### exposeFunction {#browser-context-expose-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.exposeFunction</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.exposeFunction</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in every page in the context. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`.
 
@@ -401,7 +401,7 @@ const crypto = require('crypto');
 
 ### grantPermissions {#browser-context-grant-permissions}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.grantPermissions</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.grantPermissions</x-search>
 
 Grants specified permissions to the browser context. Only grants corresponding permissions to the given origin if specified.
 
@@ -470,7 +470,7 @@ await browserContext.newCDPSession(page);
 
 ### newPage {#browser-context-new-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.newPage</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.newPage</x-search>
 
 Creates a new page in the browser context.
 
@@ -487,7 +487,7 @@ await browserContext.newPage();
 
 ### pages {#browser-context-pages}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.pages</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.pages</x-search>
 
 Returns all open pages in the context.
 
@@ -504,7 +504,7 @@ browserContext.pages();
 
 ### route {#browser-context-route}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.route</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.route</x-search>
 
 Routing provides the capability to modify network requests that are made by any page in the browser context. Once route is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
 
@@ -636,7 +636,7 @@ browserContext.serviceWorkers();
 
 ### setDefaultNavigationTimeout {#browser-context-set-default-navigation-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setDefaultNavigationTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.setDefaultNavigationTimeout</x-search>
 
 This setting will change the default maximum navigation time for the following methods and related shortcuts:
 * [page.goBack()](/api/class-page.mdx#page-go-back)
@@ -665,7 +665,7 @@ browserContext.setDefaultNavigationTimeout(timeout);
 
 ### setDefaultTimeout {#browser-context-set-default-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setDefaultTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.setDefaultTimeout</x-search>
 
 This setting will change the default maximum time for all the methods accepting `timeout` option.
 
@@ -688,7 +688,7 @@ browserContext.setDefaultTimeout(timeout);
 
 ### setExtraHTTPHeaders {#browser-context-set-extra-http-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setExtraHTTPHeaders</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.setExtraHTTPHeaders</x-search>
 
 The extra HTTP headers will be sent with every request initiated by any page in the context. These headers are merged with page-specific extra HTTP headers set with [page.setExtraHTTPHeaders()](/api/class-page.mdx#page-set-extra-http-headers). If page overrides a particular header, page-specific header value will be used instead of the browser context header value.
 
@@ -714,7 +714,7 @@ await browserContext.setExtraHTTPHeaders(headers);
 
 ### setGeolocation {#browser-context-set-geolocation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setGeolocation</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.setGeolocation</x-search>
 
 Sets the context's geolocation. Passing `null` or `undefined` emulates position unavailable.
 
@@ -747,7 +747,7 @@ Consider using [browserContext.grantPermissions()](/api/class-browsercontext.mdx
 
 ### setOffline {#browser-context-set-offline}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setOffline</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.setOffline</x-search>
 
 **Usage**
 
@@ -767,7 +767,7 @@ await browserContext.setOffline(offline);
 
 ### storageState {#browser-context-storage-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.storageState</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.storageState</x-search>
 
 Returns storage state for this browser context, contains current cookies and local storage snapshot.
 
@@ -829,7 +829,7 @@ await browserContext.storageState(options);
 
 ### unroute {#browser-context-unroute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.unroute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.unroute</x-search>
 
 Removes a route created with [browserContext.route()](/api/class-browsercontext.mdx#browser-context-route). When `handler` is not specified, removes all routes for the `url`.
 
@@ -882,7 +882,7 @@ await browserContext.unrouteAll(options);
 
 ### waitForEvent {#browser-context-wait-for-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.waitForEvent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.waitForEvent</x-search>
 
 Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy value. Will throw an error if the context closes before the event is fired. Returns the event data value.
 
@@ -997,7 +997,7 @@ browserContext.on('backgroundpage', data => {});
 
 ### on('close') {#browser-context-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.on('close')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.on('close')</x-search>
 
 Emitted when Browser context gets closed. This might happen because of one of the following:
 * Browser context is closed.
@@ -1065,7 +1065,7 @@ When no [page.on('dialog')](/api/class-page.mdx#page-event-dialog) or [browserCo
 
 ### on('page') {#browser-context-event-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.on('page')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.on('page')</x-search>
 
 The event is emitted when a new Page is created in the BrowserContext. The page may still be loading. The event will also fire for popup pages. See also [page.on('popup')](/api/class-page.mdx#page-event-popup) to receive events about popups relevant to a specific page.
 
@@ -1209,7 +1209,7 @@ browserContext.on('weberror', data => {});
 
 ### setHTTPCredentials {#browser-context-set-http-credentials}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.setHTTPCredentials</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.setHTTPCredentials</x-search>
 
 :::warning Deprecated
 

--- a/nodejs/docs/api/class-browserserver.mdx
+++ b/nodejs/docs/api/class-browserserver.mdx
@@ -14,7 +14,7 @@ import HTMLCard from '@site/src/components/HTMLCard';
 
 ### close {#browser-server-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserServer.close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserServer.close</x-search>
 
 Closes the browser gracefully and makes sure the process is terminated.
 
@@ -31,7 +31,7 @@ await browserServer.close();
 
 ### kill {#browser-server-kill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserServer.kill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserServer.kill</x-search>
 
 Kills the browser process and waits for the process to exit.
 
@@ -48,7 +48,7 @@ await browserServer.kill();
 
 ### process {#browser-server-process}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserServer.process</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserServer.process</x-search>
 
 Spawned browser application process.
 
@@ -65,7 +65,7 @@ browserServer.process();
 
 ### wsEndpoint {#browser-server-ws-endpoint}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserServer.wsEndpoint</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserServer.wsEndpoint</x-search>
 
 Browser websocket url.
 
@@ -88,7 +88,7 @@ browserServer.wsEndpoint();
 
 ### on('close') {#browser-server-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserServer.on('close')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserServer.on('close')</x-search>
 
 Emitted when the browser server closes.
 

--- a/nodejs/docs/api/class-browsertype.mdx
+++ b/nodejs/docs/api/class-browsertype.mdx
@@ -28,7 +28,7 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 
 ### connect {#browser-type-connect}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.connect</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.connect</x-search>
 
 This method attaches Playwright to an existing browser instance. When connecting to another browser launched via `BrowserType.launchServer` in Node.js, the major and minor version needs to match the client version (1.2.3 → is compatible with 1.2.x).
 
@@ -123,7 +123,7 @@ const page = defaultContext.pages()[0];
 
 ### executablePath {#browser-type-executable-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.executablePath</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.executablePath</x-search>
 
 A path where Playwright expects to find a bundled browser executable.
 
@@ -140,7 +140,7 @@ browserType.executablePath();
 
 ### launch {#browser-type-launch}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.launch</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.launch</x-search>
 
 Returns the browser instance.
 
@@ -245,7 +245,7 @@ const browser = await chromium.launch({  // Or 'firefox' or 'webkit'.
 
 ### launchPersistentContext {#browser-type-launch-persistent-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.launchPersistentContext</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.launchPersistentContext</x-search>
 
 Returns the persistent browser context instance.
 
@@ -537,7 +537,7 @@ await browserType.launchPersistentContext(userDataDir, options);
 
 ### launchServer {#browser-type-launch-server}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.launchServer</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.launchServer</x-search>
 
 Returns the browser app instance. You can connect to it via [browserType.connect()](/api/class-browsertype.mdx#browser-type-connect), which requires the major/minor client/server version to match (1.2.3 → is compatible with 1.2.x).
 
@@ -653,7 +653,7 @@ const { chromium } = require('playwright');  // Or 'webkit' or 'firefox'.
 
 ### name {#browser-type-name}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.name</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.name</x-search>
 
 Returns browser name. For example: `'chromium'`, `'webkit'` or `'firefox'`.
 

--- a/nodejs/docs/api/class-cdpsession.mdx
+++ b/nodejs/docs/api/class-cdpsession.mdx
@@ -34,7 +34,7 @@ await client.send('Animation.setPlaybackRate', {
 
 ### detach {#cdp-session-detach}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>cdpSession.detach</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>cdpSession.detach</x-search>
 
 Detaches the CDPSession from the target. Once detached, the CDPSession object won't emit any events and can't be used to send messages.
 
@@ -51,7 +51,7 @@ await cdpSession.detach();
 
 ### send {#cdp-session-send}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>cdpSession.send</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>cdpSession.send</x-search>
 
 **Usage**
 

--- a/nodejs/docs/api/class-consolemessage.mdx
+++ b/nodejs/docs/api/class-consolemessage.mdx
@@ -38,7 +38,7 @@ await msg.args()[1].jsonValue(); // 42
 
 ### args {#console-message-args}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.args</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.args</x-search>
 
 List of arguments passed to a `console` function call. See also [page.on('console')](/api/class-page.mdx#page-event-console).
 
@@ -55,7 +55,7 @@ consoleMessage.args();
 
 ### location {#console-message-location}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.location</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.location</x-search>
 
 **Usage**
 
@@ -96,7 +96,7 @@ consoleMessage.page();
 
 ### text {#console-message-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.text</x-search>
 
 The text of the console message.
 
@@ -113,7 +113,7 @@ consoleMessage.text();
 
 ### type {#console-message-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.type</x-search>
 
 One of the following values: `'log'`, `'debug'`, `'info'`, `'error'`, `'warning'`, `'dir'`, `'dirxml'`, `'table'`, `'trace'`, `'clear'`, `'startGroup'`, `'startGroupCollapsed'`, `'endGroup'`, `'assert'`, `'profile'`, `'profileEnd'`, `'count'`, `'timeEnd'`.
 

--- a/nodejs/docs/api/class-dialog.mdx
+++ b/nodejs/docs/api/class-dialog.mdx
@@ -37,7 +37,7 @@ Dialogs are dismissed automatically, unless there is a [page.on('dialog')](/api/
 
 ### accept {#dialog-accept}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.accept</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.accept</x-search>
 
 Returns when the dialog has been accepted.
 
@@ -60,7 +60,7 @@ await dialog.accept(promptText);
 
 ### defaultValue {#dialog-default-value}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.defaultValue</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.defaultValue</x-search>
 
 If dialog is prompt, returns default prompt value. Otherwise, returns empty string.
 
@@ -77,7 +77,7 @@ dialog.defaultValue();
 
 ### dismiss {#dialog-dismiss}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.dismiss</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.dismiss</x-search>
 
 Returns when the dialog has been dismissed.
 
@@ -94,7 +94,7 @@ await dialog.dismiss();
 
 ### message {#dialog-message}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.message</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.message</x-search>
 
 A message displayed in the dialog.
 
@@ -128,7 +128,7 @@ dialog.page();
 
 ### type {#dialog-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.type</x-search>
 
 Returns dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prompt`.
 

--- a/nodejs/docs/api/class-download.mdx
+++ b/nodejs/docs/api/class-download.mdx
@@ -47,7 +47,7 @@ await download.cancel();
 
 ### createReadStream {#download-create-read-stream}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.createReadStream</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.createReadStream</x-search>
 
 Returns a readable stream for a successful download, or throws for a failed/canceled download.
 
@@ -64,7 +64,7 @@ await download.createReadStream();
 
 ### delete {#download-delete}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.delete</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.delete</x-search>
 
 Deletes the downloaded file. Will wait for the download to finish if necessary.
 
@@ -81,7 +81,7 @@ await download.delete();
 
 ### failure {#download-failure}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.failure</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.failure</x-search>
 
 Returns download error if any. Will wait for the download to finish if necessary.
 
@@ -115,7 +115,7 @@ download.page();
 
 ### path {#download-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.path</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.path</x-search>
 
 Returns path to the downloaded file for a successful download, or throws for a failed/canceled download. The method will wait for the download to finish if necessary. The method throws when connected remotely.
 
@@ -134,7 +134,7 @@ await download.path();
 
 ### saveAs {#download-save-as}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.saveAs</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.saveAs</x-search>
 
 Copy the download to a user-specified path. It is safe to call this method while the download is still in progress. Will wait for the download to finish if necessary.
 
@@ -156,7 +156,7 @@ await download.saveAs('/path/to/save/at/' + download.suggestedFilename());
 
 ### suggestedFilename {#download-suggested-filename}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.suggestedFilename</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.suggestedFilename</x-search>
 
 Returns suggested filename for this download. It is typically computed by the browser from the [`Content-Disposition`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) response header or the `download` attribute. See the spec on [whatwg](https://html.spec.whatwg.org/#downloading-resources). Different browsers can use different logic for computing it.
 
@@ -173,7 +173,7 @@ download.suggestedFilename();
 
 ### url {#download-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.url</x-search>
 
 Returns downloaded url.
 

--- a/nodejs/docs/api/class-elementhandle.mdx
+++ b/nodejs/docs/api/class-elementhandle.mdx
@@ -50,7 +50,7 @@ await locator.click();
 
 ### boundingBox {#element-handle-bounding-box}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.boundingBox</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.boundingBox</x-search>
 
 This method returns the bounding box of the element, or `null` if the element is not visible. The bounding box is calculated relative to the main frame viewport - which is usually the same as the browser window.
 
@@ -86,7 +86,7 @@ await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
 
 ### contentFrame {#element-handle-content-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.contentFrame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.contentFrame</x-search>
 
 Returns the content frame for element handles referencing iframe nodes, or `null` otherwise
 
@@ -103,7 +103,7 @@ await elementHandle.contentFrame();
 
 ### ownerFrame {#element-handle-owner-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.ownerFrame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.ownerFrame</x-search>
 
 Returns the frame containing the given element.
 
@@ -120,7 +120,7 @@ await elementHandle.ownerFrame();
 
 ### waitForElementState {#element-handle-wait-for-element-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.waitForElementState</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.waitForElementState</x-search>
 
 Returns when the element satisfies the `state`.
 
@@ -307,7 +307,7 @@ expect(await feedHandle.$$eval('.tweet', nodes =>
 
 ### check {#element-handle-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.check</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.check</x-search>
 
 :::warning[Discouraged]
 
@@ -369,7 +369,7 @@ await elementHandle.check(options);
 
 ### click {#element-handle-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.click</x-search>
 
 :::warning[Discouraged]
 
@@ -442,7 +442,7 @@ await elementHandle.click(options);
 
 ### dblclick {#element-handle-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.dblclick</x-search>
 
 :::warning[Discouraged]
 
@@ -515,7 +515,7 @@ await elementHandle.dblclick(options);
 
 ### dispatchEvent {#element-handle-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dispatchEvent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.dispatchEvent</x-search>
 
 :::warning[Discouraged]
 
@@ -569,7 +569,7 @@ await elementHandle.dispatchEvent('dragstart', { dataTransfer });
 
 ### fill {#element-handle-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.fill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.fill</x-search>
 
 :::warning[Discouraged]
 
@@ -618,7 +618,7 @@ await elementHandle.fill(value, options);
 
 ### focus {#element-handle-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.focus</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.focus</x-search>
 
 :::warning[Discouraged]
 
@@ -642,7 +642,7 @@ await elementHandle.focus();
 
 ### getAttribute {#element-handle-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.getAttribute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.getAttribute</x-search>
 
 :::warning[Discouraged]
 
@@ -671,7 +671,7 @@ await elementHandle.getAttribute(name);
 
 ### hover {#element-handle-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.hover</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.hover</x-search>
 
 :::warning[Discouraged]
 
@@ -734,7 +734,7 @@ await elementHandle.hover(options);
 
 ### innerHTML {#element-handle-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.innerHTML</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.innerHTML</x-search>
 
 :::warning[Discouraged]
 
@@ -758,7 +758,7 @@ await elementHandle.innerHTML();
 
 ### innerText {#element-handle-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.innerText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.innerText</x-search>
 
 :::warning[Discouraged]
 
@@ -815,7 +815,7 @@ await elementHandle.inputValue(options);
 
 ### isChecked {#element-handle-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isChecked</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isChecked</x-search>
 
 :::warning[Discouraged]
 
@@ -839,7 +839,7 @@ await elementHandle.isChecked();
 
 ### isDisabled {#element-handle-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isDisabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isDisabled</x-search>
 
 :::warning[Discouraged]
 
@@ -863,7 +863,7 @@ await elementHandle.isDisabled();
 
 ### isEditable {#element-handle-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isEditable</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isEditable</x-search>
 
 :::warning[Discouraged]
 
@@ -887,7 +887,7 @@ await elementHandle.isEditable();
 
 ### isEnabled {#element-handle-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isEnabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isEnabled</x-search>
 
 :::warning[Discouraged]
 
@@ -911,7 +911,7 @@ await elementHandle.isEnabled();
 
 ### isHidden {#element-handle-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isHidden</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isHidden</x-search>
 
 :::warning[Discouraged]
 
@@ -935,7 +935,7 @@ await elementHandle.isHidden();
 
 ### isVisible {#element-handle-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.isVisible</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.isVisible</x-search>
 
 :::warning[Discouraged]
 
@@ -959,7 +959,7 @@ await elementHandle.isVisible();
 
 ### press {#element-handle-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.press</x-search>
 
 :::warning[Discouraged]
 
@@ -1016,7 +1016,7 @@ await elementHandle.press(key, options);
 
 ### screenshot {#element-handle-screenshot}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.screenshot</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.screenshot</x-search>
 
 :::warning[Discouraged]
 
@@ -1087,7 +1087,7 @@ await elementHandle.screenshot(options);
 
 ### scrollIntoViewIfNeeded {#element-handle-scroll-into-view-if-needed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.scrollIntoViewIfNeeded</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.scrollIntoViewIfNeeded</x-search>
 
 :::warning[Discouraged]
 
@@ -1122,7 +1122,7 @@ await elementHandle.scrollIntoViewIfNeeded(options);
 
 ### selectOption {#element-handle-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.selectOption</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.selectOption</x-search>
 
 :::warning[Discouraged]
 
@@ -1188,7 +1188,7 @@ handle.selectOption(['red', 'green', 'blue']);
 
 ### selectText {#element-handle-select-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.selectText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.selectText</x-search>
 
 :::warning[Discouraged]
 
@@ -1288,7 +1288,7 @@ await elementHandle.setChecked(checked, options);
 
 ### setInputFiles {#element-handle-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.setInputFiles</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.setInputFiles</x-search>
 
 :::warning[Discouraged]
 
@@ -1339,7 +1339,7 @@ await elementHandle.setInputFiles(files, options);
 
 ### tap {#element-handle-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.tap</x-search>
 
 :::warning[Discouraged]
 
@@ -1406,7 +1406,7 @@ await elementHandle.tap(options);
 
 ### textContent {#element-handle-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.textContent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.textContent</x-search>
 
 :::warning[Discouraged]
 
@@ -1430,7 +1430,7 @@ await elementHandle.textContent();
 
 ### type {#element-handle-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.type</x-search>
 
 :::warning Deprecated
 
@@ -1472,7 +1472,7 @@ To press a special key, like `Control` or `ArrowDown`, use [elementHandle.press(
 
 ### uncheck {#element-handle-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.uncheck</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.uncheck</x-search>
 
 :::warning[Discouraged]
 
@@ -1534,7 +1534,7 @@ await elementHandle.uncheck(options);
 
 ### waitForSelector {#element-handle-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.waitForSelector</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.waitForSelector</x-search>
 
 :::warning[Discouraged]
 

--- a/nodejs/docs/api/class-filechooser.mdx
+++ b/nodejs/docs/api/class-filechooser.mdx
@@ -24,7 +24,7 @@ await fileChooser.setFiles(path.join(__dirname, 'myfile.pdf'));
 
 ### element {#file-chooser-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.element</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.element</x-search>
 
 Returns input element associated with this file chooser.
 
@@ -41,7 +41,7 @@ fileChooser.element();
 
 ### isMultiple {#file-chooser-is-multiple}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.isMultiple</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.isMultiple</x-search>
 
 Returns whether this file chooser accepts multiple files.
 
@@ -58,7 +58,7 @@ fileChooser.isMultiple();
 
 ### page {#file-chooser-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.page</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.page</x-search>
 
 Returns page this file chooser belongs to.
 
@@ -75,7 +75,7 @@ fileChooser.page();
 
 ### setFiles {#file-chooser-set-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.setFiles</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.setFiles</x-search>
 
 Sets the value of the file input this chooser is associated with. If some of the `filePaths` are relative paths, then they are resolved relative to the current working directory. For empty array, clears the selected files.
 

--- a/nodejs/docs/api/class-frame.mdx
+++ b/nodejs/docs/api/class-frame.mdx
@@ -41,7 +41,7 @@ const { firefox } = require('playwright');  // Or 'chromium' or 'webkit'.
 
 ### addScriptTag {#frame-add-script-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.addScriptTag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.addScriptTag</x-search>
 
 Returns the added tag when the script's onload fires or when the script content was injected into frame.
 
@@ -76,7 +76,7 @@ await frame.addScriptTag(options);
 
 ### addStyleTag {#frame-add-style-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.addStyleTag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.addStyleTag</x-search>
 
 Returns the added tag when the stylesheet's onload fires or when the CSS content was injected into frame.
 
@@ -108,7 +108,7 @@ await frame.addStyleTag(options);
 
 ### childFrames {#frame-child-frames}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.childFrames</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.childFrames</x-search>
 
 **Usage**
 
@@ -123,7 +123,7 @@ frame.childFrames();
 
 ### content {#frame-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.content</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.content</x-search>
 
 Gets the full HTML contents of the frame, including the doctype.
 
@@ -201,7 +201,7 @@ await frame.dragAndDrop(source, target, options);
 
 ### evaluate {#frame-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.evaluate</x-search>
 
 Returns the return value of `pageFunction`.
 
@@ -249,7 +249,7 @@ await bodyHandle.dispose();
 
 ### evaluateHandle {#frame-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.evaluateHandle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.evaluateHandle</x-search>
 
 Returns the return value of `pageFunction` as a [JSHandle].
 
@@ -296,7 +296,7 @@ await resultHandle.dispose();
 
 ### frameElement {#frame-frame-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.frameElement</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.frameElement</x-search>
 
 Returns the `frame` or `iframe` element handle which corresponds to this frame.
 
@@ -674,7 +674,7 @@ await expect(page.getByTitle('Issues count')).toHaveText('25 issues');
 
 ### goto {#frame-goto}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.goto</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.goto</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
@@ -728,7 +728,7 @@ await frame.goto(url, options);
 
 ### isDetached {#frame-is-detached}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isDetached</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isDetached</x-search>
 
 Returns `true` if the frame has been detached, or `false` otherwise.
 
@@ -745,7 +745,7 @@ frame.isDetached();
 
 ### isEnabled {#frame-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isEnabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isEnabled</x-search>
 
 Returns whether the element is [enabled](../actionability.mdx#enabled).
 
@@ -821,7 +821,7 @@ frame.locator(selector, options);
 
 ### name {#frame-name}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.name</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.name</x-search>
 
 Returns frame's name attribute as specified in the tag.
 
@@ -844,7 +844,7 @@ frame.name();
 
 ### page {#frame-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.page</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.page</x-search>
 
 Returns the page containing this frame.
 
@@ -861,7 +861,7 @@ frame.page();
 
 ### parentFrame {#frame-parent-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.parentFrame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.parentFrame</x-search>
 
 Parent frame, if any. Detached frames and main frames return `null`.
 
@@ -878,7 +878,7 @@ frame.parentFrame();
 
 ### setContent {#frame-set-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.setContent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.setContent</x-search>
 
 This method internally calls [document.write()](https://developer.mozilla.org/en-US/docs/Web/API/Document/write), inheriting all its specific characteristics and behaviors.
 
@@ -912,7 +912,7 @@ await frame.setContent(html, options);
 
 ### title {#frame-title}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.title</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.title</x-search>
 
 Returns the page title.
 
@@ -929,7 +929,7 @@ await frame.title();
 
 ### url {#frame-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.url</x-search>
 
 Returns frame's url.
 
@@ -946,7 +946,7 @@ frame.url();
 
 ### waitForFunction {#frame-wait-for-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForFunction</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.waitForFunction</x-search>
 
 Returns when the `pageFunction` returns a truthy value, returns that value.
 
@@ -996,7 +996,7 @@ await frame.waitForFunction(selector => !!document.querySelector(selector), sele
 
 ### waitForLoadState {#frame-wait-for-load-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForLoadState</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.waitForLoadState</x-search>
 
 Waits for the required load state to be reached.
 
@@ -1227,7 +1227,7 @@ const divsCounts = await frame.$$eval('div', (divs, min) => divs.length >= min, 
 
 ### check {#frame-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.check</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.check</x-search>
 
 :::warning[Discouraged]
 
@@ -1294,7 +1294,7 @@ await frame.check(selector, options);
 
 ### click {#frame-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.click</x-search>
 
 :::warning[Discouraged]
 
@@ -1372,7 +1372,7 @@ await frame.click(selector, options);
 
 ### dblclick {#frame-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.dblclick</x-search>
 
 :::warning[Discouraged]
 
@@ -1450,7 +1450,7 @@ await frame.dblclick(selector, options);
 
 ### dispatchEvent {#frame-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dispatchEvent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.dispatchEvent</x-search>
 
 :::warning[Discouraged]
 
@@ -1514,7 +1514,7 @@ await frame.dispatchEvent('#source', 'dragstart', { dataTransfer });
 
 ### fill {#frame-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.fill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.fill</x-search>
 
 :::warning[Discouraged]
 
@@ -1569,7 +1569,7 @@ await frame.fill(selector, value, options);
 
 ### focus {#frame-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.focus</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.focus</x-search>
 
 :::warning[Discouraged]
 
@@ -1606,7 +1606,7 @@ await frame.focus(selector, options);
 
 ### getAttribute {#frame-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.getAttribute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.getAttribute</x-search>
 
 :::warning[Discouraged]
 
@@ -1646,7 +1646,7 @@ await frame.getAttribute(selector, name, options);
 
 ### hover {#frame-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.hover</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.hover</x-search>
 
 :::warning[Discouraged]
 
@@ -1714,7 +1714,7 @@ await frame.hover(selector, options);
 
 ### innerHTML {#frame-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerHTML</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.innerHTML</x-search>
 
 :::warning[Discouraged]
 
@@ -1751,7 +1751,7 @@ await frame.innerHTML(selector, options);
 
 ### innerText {#frame-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.innerText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.innerText</x-search>
 
 :::warning[Discouraged]
 
@@ -1827,7 +1827,7 @@ await frame.inputValue(selector, options);
 
 ### isChecked {#frame-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isChecked</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isChecked</x-search>
 
 :::warning[Discouraged]
 
@@ -1864,7 +1864,7 @@ await frame.isChecked(selector, options);
 
 ### isDisabled {#frame-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isDisabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isDisabled</x-search>
 
 :::warning[Discouraged]
 
@@ -1901,7 +1901,7 @@ await frame.isDisabled(selector, options);
 
 ### isEditable {#frame-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isEditable</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isEditable</x-search>
 
 :::warning[Discouraged]
 
@@ -1938,7 +1938,7 @@ await frame.isEditable(selector, options);
 
 ### isHidden {#frame-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isHidden</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isHidden</x-search>
 
 :::warning[Discouraged]
 
@@ -1978,7 +1978,7 @@ await frame.isHidden(selector, options);
 
 ### isVisible {#frame-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.isVisible</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.isVisible</x-search>
 
 :::warning[Discouraged]
 
@@ -2018,7 +2018,7 @@ await frame.isVisible(selector, options);
 
 ### press {#frame-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.press</x-search>
 
 :::warning[Discouraged]
 
@@ -2079,7 +2079,7 @@ await frame.press(selector, key, options);
 
 ### selectOption {#frame-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.selectOption</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.selectOption</x-search>
 
 :::warning[Discouraged]
 
@@ -2222,7 +2222,7 @@ await frame.setChecked(selector, checked, options);
 
 ### setInputFiles {#frame-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.setInputFiles</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.setInputFiles</x-search>
 
 :::warning[Discouraged]
 
@@ -2279,7 +2279,7 @@ await frame.setInputFiles(selector, files, options);
 
 ### tap {#frame-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.tap</x-search>
 
 :::warning[Discouraged]
 
@@ -2351,7 +2351,7 @@ await frame.tap(selector, options);
 
 ### textContent {#frame-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.textContent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.textContent</x-search>
 
 :::warning[Discouraged]
 
@@ -2388,7 +2388,7 @@ await frame.textContent(selector, options);
 
 ### type {#frame-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.type</x-search>
 
 :::warning Deprecated
 
@@ -2436,7 +2436,7 @@ To press a special key, like `Control` or `ArrowDown`, use [keyboard.press()](/a
 
 ### uncheck {#frame-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.uncheck</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.uncheck</x-search>
 
 :::warning[Discouraged]
 
@@ -2503,7 +2503,7 @@ await frame.uncheck(selector, options);
 
 ### waitForNavigation {#frame-wait-for-navigation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForNavigation</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.waitForNavigation</x-search>
 
 :::warning Deprecated
 
@@ -2552,7 +2552,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 ### waitForSelector {#frame-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForSelector</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.waitForSelector</x-search>
 
 :::warning[Discouraged]
 
@@ -2614,7 +2614,7 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 
 ### waitForTimeout {#frame-wait-for-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.waitForTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.waitForTimeout</x-search>
 
 :::warning[Discouraged]
 

--- a/nodejs/docs/api/class-jshandle.mdx
+++ b/nodejs/docs/api/class-jshandle.mdx
@@ -25,7 +25,7 @@ JSHandle instances can be used as an argument in [page.$eval()](/api/class-page.
 
 ### asElement {#js-handle-as-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.asElement</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.asElement</x-search>
 
 Returns either `null` or the object handle itself, if the object handle is an instance of [ElementHandle].
 
@@ -42,7 +42,7 @@ jsHandle.asElement();
 
 ### dispose {#js-handle-dispose}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.dispose</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.dispose</x-search>
 
 The `jsHandle.dispose` method stops referencing the element handle.
 
@@ -59,7 +59,7 @@ await jsHandle.dispose();
 
 ### evaluate {#js-handle-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.evaluate</x-search>
 
 Returns the return value of `pageFunction`.
 
@@ -89,7 +89,7 @@ expect(await tweetHandle.evaluate(node => node.innerText)).toBe('10 retweets');
 
 ### evaluateHandle {#js-handle-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.evaluateHandle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.evaluateHandle</x-search>
 
 Returns the return value of `pageFunction` as a [JSHandle].
 
@@ -123,7 +123,7 @@ await jsHandle.evaluateHandle(pageFunction, arg);
 
 ### getProperties {#js-handle-get-properties}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.getProperties</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.getProperties</x-search>
 
 The method returns a map with **own property names** as keys and JSHandle instances for the property values.
 
@@ -144,7 +144,7 @@ await handle.dispose();
 
 ### getProperty {#js-handle-get-property}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.getProperty</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.getProperty</x-search>
 
 Fetches a single property from the referenced object.
 
@@ -166,7 +166,7 @@ await jsHandle.getProperty(propertyName);
 
 ### jsonValue {#js-handle-json-value}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.jsonValue</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.jsonValue</x-search>
 
 Returns a JSON representation of the object. If the object has a `toJSON` function, it **will not be called**.
 

--- a/nodejs/docs/api/class-keyboard.mdx
+++ b/nodejs/docs/api/class-keyboard.mdx
@@ -50,7 +50,7 @@ await page.keyboard.press('Meta+A');
 
 ### down {#keyboard-down}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.down</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.down</x-search>
 
 Dispatches a `keydown` event.
 
@@ -90,7 +90,7 @@ await keyboard.down(key);
 
 ### insertText {#keyboard-insert-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.insertText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.insertText</x-search>
 
 Dispatches only `input` event, does not emit the `keydown`, `keyup` or `keypress` events.
 
@@ -116,7 +116,7 @@ Modifier keys DO NOT effect `keyboard.insertText`. Holding down `Shift` will not
 
 ### press {#keyboard-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.press</x-search>
 
 :::tip
 In most cases, you should use [locator.press()](/api/class-locator.mdx#locator-press) instead.
@@ -166,7 +166,7 @@ Shortcut for [keyboard.down()](/api/class-keyboard.mdx#keyboard-down) and [keybo
 
 ### type {#keyboard-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.type</x-search>
 
 :::caution
 In most cases, you should use [locator.fill()](/api/class-locator.mdx#locator-fill) instead. You only need to press keys one by one if there is special keyboard handling on the page - in this case use [locator.pressSequentially()](/api/class-locator.mdx#locator-press-sequentially).
@@ -207,7 +207,7 @@ For characters that are not on a US keyboard, only an `input` event will be sent
 
 ### up {#keyboard-up}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.up</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.up</x-search>
 
 Dispatches a `keyup` event.
 

--- a/nodejs/docs/api/class-logger.mdx
+++ b/nodejs/docs/api/class-logger.mdx
@@ -30,7 +30,7 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 
 ### isEnabled {#logger-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>logger.isEnabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>logger.isEnabled</x-search>
 
 Determines whether sink is interested in the logger with the given name and severity.
 
@@ -53,7 +53,7 @@ logger.isEnabled(name, severity);
 
 ### log {#logger-log}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>logger.log</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>logger.log</x-search>
 
 **Usage**
 

--- a/nodejs/docs/api/class-mouse.mdx
+++ b/nodejs/docs/api/class-mouse.mdx
@@ -29,7 +29,7 @@ await page.mouse.up();
 
 ### click {#mouse-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.click</x-search>
 
 Shortcut for [mouse.move()](/api/class-mouse.mdx#mouse-move), [mouse.down()](/api/class-mouse.mdx#mouse-down), [mouse.up()](/api/class-mouse.mdx#mouse-up).
 
@@ -65,7 +65,7 @@ await mouse.click(x, y, options);
 
 ### dblclick {#mouse-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.dblclick</x-search>
 
 Shortcut for [mouse.move()](/api/class-mouse.mdx#mouse-move), [mouse.down()](/api/class-mouse.mdx#mouse-down), [mouse.up()](/api/class-mouse.mdx#mouse-up), [mouse.down()](/api/class-mouse.mdx#mouse-down) and [mouse.up()](/api/class-mouse.mdx#mouse-up).
 
@@ -98,7 +98,7 @@ await mouse.dblclick(x, y, options);
 
 ### down {#mouse-down}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.down</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.down</x-search>
 
 Dispatches a `mousedown` event.
 
@@ -125,7 +125,7 @@ await mouse.down(options);
 
 ### move {#mouse-move}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.move</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.move</x-search>
 
 Dispatches a `mousemove` event.
 
@@ -155,7 +155,7 @@ await mouse.move(x, y, options);
 
 ### up {#mouse-up}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.up</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.up</x-search>
 
 Dispatches a `mouseup` event.
 

--- a/nodejs/docs/api/class-page.mdx
+++ b/nodejs/docs/api/class-page.mdx
@@ -51,7 +51,7 @@ page.removeListener('request', logRequest);
 
 ### addInitScript {#page-add-init-script}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.addInitScript</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.addInitScript</x-search>
 
 Adds a script which would be evaluated in one of the following scenarios:
 * Whenever the page is navigated.
@@ -192,7 +192,7 @@ await page.addLocatorHandler(page.getByLabel('Close'), async locator => {
 
 ### addScriptTag {#page-add-script-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.addScriptTag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.addScriptTag</x-search>
 
 Adds a `<script>` tag into the page with the desired url or content. Returns the added tag when the script's onload fires or when the script content was injected into frame.
 
@@ -225,7 +225,7 @@ await page.addScriptTag(options);
 
 ### addStyleTag {#page-add-style-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.addStyleTag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.addStyleTag</x-search>
 
 Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<style type="text/css">` tag with the content. Returns the added tag when the stylesheet's onload fires or when the CSS content was injected into frame.
 
@@ -255,7 +255,7 @@ await page.addStyleTag(options);
 
 ### bringToFront {#page-bring-to-front}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.bringToFront</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.bringToFront</x-search>
 
 Brings page to front (activates tab).
 
@@ -272,7 +272,7 @@ await page.bringToFront();
 
 ### close {#page-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.close</x-search>
 
 If `runBeforeUnload` is `false`, does not run any unload handlers and waits for the page to be closed. If `runBeforeUnload` is `true` the method will run unload handlers, but will **not** wait for the page to close.
 
@@ -305,7 +305,7 @@ await page.close(options);
 
 ### content {#page-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.content</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.content</x-search>
 
 Gets the full HTML contents of the page, including the doctype.
 
@@ -322,7 +322,7 @@ await page.content();
 
 ### context {#page-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.context</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.context</x-search>
 
 Get the browser context that the page belongs to.
 
@@ -406,7 +406,7 @@ await page.dragAndDrop('#source', '#target', {
 
 ### emulateMedia {#page-emulate-media}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.emulateMedia</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.emulateMedia</x-search>
 
 This method changes the `CSS media type` through the `media` argument, and/or the `'prefers-colors-scheme'` media feature, using the `colorScheme` argument.
 
@@ -463,7 +463,7 @@ await page.evaluate(() => matchMedia('(prefers-color-scheme: no-preference)').ma
 
 ### evaluate {#page-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.evaluate</x-search>
 
 Returns the value of the `pageFunction` invocation.
 
@@ -515,7 +515,7 @@ await bodyHandle.dispose();
 
 ### evaluateHandle {#page-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.evaluateHandle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.evaluateHandle</x-search>
 
 Returns the value of the `pageFunction` invocation as a [JSHandle].
 
@@ -560,7 +560,7 @@ await resultHandle.dispose();
 
 ### exposeBinding {#page-expose-binding}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.exposeBinding</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.exposeBinding</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in this page. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`. If the `callback` returns a [Promise], it will be awaited.
 
@@ -621,7 +621,7 @@ const { webkit } = require('playwright');  // Or 'chromium' or 'firefox'.
 
 ### exposeFunction {#page-expose-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.exposeFunction</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.exposeFunction</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in the page. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`.
 
@@ -675,7 +675,7 @@ const crypto = require('crypto');
 
 ### frame {#page-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.frame</x-search>
 
 Returns frame matching the specified criteria. Either `name` or `url` must be specified.
 
@@ -732,7 +732,7 @@ await locator.click();
 
 ### frames {#page-frames}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.frames</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.frames</x-search>
 
 An array of all frames attached to the page.
 
@@ -1079,7 +1079,7 @@ await expect(page.getByTitle('Issues count')).toHaveText('25 issues');
 
 ### goBack {#page-go-back}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.goBack</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.goBack</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. If cannot go back, returns `null`.
 
@@ -1112,7 +1112,7 @@ await page.goBack(options);
 
 ### goForward {#page-go-forward}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.goForward</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.goForward</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. If cannot go forward, returns `null`.
 
@@ -1145,7 +1145,7 @@ await page.goForward(options);
 
 ### goto {#page-goto}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.goto</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.goto</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the first non-redirect response.
 
@@ -1199,7 +1199,7 @@ await page.goto(url, options);
 
 ### isClosed {#page-is-closed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isClosed</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isClosed</x-search>
 
 Indicates that the page has been closed.
 
@@ -1260,7 +1260,7 @@ page.locator(selector, options);
 
 ### mainFrame {#page-main-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.mainFrame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.mainFrame</x-search>
 
 The page's main frame. Page is guaranteed to have a main frame which persists during navigations.
 
@@ -1277,7 +1277,7 @@ page.mainFrame();
 
 ### opener {#page-opener}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.opener</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.opener</x-search>
 
 Returns the opener for popup pages and `null` for others. If the opener has been closed already the returns `null`.
 
@@ -1317,7 +1317,7 @@ await page.pause();
 
 ### pdf {#page-pdf}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.pdf</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.pdf</x-search>
 
 Returns the PDF buffer.
 
@@ -1441,7 +1441,7 @@ The `format` options are:
 
 ### reload {#page-reload}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.reload</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.reload</x-search>
 
 This method reloads the current page, in the same way as if the user had triggered a browser refresh. Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
@@ -1494,7 +1494,7 @@ await page.removeLocatorHandler(locator);
 
 ### route {#page-route}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.route</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.route</x-search>
 
 Routing provides the capability to modify network requests that are made by a page.
 
@@ -1613,7 +1613,7 @@ await page.routeFromHAR(har, options);
 
 ### screenshot {#page-screenshot}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.screenshot</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.screenshot</x-search>
 
 Returns the buffer with the captured screenshot.
 
@@ -1691,7 +1691,7 @@ await page.screenshot(options);
 
 ### setContent {#page-set-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setContent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setContent</x-search>
 
 This method internally calls [document.write()](https://developer.mozilla.org/en-US/docs/Web/API/Document/write), inheriting all its specific characteristics and behaviors.
 
@@ -1725,7 +1725,7 @@ await page.setContent(html, options);
 
 ### setDefaultNavigationTimeout {#page-set-default-navigation-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setDefaultNavigationTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setDefaultNavigationTimeout</x-search>
 
 This setting will change the default maximum navigation time for the following methods and related shortcuts:
 * [page.goBack()](/api/class-page.mdx#page-go-back)
@@ -1755,7 +1755,7 @@ page.setDefaultNavigationTimeout(timeout);
 
 ### setDefaultTimeout {#page-set-default-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setDefaultTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setDefaultTimeout</x-search>
 
 This setting will change the default maximum time for all the methods accepting `timeout` option.
 
@@ -1778,7 +1778,7 @@ page.setDefaultTimeout(timeout);
 
 ### setExtraHTTPHeaders {#page-set-extra-http-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setExtraHTTPHeaders</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setExtraHTTPHeaders</x-search>
 
 The extra HTTP headers will be sent with every request the page initiates.
 
@@ -1804,7 +1804,7 @@ await page.setExtraHTTPHeaders(headers);
 
 ### setViewportSize {#page-set-viewport-size}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setViewportSize</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setViewportSize</x-search>
 
 In the case of multiple pages in a single browser, each page can have its own viewport size. However, [browser.newContext()](/api/class-browser.mdx#browser-new-context) allows to set viewport size (and more) for all pages in the context at once.
 
@@ -1837,7 +1837,7 @@ await page.goto('https://example.com');
 
 ### title {#page-title}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.title</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.title</x-search>
 
 Returns the page's title.
 
@@ -1854,7 +1854,7 @@ await page.title();
 
 ### unroute {#page-unroute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.unroute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.unroute</x-search>
 
 Removes a route created with [page.route()](/api/class-page.mdx#page-route). When `handler` is not specified, removes all routes for the `url`.
 
@@ -1907,7 +1907,7 @@ await page.unrouteAll(options);
 
 ### url {#page-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.url</x-search>
 
 **Usage**
 
@@ -1922,7 +1922,7 @@ page.url();
 
 ### video {#page-video}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.video</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.video</x-search>
 
 Video object associated with this page.
 
@@ -1939,7 +1939,7 @@ page.video();
 
 ### viewportSize {#page-viewport-size}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.viewportSize</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.viewportSize</x-search>
 
 **Usage**
 
@@ -1960,7 +1960,7 @@ page.viewportSize();
 
 ### waitForEvent {#page-wait-for-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForEvent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForEvent</x-search>
 
 Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy value. Will throw an error if the page is closed before the event is fired. Returns the event data value.
 
@@ -1998,7 +1998,7 @@ const download = await downloadPromise;
 
 ### waitForFunction {#page-wait-for-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForFunction</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForFunction</x-search>
 
 Returns when the `pageFunction` returns a truthy value. It resolves to a JSHandle of the truthy value.
 
@@ -2048,7 +2048,7 @@ await page.waitForFunction(selector => !!document.querySelector(selector), selec
 
 ### waitForLoadState {#page-wait-for-load-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForLoadState</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForLoadState</x-search>
 
 Returns when the required load state has been reached.
 
@@ -2092,7 +2092,7 @@ console.log(await popup.title()); // Popup is ready to use.
 
 ### waitForRequest {#page-wait-for-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForRequest</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForRequest</x-search>
 
 Waits for the matching request and returns it. See [waiting for event](../events.mdx#waiting-for-event) for more details about events.
 
@@ -2128,7 +2128,7 @@ const request = await requestPromise;
 
 ### waitForResponse {#page-wait-for-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForResponse</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForResponse</x-search>
 
 Returns the matched response. See [waiting for event](../events.mdx#waiting-for-event) for more details about events.
 
@@ -2199,7 +2199,7 @@ await page.waitForURL('**/target.html');
 
 ### workers {#page-workers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.workers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.workers</x-search>
 
 This method returns all of the dedicated [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) associated with the page.
 
@@ -2239,7 +2239,7 @@ page.clock
 
 ### coverage {#page-coverage}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.coverage</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.coverage</x-search>
 
 :::note
 Only available for Chromium atm.
@@ -2260,7 +2260,7 @@ page.coverage
 
 ### keyboard {#page-keyboard}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.keyboard</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.keyboard</x-search>
 
 **Usage**
 
@@ -2275,7 +2275,7 @@ page.keyboard
 
 ### mouse {#page-mouse}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.mouse</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.mouse</x-search>
 
 **Usage**
 
@@ -2307,7 +2307,7 @@ page.request
 
 ### touchscreen {#page-touchscreen}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.touchscreen</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.touchscreen</x-search>
 
 **Usage**
 
@@ -2324,7 +2324,7 @@ page.touchscreen
 
 ### on('close') {#page-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on('close')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on('close')</x-search>
 
 Emitted when the page closes.
 
@@ -2341,7 +2341,7 @@ page.on('close', data => {});
 
 ### on('console') {#page-event-console}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on('console')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on('console')</x-search>
 
 Emitted when JavaScript within the page calls one of console API methods, e.g. `console.log` or `console.dir`.
 
@@ -2366,7 +2366,7 @@ await page.evaluate(() => console.log('hello', 5, { foo: 'bar' }));
 
 ### on('crash') {#page-event-crash}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on('crash')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on('crash')</x-search>
 
 Emitted when the page crashes. Browser pages might crash if they try to allocate too much memory. When the page crashes, ongoing and subsequent operations will throw.
 
@@ -2396,7 +2396,7 @@ page.on('crash', data => {});
 
 ### on('dialog') {#page-event-dialog}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on('dialog')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on('dialog')</x-search>
 
 Emitted when a JavaScript dialog appears, such as `alert`, `prompt`, `confirm` or `beforeunload`. Listener **must** either [dialog.accept()](/api/class-dialog.mdx#dialog-accept) or [dialog.dismiss()](/api/class-dialog.mdx#dialog-dismiss) the dialog - otherwise the page will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the dialog, and actions like click will never finish.
 
@@ -2434,7 +2434,7 @@ page.on('domcontentloaded', data => {});
 
 ### on('download') {#page-event-download}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on('download')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on('download')</x-search>
 
 Emitted when attachment download started. User can access basic file operations on downloaded content via the passed [Download] instance.
 
@@ -2525,7 +2525,7 @@ page.on('framenavigated', data => {});
 
 ### on('load') {#page-event-load}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on('load')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on('load')</x-search>
 
 Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched.
 
@@ -2569,7 +2569,7 @@ page.on('pageerror', data => {});
 
 ### on('popup') {#page-event-popup}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on('popup')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on('popup')</x-search>
 
 Emitted when the page opens a new tab or window. This event is emitted in addition to the [browserContext.on('page')](/api/class-browsercontext.mdx#browser-context-event-page), but only for popups relevant to this page.
 
@@ -2600,7 +2600,7 @@ page.on('popup', data => {});
 
 ### on('request') {#page-event-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on('request')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on('request')</x-search>
 
 Emitted when a page issues a request. The [request] object is read-only. In order to intercept and mutate requests, see [page.route()](/api/class-page.mdx#page-route) or [browserContext.route()](/api/class-browsercontext.mdx#browser-context-route).
 
@@ -2661,7 +2661,7 @@ page.on('requestfinished', data => {});
 
 ### on('response') {#page-event-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on('response')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on('response')</x-search>
 
 Emitted when [response] status and headers are received for a request. For a successful response, the sequence of events is `request`, `response` and `requestfinished`.
 
@@ -2695,7 +2695,7 @@ page.on('websocket', data => {});
 
 ### on('worker') {#page-event-worker}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on('worker')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on('worker')</x-search>
 
 Emitted when a dedicated [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) is spawned by the page.
 
@@ -2859,7 +2859,7 @@ const divCounts = await page.$$eval('div', (divs, min) => divs.length >= min, 10
 
 ### accessibility {#page-accessibility}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.accessibility</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.accessibility</x-search>
 
 :::warning Deprecated
 
@@ -2881,7 +2881,7 @@ page.accessibility
 
 ### check {#page-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.check</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.check</x-search>
 
 :::warning[Discouraged]
 
@@ -2948,7 +2948,7 @@ await page.check(selector, options);
 
 ### click {#page-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.click</x-search>
 
 :::warning[Discouraged]
 
@@ -3026,7 +3026,7 @@ await page.click(selector, options);
 
 ### dblclick {#page-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.dblclick</x-search>
 
 :::warning[Discouraged]
 
@@ -3104,7 +3104,7 @@ await page.dblclick(selector, options);
 
 ### dispatchEvent {#page-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dispatchEvent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.dispatchEvent</x-search>
 
 :::warning[Discouraged]
 
@@ -3168,7 +3168,7 @@ await page.dispatchEvent('#source', 'dragstart', { dataTransfer });
 
 ### fill {#page-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.fill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.fill</x-search>
 
 :::warning[Discouraged]
 
@@ -3223,7 +3223,7 @@ await page.fill(selector, value, options);
 
 ### focus {#page-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.focus</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.focus</x-search>
 
 :::warning[Discouraged]
 
@@ -3260,7 +3260,7 @@ await page.focus(selector, options);
 
 ### getAttribute {#page-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.getAttribute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.getAttribute</x-search>
 
 :::warning[Discouraged]
 
@@ -3300,7 +3300,7 @@ await page.getAttribute(selector, name, options);
 
 ### hover {#page-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.hover</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.hover</x-search>
 
 :::warning[Discouraged]
 
@@ -3368,7 +3368,7 @@ await page.hover(selector, options);
 
 ### innerHTML {#page-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerHTML</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.innerHTML</x-search>
 
 :::warning[Discouraged]
 
@@ -3405,7 +3405,7 @@ await page.innerHTML(selector, options);
 
 ### innerText {#page-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.innerText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.innerText</x-search>
 
 :::warning[Discouraged]
 
@@ -3481,7 +3481,7 @@ await page.inputValue(selector, options);
 
 ### isChecked {#page-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isChecked</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isChecked</x-search>
 
 :::warning[Discouraged]
 
@@ -3518,7 +3518,7 @@ await page.isChecked(selector, options);
 
 ### isDisabled {#page-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isDisabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isDisabled</x-search>
 
 :::warning[Discouraged]
 
@@ -3555,7 +3555,7 @@ await page.isDisabled(selector, options);
 
 ### isEditable {#page-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEditable</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isEditable</x-search>
 
 :::warning[Discouraged]
 
@@ -3592,7 +3592,7 @@ await page.isEditable(selector, options);
 
 ### isEnabled {#page-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isEnabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isEnabled</x-search>
 
 :::warning[Discouraged]
 
@@ -3629,7 +3629,7 @@ await page.isEnabled(selector, options);
 
 ### isHidden {#page-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isHidden</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isHidden</x-search>
 
 :::warning[Discouraged]
 
@@ -3669,7 +3669,7 @@ await page.isHidden(selector, options);
 
 ### isVisible {#page-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.isVisible</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.isVisible</x-search>
 
 :::warning[Discouraged]
 
@@ -3709,7 +3709,7 @@ await page.isVisible(selector, options);
 
 ### press {#page-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.press</x-search>
 
 :::warning[Discouraged]
 
@@ -3779,7 +3779,7 @@ await browser.close();
 
 ### selectOption {#page-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.selectOption</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.selectOption</x-search>
 
 :::warning[Discouraged]
 
@@ -3923,7 +3923,7 @@ await page.setChecked(selector, checked, options);
 
 ### setInputFiles {#page-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.setInputFiles</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.setInputFiles</x-search>
 
 :::warning[Discouraged]
 
@@ -3980,7 +3980,7 @@ await page.setInputFiles(selector, files, options);
 
 ### tap {#page-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.tap</x-search>
 
 :::warning[Discouraged]
 
@@ -4052,7 +4052,7 @@ await page.tap(selector, options);
 
 ### textContent {#page-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.textContent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.textContent</x-search>
 
 :::warning[Discouraged]
 
@@ -4089,7 +4089,7 @@ await page.textContent(selector, options);
 
 ### type {#page-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.type</x-search>
 
 :::warning Deprecated
 
@@ -4137,7 +4137,7 @@ To press a special key, like `Control` or `ArrowDown`, use [keyboard.press()](/a
 
 ### uncheck {#page-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.uncheck</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.uncheck</x-search>
 
 :::warning[Discouraged]
 
@@ -4204,7 +4204,7 @@ await page.uncheck(selector, options);
 
 ### waitForNavigation {#page-wait-for-navigation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForNavigation</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForNavigation</x-search>
 
 :::warning Deprecated
 
@@ -4253,7 +4253,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 ### waitForSelector {#page-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForSelector</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForSelector</x-search>
 
 :::warning[Discouraged]
 
@@ -4315,7 +4315,7 @@ const { chromium } = require('playwright');  // Or 'firefox' or 'webkit'.
 
 ### waitForTimeout {#page-wait-for-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.waitForTimeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.waitForTimeout</x-search>
 
 :::warning[Discouraged]
 

--- a/nodejs/docs/api/class-playwright.mdx
+++ b/nodejs/docs/api/class-playwright.mdx
@@ -28,7 +28,7 @@ const { chromium, firefox, webkit } = require('playwright');
 
 ### chromium {#playwright-chromium}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.chromium</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.chromium</x-search>
 
 This object can be used to launch or connect to Chromium, returning instances of [Browser].
 
@@ -45,7 +45,7 @@ playwright.chromium
 
 ### devices {#playwright-devices}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.devices</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.devices</x-search>
 
 Returns a dictionary of devices to be used with [browser.newContext()](/api/class-browser.mdx#browser-new-context) or [browser.newPage()](/api/class-browser.mdx#browser-new-page).
 
@@ -78,7 +78,7 @@ playwright.devices
 
 ### errors {#playwright-errors}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.errors</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.errors</x-search>
 
 Playwright methods might throw errors if they are unable to fulfill a request. For example, [locator.waitFor()](/api/class-locator.mdx#locator-wait-for) might fail if the selector doesn't match any nodes during the given timeframe.
 
@@ -112,7 +112,7 @@ playwright.errors
 
 ### firefox {#playwright-firefox}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.firefox</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.firefox</x-search>
 
 This object can be used to launch or connect to Firefox, returning instances of [Browser].
 
@@ -146,7 +146,7 @@ playwright.request
 
 ### selectors {#playwright-selectors}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.selectors</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.selectors</x-search>
 
 Selectors can be used to install custom selector engines. See [extensibility](../extensibility.mdx) for more information.
 
@@ -163,7 +163,7 @@ playwright.selectors
 
 ### webkit {#playwright-webkit}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.webkit</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.webkit</x-search>
 
 This object can be used to launch or connect to WebKit, returning instances of [Browser].
 

--- a/nodejs/docs/api/class-request.mdx
+++ b/nodejs/docs/api/class-request.mdx
@@ -44,7 +44,7 @@ await request.allHeaders();
 
 ### failure {#request-failure}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.failure</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.failure</x-search>
 
 The method returns `null` unless this request has failed, as reported by `requestfailed` event.
 
@@ -68,7 +68,7 @@ page.on('requestfailed', request => {
 
 ### frame {#request-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.frame</x-search>
 
 Returns the [Frame] that initiated this request.
 
@@ -124,7 +124,7 @@ await request.headerValue(name);
 
 ### headers {#request-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.headers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.headers</x-search>
 
 An object with the request HTTP headers. The header names are lower-cased. Note that this method does not return security-related headers, including cookie-related ones. You can use [request.allHeaders()](/api/class-request.mdx#request-all-headers) for complete list of headers that include `cookie` information.
 
@@ -164,7 +164,7 @@ await request.headersArray();
 
 ### isNavigationRequest {#request-is-navigation-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.isNavigationRequest</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.isNavigationRequest</x-search>
 
 Whether this request is driving frame's navigation.
 
@@ -183,7 +183,7 @@ request.isNavigationRequest();
 
 ### method {#request-method}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.method</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.method</x-search>
 
 Request's method (GET, POST, etc.)
 
@@ -200,7 +200,7 @@ request.method();
 
 ### postData {#request-post-data}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.postData</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.postData</x-search>
 
 Request's post body, if any.
 
@@ -217,7 +217,7 @@ request.postData();
 
 ### postDataBuffer {#request-post-data-buffer}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.postDataBuffer</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.postDataBuffer</x-search>
 
 Request's post body in a binary form, if any.
 
@@ -234,7 +234,7 @@ request.postDataBuffer();
 
 ### postDataJSON {#request-post-data-json}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.postDataJSON</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.postDataJSON</x-search>
 
 Returns parsed request's body for `form-urlencoded` and JSON as a fallback if any.
 
@@ -253,7 +253,7 @@ request.postDataJSON();
 
 ### redirectedFrom {#request-redirected-from}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.redirectedFrom</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.redirectedFrom</x-search>
 
 Request that was redirected by the server to this one, if any.
 
@@ -282,7 +282,7 @@ console.log(response.request().redirectedFrom()); // null
 
 ### redirectedTo {#request-redirected-to}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.redirectedTo</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.redirectedTo</x-search>
 
 New request issued by the browser if the server responded with redirect.
 
@@ -301,7 +301,7 @@ console.log(request.redirectedFrom().redirectedTo() === request); // true
 
 ### resourceType {#request-resource-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.resourceType</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.resourceType</x-search>
 
 Contains the request's resource type as it was perceived by the rendering engine. ResourceType will be one of the following: `document`, `stylesheet`, `image`, `media`, `font`, `script`, `texttrack`, `xhr`, `fetch`, `eventsource`, `websocket`, `manifest`, `other`.
 
@@ -318,7 +318,7 @@ request.resourceType();
 
 ### response {#request-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.response</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.response</x-search>
 
 Returns the matching [Response] object, or `null` if the response was not received due to error.
 
@@ -387,7 +387,7 @@ await request.sizes();
 
 ### timing {#request-timing}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.timing</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.timing</x-search>
 
 Returns resource timing information for given request. Most of the timing values become available upon the response, `responseEnd` becomes available when request finishes. Find more information at [Resource Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming).
 
@@ -434,7 +434,7 @@ console.log(request.timing());
 
 ### url {#request-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.url</x-search>
 
 URL of the request.
 

--- a/nodejs/docs/api/class-response.mdx
+++ b/nodejs/docs/api/class-response.mdx
@@ -33,7 +33,7 @@ await response.allHeaders();
 
 ### body {#response-body}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.body</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.body</x-search>
 
 Returns the buffer with response body.
 
@@ -50,7 +50,7 @@ await response.body();
 
 ### finished {#response-finished}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.finished</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.finished</x-search>
 
 Waits for this response to finish, returns always `null`.
 
@@ -67,7 +67,7 @@ await response.finished();
 
 ### frame {#response-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.frame</x-search>
 
 Returns the [Frame] that initiated this response.
 
@@ -145,7 +145,7 @@ await response.headerValues(name);
 
 ### headers {#response-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.headers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.headers</x-search>
 
 An object with the response HTTP headers. The header names are lower-cased. Note that this method does not return security-related headers, including cookie-related ones. You can use [response.allHeaders()](/api/class-response.mdx#response-all-headers) for complete list of headers that include `cookie` information.
 
@@ -185,7 +185,7 @@ await response.headersArray();
 
 ### json {#response-json}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.json</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.json</x-search>
 
 Returns the JSON representation of response body.
 
@@ -204,7 +204,7 @@ await response.json();
 
 ### ok {#response-ok}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.ok</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.ok</x-search>
 
 Contains a boolean stating whether the response was successful (status in the range 200-299) or not.
 
@@ -221,7 +221,7 @@ response.ok();
 
 ### request {#response-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.request</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.request</x-search>
 
 Returns the matching [Request] object.
 
@@ -292,7 +292,7 @@ await response.serverAddr();
 
 ### status {#response-status}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.status</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.status</x-search>
 
 Contains the status code of the response (e.g., 200 for a success).
 
@@ -309,7 +309,7 @@ response.status();
 
 ### statusText {#response-status-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.statusText</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.statusText</x-search>
 
 Contains the status text of the response (e.g. usually an "OK" for a success).
 
@@ -326,7 +326,7 @@ response.statusText();
 
 ### text {#response-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.text</x-search>
 
 Returns the text representation of response body.
 
@@ -343,7 +343,7 @@ await response.text();
 
 ### url {#response-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.url</x-search>
 
 Contains the URL of the response.
 

--- a/nodejs/docs/api/class-route.mdx
+++ b/nodejs/docs/api/class-route.mdx
@@ -18,7 +18,7 @@ Learn more about [networking](../network.mdx).
 
 ### abort {#route-abort}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.abort</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.abort</x-search>
 
 Aborts the route's request.
 
@@ -55,7 +55,7 @@ await route.abort(errorCode);
 
 ### continue {#route-continue}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.continue</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.continue</x-search>
 
 Continues route's request with optional overrides.
 
@@ -230,7 +230,7 @@ Note that `headers` option will apply to the fetched request as well as any redi
 
 ### fulfill {#route-fulfill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.fulfill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.fulfill</x-search>
 
 Fulfills route's request with given response.
 
@@ -285,7 +285,7 @@ await page.route('**/xhr_endpoint', route => route.fulfill({ path: 'mock_data.js
 
 ### request {#route-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.request</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.request</x-search>
 
 A request to be routed.
 

--- a/nodejs/docs/api/class-selectors.mdx
+++ b/nodejs/docs/api/class-selectors.mdx
@@ -16,7 +16,7 @@ Selectors can be used to install custom selector engines. See [extensibility](..
 
 ### register {#selectors-register}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>selectors.register</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>selectors.register</x-search>
 
 Selectors must be registered before creating the page.
 

--- a/nodejs/docs/api/class-touchscreen.mdx
+++ b/nodejs/docs/api/class-touchscreen.mdx
@@ -16,7 +16,7 @@ The Touchscreen class operates in main-frame CSS pixels relative to the top-left
 
 ### tap {#touchscreen-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>touchscreen.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>touchscreen.tap</x-search>
 
 Dispatches a `touchstart` and `touchend` event with a single touch at the position (`x`,`y`).
 

--- a/nodejs/docs/api/class-video.mdx
+++ b/nodejs/docs/api/class-video.mdx
@@ -37,7 +37,7 @@ await video.delete();
 
 ### path {#video-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>video.path</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>video.path</x-search>
 
 Returns the file system path this video will be recorded to. The video is guaranteed to be written to the filesystem upon closing the browser context. This method throws when connected remotely.
 

--- a/nodejs/docs/api/class-websocket.mdx
+++ b/nodejs/docs/api/class-websocket.mdx
@@ -16,7 +16,7 @@ The [WebSocket] class represents websocket connections in the page.
 
 ### isClosed {#web-socket-is-closed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.isClosed</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.isClosed</x-search>
 
 Indicates that the web socket has been closed.
 
@@ -33,7 +33,7 @@ webSocket.isClosed();
 
 ### url {#web-socket-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.url</x-search>
 
 Contains the URL of the WebSocket.
 
@@ -50,7 +50,7 @@ webSocket.url();
 
 ### waitForEvent {#web-socket-wait-for-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.waitForEvent</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.waitForEvent</x-search>
 
 Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy value. Will throw an error if the webSocket is closed before the event is fired. Returns the event data value.
 
@@ -88,7 +88,7 @@ await webSocket.waitForEvent(event, optionsOrPredicate, options);
 
 ### on('close') {#web-socket-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.on('close')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.on('close')</x-search>
 
 Fired when the websocket closes.
 

--- a/nodejs/docs/api/class-worker.mdx
+++ b/nodejs/docs/api/class-worker.mdx
@@ -27,7 +27,7 @@ for (const worker of page.workers())
 
 ### evaluate {#worker-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.evaluate</x-search>
 
 Returns the return value of `pageFunction`.
 
@@ -57,7 +57,7 @@ await worker.evaluate(pageFunction, arg);
 
 ### evaluateHandle {#worker-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.evaluateHandle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.evaluateHandle</x-search>
 
 Returns the return value of `pageFunction` as a [JSHandle].
 
@@ -87,7 +87,7 @@ await worker.evaluateHandle(pageFunction, arg);
 
 ### url {#worker-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.url</x-search>
 
 **Usage**
 
@@ -104,7 +104,7 @@ worker.url();
 
 ### on('close') {#worker-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.on('close')</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.on('close')</x-search>
 
 Emitted when this dedicated [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) is terminated.
 

--- a/python/docs/api/class-accessibility.mdx
+++ b/python/docs/api/class-accessibility.mdx
@@ -22,7 +22,7 @@ Most of the accessibility tree gets filtered out when converting from internal b
 
 ### snapshot {#accessibility-snapshot}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>accessibility.snapshot</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>accessibility.snapshot</x-search>
 
 :::warning Deprecated
 

--- a/python/docs/api/class-browser.mdx
+++ b/python/docs/api/class-browser.mdx
@@ -64,7 +64,7 @@ asyncio.run(main())
 
 ### close {#browser-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.close</x-search>
 
 In case this browser is obtained using [browser_type.launch()](/api/class-browsertype.mdx#browser-type-launch), closes the browser and all of its pages (if any were opened).
 
@@ -116,7 +116,7 @@ browser.new_browser_cdp_session()
 
 ### new_context {#browser-new-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.new_context</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.new_context</x-search>
 
 Creates a new browser context. It won't share cookies/cache with other browser contexts.
 
@@ -406,7 +406,7 @@ await browser.close()
 
 ### new_page {#browser-new-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.new_page</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.new_page</x-search>
 
 Creates a new page in a new browser context. Closing this page will close the context as well.
 
@@ -756,7 +756,7 @@ browser.browser_type
 
 ### contexts {#browser-contexts}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.contexts</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.contexts</x-search>
 
 Returns an array of all open browser contexts. In a newly created browser, this will return zero browser contexts.
 
@@ -799,7 +799,7 @@ print(len(browser.contexts)) # prints `1`
 
 ### is_connected {#browser-is-connected}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.is_connected</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.is_connected</x-search>
 
 Indicates that the browser is connected.
 
@@ -816,7 +816,7 @@ browser.is_connected()
 
 ### version {#browser-version}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.version</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.version</x-search>
 
 Returns the browser version.
 
@@ -835,7 +835,7 @@ browser.version
 
 ### on("disconnected") {#browser-event-disconnected}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browser.on("disconnected")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browser.on("disconnected")</x-search>
 
 Emitted when Browser gets disconnected from the browser application. This might happen because of one of the following:
 * Browser application is closed or crashed.

--- a/python/docs/api/class-browsercontext.mdx
+++ b/python/docs/api/class-browsercontext.mdx
@@ -57,7 +57,7 @@ await context.close()
 
 ### add_cookies {#browser-context-add-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.add_cookies</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.add_cookies</x-search>
 
 Adds cookies into this browser context. All pages within this context will have these cookies installed. Cookies can be obtained via [browser_context.cookies()](/api/class-browsercontext.mdx#browser-context-cookies).
 
@@ -124,7 +124,7 @@ await browser_context.add_cookies([cookie_object1, cookie_object2])
 
 ### add_init_script {#browser-context-add-init-script}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.add_init_script</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.add_init_script</x-search>
 
 Adds a script which would be evaluated in one of the following scenarios:
 * Whenever a page is created in the browser context or is navigated.
@@ -186,7 +186,7 @@ The order of evaluation of multiple scripts installed via [browser_context.add_i
 
 ### clear_cookies {#browser-context-clear-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.clear_cookies</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.clear_cookies</x-search>
 
 Removes cookies from context. Accepts optional filter.
 
@@ -242,7 +242,7 @@ await context.clear_cookies(name="session-id", domain="my-origin.com")
 
 ### clear_permissions {#browser-context-clear-permissions}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.clear_permissions</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.clear_permissions</x-search>
 
 Clears all permission overrides for the browser context.
 
@@ -285,7 +285,7 @@ context.clear_permissions()
 
 ### close {#browser-context-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.close</x-search>
 
 Closes the browser context. All the pages that belong to the browser context will be closed.
 
@@ -312,7 +312,7 @@ browser_context.close(**kwargs)
 
 ### cookies {#browser-context-cookies}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.cookies</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.cookies</x-search>
 
 If no URLs are specified, this method returns all cookies. If URLs are specified, only cookies that affect those URLs are returned.
 
@@ -384,7 +384,7 @@ browser_context.expect_console_message(**kwargs)
 
 ### expect_event {#browser-context-wait-for-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.expect_event</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.expect_event</x-search>
 
 Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy value. Will throw an error if the context closes before the event is fired. Returns the event data value.
 
@@ -462,7 +462,7 @@ browser_context.expect_page(**kwargs)
 
 ### expose_binding {#browser-context-expose-binding}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.expose_binding</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.expose_binding</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in every page in the context. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`. If the `callback` returns a [Promise], it will be awaited.
 
@@ -564,7 +564,7 @@ asyncio.run(main())
 
 ### expose_function {#browser-context-expose-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.expose_function</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.expose_function</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in every page in the context. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`.
 
@@ -672,7 +672,7 @@ asyncio.run(main())
 
 ### grant_permissions {#browser-context-grant-permissions}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.grant_permissions</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.grant_permissions</x-search>
 
 Grants specified permissions to the browser context. Only grants corresponding permissions to the given origin if specified.
 
@@ -740,7 +740,7 @@ browser_context.new_cdp_session(page)
 
 ### new_page {#browser-context-new-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.new_page</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.new_page</x-search>
 
 Creates a new page in the browser context.
 
@@ -757,7 +757,7 @@ browser_context.new_page()
 
 ### route {#browser-context-route}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.route</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.route</x-search>
 
 Routing provides the capability to modify network requests that are made by any page in the browser context. Once route is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.
 
@@ -942,7 +942,7 @@ browser_context.route_from_har(har, **kwargs)
 
 ### set_default_navigation_timeout {#browser-context-set-default-navigation-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.set_default_navigation_timeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.set_default_navigation_timeout</x-search>
 
 This setting will change the default maximum navigation time for the following methods and related shortcuts:
 * [page.go_back()](/api/class-page.mdx#page-go-back)
@@ -971,7 +971,7 @@ browser_context.set_default_navigation_timeout(timeout)
 
 ### set_default_timeout {#browser-context-set-default-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.set_default_timeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.set_default_timeout</x-search>
 
 This setting will change the default maximum time for all the methods accepting `timeout` option.
 
@@ -994,7 +994,7 @@ browser_context.set_default_timeout(timeout)
 
 ### set_extra_http_headers {#browser-context-set-extra-http-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.set_extra_http_headers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.set_extra_http_headers</x-search>
 
 The extra HTTP headers will be sent with every request initiated by any page in the context. These headers are merged with page-specific extra HTTP headers set with [page.set_extra_http_headers()](/api/class-page.mdx#page-set-extra-http-headers). If page overrides a particular header, page-specific header value will be used instead of the browser context header value.
 
@@ -1020,7 +1020,7 @@ browser_context.set_extra_http_headers(headers)
 
 ### set_geolocation {#browser-context-set-geolocation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.set_geolocation</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.set_geolocation</x-search>
 
 Sets the context's geolocation. Passing `null` or `undefined` emulates position unavailable.
 
@@ -1073,7 +1073,7 @@ Consider using [browser_context.grant_permissions()](/api/class-browsercontext.m
 
 ### set_offline {#browser-context-set-offline}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.set_offline</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.set_offline</x-search>
 
 **Usage**
 
@@ -1093,7 +1093,7 @@ browser_context.set_offline(offline)
 
 ### storage_state {#browser-context-storage-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.storage_state</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.storage_state</x-search>
 
 Returns storage state for this browser context, contains current cookies and local storage snapshot.
 
@@ -1154,7 +1154,7 @@ browser_context.storage_state(**kwargs)
 
 ### unroute {#browser-context-unroute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.unroute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.unroute</x-search>
 
 Removes a route created with [browser_context.route()](/api/class-browsercontext.mdx#browser-context-route). When `handler` is not specified, removes all routes for the `url`.
 
@@ -1206,7 +1206,7 @@ browser_context.unroute_all(**kwargs)
 
 ### wait_for_event {#browser-context-wait-for-event-2}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.wait_for_event</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.wait_for_event</x-search>
 
 :::note
 In most cases, you should use [browser_context.expect_event()](/api/class-browsercontext.mdx#browser-context-wait-for-event).
@@ -1262,7 +1262,7 @@ browser_context.background_pages
 
 ### browser {#browser-context-browser}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.browser</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.browser</x-search>
 
 Returns the browser instance of the context. If it was launched as a persistent context null gets returned.
 
@@ -1296,7 +1296,7 @@ browser_context.clock
 
 ### pages {#browser-context-pages}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.pages</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.pages</x-search>
 
 Returns all open pages in the context.
 
@@ -1413,7 +1413,7 @@ browser_context.on("backgroundpage", handler)
 
 ### on("close") {#browser-context-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.on("close")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.on("close")</x-search>
 
 Emitted when Browser context gets closed. This might happen because of one of the following:
 * Browser context is closed.
@@ -1505,7 +1505,7 @@ When no [page.on("dialog")](/api/class-page.mdx#page-event-dialog) or [browser_c
 
 ### on("page") {#browser-context-event-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserContext.on("page")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserContext.on("page")</x-search>
 
 The event is emitted when a new Page is created in the BrowserContext. The page may still be loading. The event will also fire for popup pages. See also [page.on("popup")](/api/class-page.mdx#page-event-popup) to receive events about popups relevant to a specific page.
 

--- a/python/docs/api/class-browsertype.mdx
+++ b/python/docs/api/class-browsertype.mdx
@@ -65,7 +65,7 @@ asyncio.run(main())
 
 ### connect {#browser-type-connect}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.connect</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.connect</x-search>
 
 This method attaches Playwright to an existing browser instance. When connecting to another browser launched via `BrowserType.launchServer` in Node.js, the major and minor version needs to match the client version (1.2.3 → is compatible with 1.2.x).
 
@@ -171,7 +171,7 @@ page = default_context.pages[0]
 
 ### launch {#browser-type-launch}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.launch</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.launch</x-search>
 
 Returns the browser instance.
 
@@ -294,7 +294,7 @@ browser = await playwright.chromium.launch( # or "firefox" or "webkit".
 
 ### launch_persistent_context {#browser-type-launch-persistent-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.launch_persistent_context</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.launch_persistent_context</x-search>
 
 Returns the persistent browser context instance.
 
@@ -557,7 +557,7 @@ browser_type.launch_persistent_context(user_data_dir, **kwargs)
 
 ### executable_path {#browser-type-executable-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.executable_path</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.executable_path</x-search>
 
 A path where Playwright expects to find a bundled browser executable.
 
@@ -574,7 +574,7 @@ browser_type.executable_path
 
 ### name {#browser-type-name}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>browserType.name</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>browserType.name</x-search>
 
 Returns browser name. For example: `'chromium'`, `'webkit'` or `'firefox'`.
 

--- a/python/docs/api/class-cdpsession.mdx
+++ b/python/docs/api/class-cdpsession.mdx
@@ -61,7 +61,7 @@ await client.send("Animation.setPlaybackRate", {
 
 ### detach {#cdp-session-detach}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>cdpSession.detach</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>cdpSession.detach</x-search>
 
 Detaches the CDPSession from the target. Once detached, the CDPSession object won't emit any events and can't be used to send messages.
 
@@ -78,7 +78,7 @@ cdp_session.detach()
 
 ### send {#cdp-session-send}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>cdpSession.send</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>cdpSession.send</x-search>
 
 **Usage**
 

--- a/python/docs/api/class-consolemessage.mdx
+++ b/python/docs/api/class-consolemessage.mdx
@@ -68,7 +68,7 @@ await msg.args[1].json_value() # 42
 
 ### args {#console-message-args}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.args</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.args</x-search>
 
 List of arguments passed to a `console` function call. See also [page.on("console")](/api/class-page.mdx#page-event-console).
 
@@ -85,7 +85,7 @@ console_message.args
 
 ### location {#console-message-location}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.location</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.location</x-search>
 
 **Usage**
 
@@ -126,7 +126,7 @@ console_message.page
 
 ### text {#console-message-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.text</x-search>
 
 The text of the console message.
 
@@ -143,7 +143,7 @@ console_message.text
 
 ### type {#console-message-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>consoleMessage.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>consoleMessage.type</x-search>
 
 One of the following values: `'log'`, `'debug'`, `'info'`, `'error'`, `'warning'`, `'dir'`, `'dirxml'`, `'table'`, `'trace'`, `'clear'`, `'startGroup'`, `'startGroupCollapsed'`, `'endGroup'`, `'assert'`, `'profile'`, `'profileEnd'`, `'count'`, `'timeEnd'`.
 

--- a/python/docs/api/class-dialog.mdx
+++ b/python/docs/api/class-dialog.mdx
@@ -79,7 +79,7 @@ Dialogs are dismissed automatically, unless there is a [page.on("dialog")](/api/
 
 ### accept {#dialog-accept}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.accept</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.accept</x-search>
 
 Returns when the dialog has been accepted.
 
@@ -102,7 +102,7 @@ dialog.accept(**kwargs)
 
 ### dismiss {#dialog-dismiss}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.dismiss</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.dismiss</x-search>
 
 Returns when the dialog has been dismissed.
 
@@ -121,7 +121,7 @@ dialog.dismiss()
 
 ### default_value {#dialog-default-value}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.default_value</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.default_value</x-search>
 
 If dialog is prompt, returns default prompt value. Otherwise, returns empty string.
 
@@ -138,7 +138,7 @@ dialog.default_value
 
 ### message {#dialog-message}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.message</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.message</x-search>
 
 A message displayed in the dialog.
 
@@ -172,7 +172,7 @@ dialog.page
 
 ### type {#dialog-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>dialog.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>dialog.type</x-search>
 
 Returns dialog's type, can be one of `alert`, `beforeunload`, `confirm` or `prompt`.
 

--- a/python/docs/api/class-download.mdx
+++ b/python/docs/api/class-download.mdx
@@ -75,7 +75,7 @@ download.cancel()
 
 ### delete {#download-delete}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.delete</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.delete</x-search>
 
 Deletes the downloaded file. Will wait for the download to finish if necessary.
 
@@ -92,7 +92,7 @@ download.delete()
 
 ### failure {#download-failure}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.failure</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.failure</x-search>
 
 Returns download error if any. Will wait for the download to finish if necessary.
 
@@ -109,7 +109,7 @@ download.failure()
 
 ### path {#download-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.path</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.path</x-search>
 
 Returns path to the downloaded file for a successful download, or throws for a failed/canceled download. The method will wait for the download to finish if necessary. The method throws when connected remotely.
 
@@ -128,7 +128,7 @@ download.path()
 
 ### save_as {#download-save-as}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.save_as</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.save_as</x-search>
 
 Copy the download to a user-specified path. It is safe to call this method while the download is still in progress. Will wait for the download to finish if necessary.
 
@@ -189,7 +189,7 @@ download.page
 
 ### suggested_filename {#download-suggested-filename}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.suggested_filename</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.suggested_filename</x-search>
 
 Returns suggested filename for this download. It is typically computed by the browser from the [`Content-Disposition`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) response header or the `download` attribute. See the spec on [whatwg](https://html.spec.whatwg.org/#downloading-resources). Different browsers can use different logic for computing it.
 
@@ -206,7 +206,7 @@ download.suggested_filename
 
 ### url {#download-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>download.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>download.url</x-search>
 
 Returns downloaded url.
 

--- a/python/docs/api/class-elementhandle.mdx
+++ b/python/docs/api/class-elementhandle.mdx
@@ -113,7 +113,7 @@ await locator.click()
 
 ### bounding_box {#element-handle-bounding-box}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.bounding_box</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.bounding_box</x-search>
 
 This method returns the bounding box of the element, or `null` if the element is not visible. The bounding box is calculated relative to the main frame viewport - which is usually the same as the browser window.
 
@@ -170,7 +170,7 @@ await page.mouse.click(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
 
 ### content_frame {#element-handle-content-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.content_frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.content_frame</x-search>
 
 Returns the content frame for element handles referencing iframe nodes, or `null` otherwise
 
@@ -187,7 +187,7 @@ element_handle.content_frame()
 
 ### owner_frame {#element-handle-owner-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.owner_frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.owner_frame</x-search>
 
 Returns the frame containing the given element.
 
@@ -204,7 +204,7 @@ element_handle.owner_frame()
 
 ### wait_for_element_state {#element-handle-wait-for-element-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.wait_for_element_state</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.wait_for_element_state</x-search>
 
 Returns when the element satisfies the `state`.
 
@@ -242,7 +242,7 @@ element_handle.wait_for_element_state(state, **kwargs)
 
 ### check {#element-handle-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.check</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.check</x-search>
 
 :::warning[Discouraged]
 
@@ -303,7 +303,7 @@ element_handle.check(**kwargs)
 
 ### click {#element-handle-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.click</x-search>
 
 :::warning[Discouraged]
 
@@ -375,7 +375,7 @@ element_handle.click(**kwargs)
 
 ### dblclick {#element-handle-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.dblclick</x-search>
 
 :::warning[Discouraged]
 
@@ -447,7 +447,7 @@ element_handle.dblclick(**kwargs)
 
 ### dispatch_event {#element-handle-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.dispatch_event</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.dispatch_event</x-search>
 
 :::warning[Discouraged]
 
@@ -674,7 +674,7 @@ assert await feed_handle.eval_on_selector_all(".tweet", "nodes => nodes.map(n =>
 
 ### fill {#element-handle-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.fill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.fill</x-search>
 
 :::warning[Discouraged]
 
@@ -722,7 +722,7 @@ element_handle.fill(value, **kwargs)
 
 ### focus {#element-handle-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.focus</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.focus</x-search>
 
 :::warning[Discouraged]
 
@@ -746,7 +746,7 @@ element_handle.focus()
 
 ### get_attribute {#element-handle-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.get_attribute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.get_attribute</x-search>
 
 :::warning[Discouraged]
 
@@ -775,7 +775,7 @@ element_handle.get_attribute(name)
 
 ### hover {#element-handle-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.hover</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.hover</x-search>
 
 :::warning[Discouraged]
 
@@ -837,7 +837,7 @@ element_handle.hover(**kwargs)
 
 ### inner_html {#element-handle-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.inner_html</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.inner_html</x-search>
 
 :::warning[Discouraged]
 
@@ -861,7 +861,7 @@ element_handle.inner_html()
 
 ### inner_text {#element-handle-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.inner_text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.inner_text</x-search>
 
 :::warning[Discouraged]
 
@@ -917,7 +917,7 @@ element_handle.input_value(**kwargs)
 
 ### is_checked {#element-handle-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_checked</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.is_checked</x-search>
 
 :::warning[Discouraged]
 
@@ -941,7 +941,7 @@ element_handle.is_checked()
 
 ### is_disabled {#element-handle-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_disabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.is_disabled</x-search>
 
 :::warning[Discouraged]
 
@@ -965,7 +965,7 @@ element_handle.is_disabled()
 
 ### is_editable {#element-handle-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_editable</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.is_editable</x-search>
 
 :::warning[Discouraged]
 
@@ -989,7 +989,7 @@ element_handle.is_editable()
 
 ### is_enabled {#element-handle-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_enabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.is_enabled</x-search>
 
 :::warning[Discouraged]
 
@@ -1013,7 +1013,7 @@ element_handle.is_enabled()
 
 ### is_hidden {#element-handle-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_hidden</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.is_hidden</x-search>
 
 :::warning[Discouraged]
 
@@ -1037,7 +1037,7 @@ element_handle.is_hidden()
 
 ### is_visible {#element-handle-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.is_visible</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.is_visible</x-search>
 
 :::warning[Discouraged]
 
@@ -1061,7 +1061,7 @@ element_handle.is_visible()
 
 ### press {#element-handle-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.press</x-search>
 
 :::warning[Discouraged]
 
@@ -1175,7 +1175,7 @@ element_handle.query_selector_all(selector)
 
 ### screenshot {#element-handle-screenshot}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.screenshot</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.screenshot</x-search>
 
 :::warning[Discouraged]
 
@@ -1245,7 +1245,7 @@ element_handle.screenshot(**kwargs)
 
 ### scroll_into_view_if_needed {#element-handle-scroll-into-view-if-needed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.scroll_into_view_if_needed</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.scroll_into_view_if_needed</x-search>
 
 :::warning[Discouraged]
 
@@ -1279,7 +1279,7 @@ element_handle.scroll_into_view_if_needed(**kwargs)
 
 ### select_option {#element-handle-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.select_option</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.select_option</x-search>
 
 :::warning[Discouraged]
 
@@ -1367,7 +1367,7 @@ await handle.select_option(value=["red", "green", "blue"])
 
 ### select_text {#element-handle-select-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.select_text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.select_text</x-search>
 
 :::warning[Discouraged]
 
@@ -1465,7 +1465,7 @@ element_handle.set_checked(checked, **kwargs)
 
 ### set_input_files {#element-handle-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.set_input_files</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.set_input_files</x-search>
 
 :::warning[Discouraged]
 
@@ -1515,7 +1515,7 @@ element_handle.set_input_files(files, **kwargs)
 
 ### tap {#element-handle-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.tap</x-search>
 
 :::warning[Discouraged]
 
@@ -1581,7 +1581,7 @@ element_handle.tap(**kwargs)
 
 ### text_content {#element-handle-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.text_content</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.text_content</x-search>
 
 :::warning[Discouraged]
 
@@ -1605,7 +1605,7 @@ element_handle.text_content()
 
 ### type {#element-handle-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.type</x-search>
 
 :::warning Deprecated
 
@@ -1646,7 +1646,7 @@ To press a special key, like `Control` or `ArrowDown`, use [element_handle.press
 
 ### uncheck {#element-handle-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.uncheck</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.uncheck</x-search>
 
 :::warning[Discouraged]
 
@@ -1707,7 +1707,7 @@ element_handle.uncheck(**kwargs)
 
 ### wait_for_selector {#element-handle-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>elementHandle.wait_for_selector</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>elementHandle.wait_for_selector</x-search>
 
 :::warning[Discouraged]
 

--- a/python/docs/api/class-filechooser.mdx
+++ b/python/docs/api/class-filechooser.mdx
@@ -46,7 +46,7 @@ await file_chooser.set_files("myfile.pdf")
 
 ### set_files {#file-chooser-set-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.set_files</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.set_files</x-search>
 
 Sets the value of the file input this chooser is associated with. If some of the `filePaths` are relative paths, then they are resolved relative to the current working directory. For empty array, clears the selected files.
 
@@ -89,7 +89,7 @@ file_chooser.set_files(files, **kwargs)
 
 ### element {#file-chooser-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.element</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.element</x-search>
 
 Returns input element associated with this file chooser.
 
@@ -106,7 +106,7 @@ file_chooser.element
 
 ### is_multiple {#file-chooser-is-multiple}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.is_multiple</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.is_multiple</x-search>
 
 Returns whether this file chooser accepts multiple files.
 
@@ -123,7 +123,7 @@ file_chooser.is_multiple()
 
 ### page {#file-chooser-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>fileChooser.page</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>fileChooser.page</x-search>
 
 Returns page this file chooser belongs to.
 

--- a/python/docs/api/class-frame.mdx
+++ b/python/docs/api/class-frame.mdx
@@ -82,7 +82,7 @@ asyncio.run(main())
 
 ### add_script_tag {#frame-add-script-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.add_script_tag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.add_script_tag</x-search>
 
 Returns the added tag when the script's onload fires or when the script content was injected into frame.
 
@@ -116,7 +116,7 @@ frame.add_script_tag(**kwargs)
 
 ### add_style_tag {#frame-add-style-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.add_style_tag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.add_style_tag</x-search>
 
 Returns the added tag when the stylesheet's onload fires or when the CSS content was injected into frame.
 
@@ -147,7 +147,7 @@ frame.add_style_tag(**kwargs)
 
 ### content {#frame-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.content</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.content</x-search>
 
 Gets the full HTML contents of the frame, including the doctype.
 
@@ -224,7 +224,7 @@ frame.drag_and_drop(source, target, **kwargs)
 
 ### evaluate {#frame-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.evaluate</x-search>
 
 Returns the return value of `expression`.
 
@@ -335,7 +335,7 @@ await body_handle.dispose()
 
 ### evaluate_handle {#frame-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.evaluate_handle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.evaluate_handle</x-search>
 
 Returns the return value of `expression` as a [JSHandle].
 
@@ -444,7 +444,7 @@ await result_handle.dispose()
 
 ### frame_element {#frame-frame-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.frame_element</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.frame_element</x-search>
 
 Returns the `frame` or `iframe` element handle which corresponds to this frame.
 
@@ -1004,7 +1004,7 @@ await expect(page.get_by_title("Issues count")).to_have_text("25 issues")
 
 ### goto {#frame-goto}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.goto</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.goto</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
@@ -1057,7 +1057,7 @@ frame.goto(url, **kwargs)
 
 ### is_enabled {#frame-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_enabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.is_enabled</x-search>
 
 Returns whether the element is [enabled](../actionability.mdx#enabled).
 
@@ -1131,7 +1131,7 @@ frame.locator(selector, **kwargs)
 
 ### set_content {#frame-set-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.set_content</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.set_content</x-search>
 
 This method internally calls [document.write()](https://developer.mozilla.org/en-US/docs/Web/API/Document/write), inheriting all its specific characteristics and behaviors.
 
@@ -1164,7 +1164,7 @@ frame.set_content(html, **kwargs)
 
 ### title {#frame-title}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.title</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.title</x-search>
 
 Returns the page title.
 
@@ -1181,7 +1181,7 @@ frame.title()
 
 ### wait_for_function {#frame-wait-for-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.wait_for_function</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.wait_for_function</x-search>
 
 Returns when the `expression` returns a truthy value, returns that value.
 
@@ -1287,7 +1287,7 @@ await frame.wait_for_function("selector => !!document.querySelector(selector)", 
 
 ### wait_for_load_state {#frame-wait-for-load-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.wait_for_load_state</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.wait_for_load_state</x-search>
 
 Waits for the required load state to be reached.
 
@@ -1399,7 +1399,7 @@ await frame.wait_for_url("**/target.html")
 
 ### child_frames {#frame-child-frames}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.child_frames</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.child_frames</x-search>
 
 **Usage**
 
@@ -1414,7 +1414,7 @@ frame.child_frames
 
 ### is_detached {#frame-is-detached}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_detached</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.is_detached</x-search>
 
 Returns `true` if the frame has been detached, or `false` otherwise.
 
@@ -1431,7 +1431,7 @@ frame.is_detached()
 
 ### name {#frame-name}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.name</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.name</x-search>
 
 Returns frame's name attribute as specified in the tag.
 
@@ -1454,7 +1454,7 @@ frame.name
 
 ### page {#frame-page}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.page</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.page</x-search>
 
 Returns the page containing this frame.
 
@@ -1471,7 +1471,7 @@ frame.page
 
 ### parent_frame {#frame-parent-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.parent_frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.parent_frame</x-search>
 
 Parent frame, if any. Detached frames and main frames return `null`.
 
@@ -1488,7 +1488,7 @@ frame.parent_frame
 
 ### url {#frame-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.url</x-search>
 
 Returns frame's url.
 
@@ -1507,7 +1507,7 @@ frame.url
 
 ### check {#frame-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.check</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.check</x-search>
 
 :::warning[Discouraged]
 
@@ -1573,7 +1573,7 @@ frame.check(selector, **kwargs)
 
 ### click {#frame-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.click</x-search>
 
 :::warning[Discouraged]
 
@@ -1650,7 +1650,7 @@ frame.click(selector, **kwargs)
 
 ### dblclick {#frame-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.dblclick</x-search>
 
 :::warning[Discouraged]
 
@@ -1727,7 +1727,7 @@ frame.dblclick(selector, **kwargs)
 
 ### dispatch_event {#frame-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.dispatch_event</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.dispatch_event</x-search>
 
 :::warning[Discouraged]
 
@@ -1957,7 +1957,7 @@ divs_counts = await frame.eval_on_selector_all("div", "(divs, min) => divs.lengt
 
 ### expect_navigation {#frame-wait-for-navigation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.expect_navigation</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.expect_navigation</x-search>
 
 :::warning Deprecated
 
@@ -2026,7 +2026,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 ### fill {#frame-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.fill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.fill</x-search>
 
 :::warning[Discouraged]
 
@@ -2080,7 +2080,7 @@ frame.fill(selector, value, **kwargs)
 
 ### focus {#frame-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.focus</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.focus</x-search>
 
 :::warning[Discouraged]
 
@@ -2116,7 +2116,7 @@ frame.focus(selector, **kwargs)
 
 ### get_attribute {#frame-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.get_attribute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.get_attribute</x-search>
 
 :::warning[Discouraged]
 
@@ -2155,7 +2155,7 @@ frame.get_attribute(selector, name, **kwargs)
 
 ### hover {#frame-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.hover</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.hover</x-search>
 
 :::warning[Discouraged]
 
@@ -2222,7 +2222,7 @@ frame.hover(selector, **kwargs)
 
 ### inner_html {#frame-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.inner_html</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.inner_html</x-search>
 
 :::warning[Discouraged]
 
@@ -2258,7 +2258,7 @@ frame.inner_html(selector, **kwargs)
 
 ### inner_text {#frame-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.inner_text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.inner_text</x-search>
 
 :::warning[Discouraged]
 
@@ -2332,7 +2332,7 @@ frame.input_value(selector, **kwargs)
 
 ### is_checked {#frame-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_checked</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.is_checked</x-search>
 
 :::warning[Discouraged]
 
@@ -2368,7 +2368,7 @@ frame.is_checked(selector, **kwargs)
 
 ### is_disabled {#frame-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_disabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.is_disabled</x-search>
 
 :::warning[Discouraged]
 
@@ -2404,7 +2404,7 @@ frame.is_disabled(selector, **kwargs)
 
 ### is_editable {#frame-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_editable</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.is_editable</x-search>
 
 :::warning[Discouraged]
 
@@ -2440,7 +2440,7 @@ frame.is_editable(selector, **kwargs)
 
 ### is_hidden {#frame-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_hidden</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.is_hidden</x-search>
 
 :::warning[Discouraged]
 
@@ -2479,7 +2479,7 @@ frame.is_hidden(selector, **kwargs)
 
 ### is_visible {#frame-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.is_visible</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.is_visible</x-search>
 
 :::warning[Discouraged]
 
@@ -2518,7 +2518,7 @@ frame.is_visible(selector, **kwargs)
 
 ### press {#frame-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.press</x-search>
 
 :::warning[Discouraged]
 
@@ -2652,7 +2652,7 @@ frame.query_selector_all(selector)
 
 ### select_option {#frame-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.select_option</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.select_option</x-search>
 
 :::warning[Discouraged]
 
@@ -2816,7 +2816,7 @@ frame.set_checked(selector, checked, **kwargs)
 
 ### set_input_files {#frame-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.set_input_files</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.set_input_files</x-search>
 
 :::warning[Discouraged]
 
@@ -2872,7 +2872,7 @@ frame.set_input_files(selector, files, **kwargs)
 
 ### tap {#frame-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.tap</x-search>
 
 :::warning[Discouraged]
 
@@ -2943,7 +2943,7 @@ frame.tap(selector, **kwargs)
 
 ### text_content {#frame-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.text_content</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.text_content</x-search>
 
 :::warning[Discouraged]
 
@@ -2979,7 +2979,7 @@ frame.text_content(selector, **kwargs)
 
 ### type {#frame-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.type</x-search>
 
 :::warning Deprecated
 
@@ -3026,7 +3026,7 @@ To press a special key, like `Control` or `ArrowDown`, use [keyboard.press()](/a
 
 ### uncheck {#frame-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.uncheck</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.uncheck</x-search>
 
 :::warning[Discouraged]
 
@@ -3092,7 +3092,7 @@ frame.uncheck(selector, **kwargs)
 
 ### wait_for_selector {#frame-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.wait_for_selector</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.wait_for_selector</x-search>
 
 :::warning[Discouraged]
 
@@ -3191,7 +3191,7 @@ asyncio.run(main())
 
 ### wait_for_timeout {#frame-wait-for-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>frame.wait_for_timeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>frame.wait_for_timeout</x-search>
 
 :::warning[Discouraged]
 

--- a/python/docs/api/class-jshandle.mdx
+++ b/python/docs/api/class-jshandle.mdx
@@ -46,7 +46,7 @@ JSHandle instances can be used as an argument in [page.eval_on_selector()](/api/
 
 ### dispose {#js-handle-dispose}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.dispose</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.dispose</x-search>
 
 The `jsHandle.dispose` method stops referencing the element handle.
 
@@ -63,7 +63,7 @@ js_handle.dispose()
 
 ### evaluate {#js-handle-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.evaluate</x-search>
 
 Returns the return value of `expression`.
 
@@ -114,7 +114,7 @@ assert await tweet_handle.evaluate("node => node.innerText") == "10 retweets"
 
 ### evaluate_handle {#js-handle-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.evaluate_handle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.evaluate_handle</x-search>
 
 Returns the return value of `expression` as a [JSHandle].
 
@@ -148,7 +148,7 @@ js_handle.evaluate_handle(expression, **kwargs)
 
 ### get_properties {#js-handle-get-properties}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.get_properties</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.get_properties</x-search>
 
 The method returns a map with **own property names** as keys and JSHandle instances for the property values.
 
@@ -193,7 +193,7 @@ await handle.dispose()
 
 ### get_property {#js-handle-get-property}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.get_property</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.get_property</x-search>
 
 Fetches a single property from the referenced object.
 
@@ -215,7 +215,7 @@ js_handle.get_property(property_name)
 
 ### json_value {#js-handle-json-value}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.json_value</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.json_value</x-search>
 
 Returns a JSON representation of the object. If the object has a `toJSON` function, it **will not be called**.
 
@@ -238,7 +238,7 @@ js_handle.json_value()
 
 ### as_element {#js-handle-as-element}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>jsHandle.as_element</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>jsHandle.as_element</x-search>
 
 Returns either `null` or the object handle itself, if the object handle is an instance of [ElementHandle].
 

--- a/python/docs/api/class-keyboard.mdx
+++ b/python/docs/api/class-keyboard.mdx
@@ -120,7 +120,7 @@ await page.keyboard.press("Meta+A")
 
 ### down {#keyboard-down}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.down</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.down</x-search>
 
 Dispatches a `keydown` event.
 
@@ -160,7 +160,7 @@ keyboard.down(key)
 
 ### insert_text {#keyboard-insert-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.insert_text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.insert_text</x-search>
 
 Dispatches only `input` event, does not emit the `keydown`, `keyup` or `keypress` events.
 
@@ -206,7 +206,7 @@ Modifier keys DO NOT effect `keyboard.insertText`. Holding down `Shift` will not
 
 ### press {#keyboard-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.press</x-search>
 
 :::tip
 In most cases, you should use [locator.press()](/api/class-locator.mdx#locator-press) instead.
@@ -283,7 +283,7 @@ Shortcut for [keyboard.down()](/api/class-keyboard.mdx#keyboard-down) and [keybo
 
 ### type {#keyboard-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.type</x-search>
 
 :::caution
 In most cases, you should use [locator.fill()](/api/class-locator.mdx#locator-fill) instead. You only need to press keys one by one if there is special keyboard handling on the page - in this case use [locator.press_sequentially()](/api/class-locator.mdx#locator-press-sequentially).
@@ -344,7 +344,7 @@ For characters that are not on a US keyboard, only an `input` event will be sent
 
 ### up {#keyboard-up}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>keyboard.up</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>keyboard.up</x-search>
 
 Dispatches a `keyup` event.
 

--- a/python/docs/api/class-mouse.mdx
+++ b/python/docs/api/class-mouse.mdx
@@ -56,7 +56,7 @@ await page.mouse.up()
 
 ### click {#mouse-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.click</x-search>
 
 Shortcut for [mouse.move()](/api/class-mouse.mdx#mouse-move), [mouse.down()](/api/class-mouse.mdx#mouse-down), [mouse.up()](/api/class-mouse.mdx#mouse-up).
 
@@ -91,7 +91,7 @@ mouse.click(x, y, **kwargs)
 
 ### dblclick {#mouse-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.dblclick</x-search>
 
 Shortcut for [mouse.move()](/api/class-mouse.mdx#mouse-move), [mouse.down()](/api/class-mouse.mdx#mouse-down), [mouse.up()](/api/class-mouse.mdx#mouse-up), [mouse.down()](/api/class-mouse.mdx#mouse-down) and [mouse.up()](/api/class-mouse.mdx#mouse-up).
 
@@ -123,7 +123,7 @@ mouse.dblclick(x, y, **kwargs)
 
 ### down {#mouse-down}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.down</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.down</x-search>
 
 Dispatches a `mousedown` event.
 
@@ -149,7 +149,7 @@ mouse.down(**kwargs)
 
 ### move {#mouse-move}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.move</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.move</x-search>
 
 Dispatches a `mousemove` event.
 
@@ -178,7 +178,7 @@ mouse.move(x, y, **kwargs)
 
 ### up {#mouse-up}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>mouse.up</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>mouse.up</x-search>
 
 Dispatches a `mouseup` event.
 

--- a/python/docs/api/class-page.mdx
+++ b/python/docs/api/class-page.mdx
@@ -88,7 +88,7 @@ page.remove_listener("request", log_request)
 
 ### add_init_script {#page-add-init-script}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.add_init_script</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.add_init_script</x-search>
 
 Adds a script which would be evaluated in one of the following scenarios:
 * Whenever the page is navigated.
@@ -340,7 +340,7 @@ await page.add_locator_handler(page.get_by_label("Close"), handler, times=1)
 
 ### add_script_tag {#page-add-script-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.add_script_tag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.add_script_tag</x-search>
 
 Adds a `<script>` tag into the page with the desired url or content. Returns the added tag when the script's onload fires or when the script content was injected into frame.
 
@@ -372,7 +372,7 @@ page.add_script_tag(**kwargs)
 
 ### add_style_tag {#page-add-style-tag}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.add_style_tag</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.add_style_tag</x-search>
 
 Adds a `<link rel="stylesheet">` tag into the page with the desired url or a `<style type="text/css">` tag with the content. Returns the added tag when the stylesheet's onload fires or when the CSS content was injected into frame.
 
@@ -401,7 +401,7 @@ page.add_style_tag(**kwargs)
 
 ### bring_to_front {#page-bring-to-front}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.bring_to_front</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.bring_to_front</x-search>
 
 Brings page to front (activates tab).
 
@@ -418,7 +418,7 @@ page.bring_to_front()
 
 ### close {#page-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.close</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.close</x-search>
 
 If `run_before_unload` is `false`, does not run any unload handlers and waits for the page to be closed. If `run_before_unload` is `true` the method will run unload handlers, but will **not** wait for the page to close.
 
@@ -450,7 +450,7 @@ page.close(**kwargs)
 
 ### content {#page-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.content</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.content</x-search>
 
 Gets the full HTML contents of the page, including the doctype.
 
@@ -562,7 +562,7 @@ await page.drag_and_drop(
 
 ### emulate_media {#page-emulate-media}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.emulate_media</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.emulate_media</x-search>
 
 This method changes the `CSS media type` through the `media` argument, and/or the `'prefers-colors-scheme'` media feature, using the `colorScheme` argument.
 
@@ -676,7 +676,7 @@ await page.evaluate("matchMedia('(prefers-color-scheme: no-preference)').matches
 
 ### evaluate {#page-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.evaluate</x-search>
 
 Returns the value of the `expression` invocation.
 
@@ -789,7 +789,7 @@ await body_handle.dispose()
 
 ### evaluate_handle {#page-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.evaluate_handle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.evaluate_handle</x-search>
 
 Returns the value of the `expression` invocation as a [JSHandle].
 
@@ -950,7 +950,7 @@ page.expect_download(**kwargs)
 
 ### expect_event {#page-wait-for-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.expect_event</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.expect_event</x-search>
 
 Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy value. Will throw an error if the page is closed before the event is fired. Returns the event data value.
 
@@ -1054,7 +1054,7 @@ page.expect_popup(**kwargs)
 
 ### expect_request {#page-wait-for-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.expect_request</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.expect_request</x-search>
 
 Waits for the matching request and returns it. See [waiting for event](../events.mdx#waiting-for-event) for more details about events.
 
@@ -1139,7 +1139,7 @@ page.expect_request_finished(**kwargs)
 
 ### expect_response {#page-wait-for-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.expect_response</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.expect_response</x-search>
 
 Returns the matched response. See [waiting for event](../events.mdx#waiting-for-event) for more details about events.
 
@@ -1254,7 +1254,7 @@ page.expect_worker(**kwargs)
 
 ### expose_binding {#page-expose-binding}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.expose_binding</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.expose_binding</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in this page. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`. If the `callback` returns a [Promise], it will be awaited.
 
@@ -1360,7 +1360,7 @@ asyncio.run(main())
 
 ### expose_function {#page-expose-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.expose_function</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.expose_function</x-search>
 
 The method adds a function called `name` on the `window` object of every frame in the page. When called, the function executes `callback` and returns a [Promise] which resolves to the return value of `callback`.
 
@@ -1470,7 +1470,7 @@ asyncio.run(main())
 
 ### frame {#page-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.frame</x-search>
 
 Returns frame matching the specified criteria. Either `name` or `url` must be specified.
 
@@ -2014,7 +2014,7 @@ await expect(page.get_by_title("Issues count")).to_have_text("25 issues")
 
 ### go_back {#page-go-back}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.go_back</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.go_back</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. If cannot go back, returns `null`.
 
@@ -2046,7 +2046,7 @@ page.go_back(**kwargs)
 
 ### go_forward {#page-go-forward}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.go_forward</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.go_forward</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect. If cannot go forward, returns `null`.
 
@@ -2078,7 +2078,7 @@ page.go_forward(**kwargs)
 
 ### goto {#page-goto}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.goto</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.goto</x-search>
 
 Returns the main resource response. In case of multiple redirects, the navigation will resolve with the first non-redirect response.
 
@@ -2174,7 +2174,7 @@ page.locator(selector, **kwargs)
 
 ### opener {#page-opener}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.opener</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.opener</x-search>
 
 Returns the opener for popup pages and `null` for others. If the opener has been closed already the returns `null`.
 
@@ -2214,7 +2214,7 @@ page.pause()
 
 ### pdf {#page-pdf}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.pdf</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.pdf</x-search>
 
 Returns the PDF buffer.
 
@@ -2359,7 +2359,7 @@ The `format` options are:
 
 ### reload {#page-reload}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.reload</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.reload</x-search>
 
 This method reloads the current page, in the same way as if the user had triggered a browser refresh. Returns the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.
 
@@ -2411,7 +2411,7 @@ page.remove_locator_handler(locator)
 
 ### route {#page-route}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.route</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.route</x-search>
 
 Routing provides the capability to modify network requests that are made by a page.
 
@@ -2599,7 +2599,7 @@ page.route_from_har(har, **kwargs)
 
 ### screenshot {#page-screenshot}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.screenshot</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.screenshot</x-search>
 
 Returns the buffer with the captured screenshot.
 
@@ -2676,7 +2676,7 @@ page.screenshot(**kwargs)
 
 ### set_content {#page-set-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.set_content</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.set_content</x-search>
 
 This method internally calls [document.write()](https://developer.mozilla.org/en-US/docs/Web/API/Document/write), inheriting all its specific characteristics and behaviors.
 
@@ -2709,7 +2709,7 @@ page.set_content(html, **kwargs)
 
 ### set_default_navigation_timeout {#page-set-default-navigation-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.set_default_navigation_timeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.set_default_navigation_timeout</x-search>
 
 This setting will change the default maximum navigation time for the following methods and related shortcuts:
 * [page.go_back()](/api/class-page.mdx#page-go-back)
@@ -2739,7 +2739,7 @@ page.set_default_navigation_timeout(timeout)
 
 ### set_default_timeout {#page-set-default-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.set_default_timeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.set_default_timeout</x-search>
 
 This setting will change the default maximum time for all the methods accepting `timeout` option.
 
@@ -2762,7 +2762,7 @@ page.set_default_timeout(timeout)
 
 ### set_extra_http_headers {#page-set-extra-http-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.set_extra_http_headers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.set_extra_http_headers</x-search>
 
 The extra HTTP headers will be sent with every request the page initiates.
 
@@ -2788,7 +2788,7 @@ page.set_extra_http_headers(headers)
 
 ### set_viewport_size {#page-set-viewport-size}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.set_viewport_size</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.set_viewport_size</x-search>
 
 In the case of multiple pages in a single browser, each page can have its own viewport size. However, [browser.new_context()](/api/class-browser.mdx#browser-new-context) allows to set viewport size (and more) for all pages in the context at once.
 
@@ -2840,7 +2840,7 @@ await page.goto("https://example.com")
 
 ### title {#page-title}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.title</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.title</x-search>
 
 Returns the page's title.
 
@@ -2857,7 +2857,7 @@ page.title()
 
 ### unroute {#page-unroute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.unroute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.unroute</x-search>
 
 Removes a route created with [page.route()](/api/class-page.mdx#page-route). When `handler` is not specified, removes all routes for the `url`.
 
@@ -2909,7 +2909,7 @@ page.unroute_all(**kwargs)
 
 ### wait_for_event {#page-wait-for-event-2}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.wait_for_event</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.wait_for_event</x-search>
 
 :::note
 In most cases, you should use [page.expect_event()](/api/class-page.mdx#page-wait-for-event).
@@ -2942,7 +2942,7 @@ page.wait_for_event(event, **kwargs)
 
 ### wait_for_function {#page-wait-for-function}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.wait_for_function</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.wait_for_function</x-search>
 
 Returns when the `expression` returns a truthy value. It resolves to a JSHandle of the truthy value.
 
@@ -3048,7 +3048,7 @@ await page.wait_for_function("selector => !!document.querySelector(selector)", s
 
 ### wait_for_load_state {#page-wait-for-load-state}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.wait_for_load_state</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.wait_for_load_state</x-search>
 
 Returns when the required load state has been reached.
 
@@ -3211,7 +3211,7 @@ page.clock
 
 ### context {#page-context}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.context</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.context</x-search>
 
 Get the browser context that the page belongs to.
 
@@ -3228,7 +3228,7 @@ page.context
 
 ### frames {#page-frames}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.frames</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.frames</x-search>
 
 An array of all frames attached to the page.
 
@@ -3245,7 +3245,7 @@ page.frames
 
 ### is_closed {#page-is-closed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_closed</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.is_closed</x-search>
 
 Indicates that the page has been closed.
 
@@ -3262,7 +3262,7 @@ page.is_closed()
 
 ### keyboard {#page-keyboard}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.keyboard</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.keyboard</x-search>
 
 **Usage**
 
@@ -3277,7 +3277,7 @@ page.keyboard
 
 ### main_frame {#page-main-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.main_frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.main_frame</x-search>
 
 The page's main frame. Page is guaranteed to have a main frame which persists during navigations.
 
@@ -3294,7 +3294,7 @@ page.main_frame
 
 ### mouse {#page-mouse}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.mouse</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.mouse</x-search>
 
 **Usage**
 
@@ -3326,7 +3326,7 @@ page.request
 
 ### touchscreen {#page-touchscreen}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.touchscreen</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.touchscreen</x-search>
 
 **Usage**
 
@@ -3341,7 +3341,7 @@ page.touchscreen
 
 ### url {#page-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.url</x-search>
 
 **Usage**
 
@@ -3356,7 +3356,7 @@ page.url
 
 ### video {#page-video}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.video</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.video</x-search>
 
 Video object associated with this page.
 
@@ -3373,7 +3373,7 @@ page.video
 
 ### viewport_size {#page-viewport-size}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.viewport_size</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.viewport_size</x-search>
 
 **Usage**
 
@@ -3394,7 +3394,7 @@ page.viewport_size
 
 ### workers {#page-workers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.workers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.workers</x-search>
 
 This method returns all of the dedicated [WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) associated with the page.
 
@@ -3417,7 +3417,7 @@ page.workers
 
 ### on("close") {#page-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on("close")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on("close")</x-search>
 
 Emitted when the page closes.
 
@@ -3434,7 +3434,7 @@ page.on("close", handler)
 
 ### on("console") {#page-event-console}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on("console")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on("console")</x-search>
 
 Emitted when JavaScript within the page calls one of console API methods, e.g. `console.log` or `console.dir`.
 
@@ -3485,7 +3485,7 @@ await page.evaluate("console.log('hello', 5, { foo: 'bar' })")
 
 ### on("crash") {#page-event-crash}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on("crash")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on("crash")</x-search>
 
 Emitted when the page crashes. Browser pages might crash if they try to allocate too much memory. When the page crashes, ongoing and subsequent operations will throw.
 
@@ -3542,7 +3542,7 @@ page.on("crash", handler)
 
 ### on("dialog") {#page-event-dialog}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on("dialog")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on("dialog")</x-search>
 
 Emitted when a JavaScript dialog appears, such as `alert`, `prompt`, `confirm` or `beforeunload`. Listener **must** either [dialog.accept()](/api/class-dialog.mdx#dialog-accept) or [dialog.dismiss()](/api/class-dialog.mdx#dialog-dismiss) the dialog - otherwise the page will [freeze](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#never_blocking) waiting for the dialog, and actions like click will never finish.
 
@@ -3580,7 +3580,7 @@ page.on("domcontentloaded", handler)
 
 ### on("download") {#page-event-download}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on("download")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on("download")</x-search>
 
 Emitted when attachment download started. User can access basic file operations on downloaded content via the passed [Download] instance.
 
@@ -3669,7 +3669,7 @@ page.on("framenavigated", handler)
 
 ### on("load") {#page-event-load}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on("load")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on("load")</x-search>
 
 Emitted when the JavaScript [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event is dispatched.
 
@@ -3735,7 +3735,7 @@ page.on("pageerror", handler)
 
 ### on("popup") {#page-event-popup}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on("popup")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on("popup")</x-search>
 
 Emitted when the page opens a new tab or window. This event is emitted in addition to the [browser_context.on("page")](/api/class-browsercontext.mdx#browser-context-event-page), but only for popups relevant to this page.
 
@@ -3788,7 +3788,7 @@ page.on("popup", handler)
 
 ### on("request") {#page-event-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on("request")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on("request")</x-search>
 
 Emitted when a page issues a request. The [request] object is read-only. In order to intercept and mutate requests, see [page.route()](/api/class-page.mdx#page-route) or [browser_context.route()](/api/class-browsercontext.mdx#browser-context-route).
 
@@ -3847,7 +3847,7 @@ page.on("requestfinished", handler)
 
 ### on("response") {#page-event-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on("response")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on("response")</x-search>
 
 Emitted when [response] status and headers are received for a request. For a successful response, the sequence of events is `request`, `response` and `requestfinished`.
 
@@ -3881,7 +3881,7 @@ page.on("websocket", handler)
 
 ### on("worker") {#page-event-worker}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.on("worker")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.on("worker")</x-search>
 
 Emitted when a dedicated [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) is spawned by the page.
 
@@ -3900,7 +3900,7 @@ page.on("worker", handler)
 
 ### accessibility {#page-accessibility}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.accessibility</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.accessibility</x-search>
 
 :::warning Deprecated
 
@@ -3922,7 +3922,7 @@ page.accessibility
 
 ### check {#page-check}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.check</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.check</x-search>
 
 :::warning[Discouraged]
 
@@ -3988,7 +3988,7 @@ page.check(selector, **kwargs)
 
 ### click {#page-click}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.click</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.click</x-search>
 
 :::warning[Discouraged]
 
@@ -4065,7 +4065,7 @@ page.click(selector, **kwargs)
 
 ### dblclick {#page-dblclick}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dblclick</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.dblclick</x-search>
 
 :::warning[Discouraged]
 
@@ -4142,7 +4142,7 @@ page.dblclick(selector, **kwargs)
 
 ### dispatch_event {#page-dispatch-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.dispatch_event</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.dispatch_event</x-search>
 
 :::warning[Discouraged]
 
@@ -4368,7 +4368,7 @@ div_counts = await page.eval_on_selector_all("div", "(divs, min) => divs.length 
 
 ### expect_navigation {#page-wait-for-navigation}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.expect_navigation</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.expect_navigation</x-search>
 
 :::warning Deprecated
 
@@ -4439,7 +4439,7 @@ Usage of the [History API](https://developer.mozilla.org/en-US/docs/Web/API/Hist
 
 ### fill {#page-fill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.fill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.fill</x-search>
 
 :::warning[Discouraged]
 
@@ -4493,7 +4493,7 @@ page.fill(selector, value, **kwargs)
 
 ### focus {#page-focus}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.focus</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.focus</x-search>
 
 :::warning[Discouraged]
 
@@ -4529,7 +4529,7 @@ page.focus(selector, **kwargs)
 
 ### get_attribute {#page-get-attribute}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.get_attribute</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.get_attribute</x-search>
 
 :::warning[Discouraged]
 
@@ -4568,7 +4568,7 @@ page.get_attribute(selector, name, **kwargs)
 
 ### hover {#page-hover}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.hover</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.hover</x-search>
 
 :::warning[Discouraged]
 
@@ -4635,7 +4635,7 @@ page.hover(selector, **kwargs)
 
 ### inner_html {#page-inner-html}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.inner_html</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.inner_html</x-search>
 
 :::warning[Discouraged]
 
@@ -4671,7 +4671,7 @@ page.inner_html(selector, **kwargs)
 
 ### inner_text {#page-inner-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.inner_text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.inner_text</x-search>
 
 :::warning[Discouraged]
 
@@ -4745,7 +4745,7 @@ page.input_value(selector, **kwargs)
 
 ### is_checked {#page-is-checked}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_checked</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.is_checked</x-search>
 
 :::warning[Discouraged]
 
@@ -4781,7 +4781,7 @@ page.is_checked(selector, **kwargs)
 
 ### is_disabled {#page-is-disabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_disabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.is_disabled</x-search>
 
 :::warning[Discouraged]
 
@@ -4817,7 +4817,7 @@ page.is_disabled(selector, **kwargs)
 
 ### is_editable {#page-is-editable}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_editable</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.is_editable</x-search>
 
 :::warning[Discouraged]
 
@@ -4853,7 +4853,7 @@ page.is_editable(selector, **kwargs)
 
 ### is_enabled {#page-is-enabled}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_enabled</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.is_enabled</x-search>
 
 :::warning[Discouraged]
 
@@ -4889,7 +4889,7 @@ page.is_enabled(selector, **kwargs)
 
 ### is_hidden {#page-is-hidden}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_hidden</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.is_hidden</x-search>
 
 :::warning[Discouraged]
 
@@ -4928,7 +4928,7 @@ page.is_hidden(selector, **kwargs)
 
 ### is_visible {#page-is-visible}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.is_visible</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.is_visible</x-search>
 
 :::warning[Discouraged]
 
@@ -4967,7 +4967,7 @@ page.is_visible(selector, **kwargs)
 
 ### press {#page-press}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.press</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.press</x-search>
 
 :::warning[Discouraged]
 
@@ -5126,7 +5126,7 @@ page.query_selector_all(selector)
 
 ### select_option {#page-select-option}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.select_option</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.select_option</x-search>
 
 :::warning[Discouraged]
 
@@ -5290,7 +5290,7 @@ page.set_checked(selector, checked, **kwargs)
 
 ### set_input_files {#page-set-input-files}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.set_input_files</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.set_input_files</x-search>
 
 :::warning[Discouraged]
 
@@ -5346,7 +5346,7 @@ page.set_input_files(selector, files, **kwargs)
 
 ### tap {#page-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.tap</x-search>
 
 :::warning[Discouraged]
 
@@ -5417,7 +5417,7 @@ page.tap(selector, **kwargs)
 
 ### text_content {#page-text-content}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.text_content</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.text_content</x-search>
 
 :::warning[Discouraged]
 
@@ -5453,7 +5453,7 @@ page.text_content(selector, **kwargs)
 
 ### type {#page-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.type</x-search>
 
 :::warning Deprecated
 
@@ -5500,7 +5500,7 @@ To press a special key, like `Control` or `ArrowDown`, use [keyboard.press()](/a
 
 ### uncheck {#page-uncheck}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.uncheck</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.uncheck</x-search>
 
 :::warning[Discouraged]
 
@@ -5566,7 +5566,7 @@ page.uncheck(selector, **kwargs)
 
 ### wait_for_selector {#page-wait-for-selector}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.wait_for_selector</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.wait_for_selector</x-search>
 
 :::warning[Discouraged]
 
@@ -5665,7 +5665,7 @@ asyncio.run(main())
 
 ### wait_for_timeout {#page-wait-for-timeout}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>page.wait_for_timeout</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>page.wait_for_timeout</x-search>
 
 :::warning[Discouraged]
 

--- a/python/docs/api/class-playwright.mdx
+++ b/python/docs/api/class-playwright.mdx
@@ -65,7 +65,7 @@ asyncio.run(main())
 
 ### stop {#playwright-stop}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.stop</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.stop</x-search>
 
 Terminates this instance of Playwright in case it was created bypassing the Python context manager. This is useful in REPL applications.
 
@@ -98,7 +98,7 @@ playwright.stop()
 
 ### chromium {#playwright-chromium}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.chromium</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.chromium</x-search>
 
 This object can be used to launch or connect to Chromium, returning instances of [Browser].
 
@@ -115,7 +115,7 @@ playwright.chromium
 
 ### devices {#playwright-devices}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.devices</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.devices</x-search>
 
 Returns a dictionary of devices to be used with [browser.new_context()](/api/class-browser.mdx#browser-new-context) or [browser.new_page()](/api/class-browser.mdx#browser-new-page).
 
@@ -185,7 +185,7 @@ playwright.devices
 
 ### firefox {#playwright-firefox}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.firefox</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.firefox</x-search>
 
 This object can be used to launch or connect to Firefox, returning instances of [Browser].
 
@@ -219,7 +219,7 @@ playwright.request
 
 ### selectors {#playwright-selectors}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.selectors</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.selectors</x-search>
 
 Selectors can be used to install custom selector engines. See [extensibility](../extensibility.mdx) for more information.
 
@@ -236,7 +236,7 @@ playwright.selectors
 
 ### webkit {#playwright-webkit}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>playwright.webkit</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>playwright.webkit</x-search>
 
 This object can be used to launch or connect to WebKit, returning instances of [Browser].
 

--- a/python/docs/api/class-request.mdx
+++ b/python/docs/api/class-request.mdx
@@ -89,7 +89,7 @@ request.headers_array()
 
 ### response {#request-response}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.response</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.response</x-search>
 
 Returns the matching [Response] object, or `null` if the response was not received due to error.
 
@@ -137,7 +137,7 @@ request.sizes()
 
 ### failure {#request-failure}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.failure</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.failure</x-search>
 
 The method returns `null` unless this request has failed, as reported by `requestfailed` event.
 
@@ -156,7 +156,7 @@ page.on("requestfailed", lambda request: print(request.url + " " + request.failu
 
 ### frame {#request-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.frame</x-search>
 
 Returns the [Frame] that initiated this request.
 
@@ -181,7 +181,7 @@ Here is an example that handles all the cases:
 
 ### headers {#request-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.headers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.headers</x-search>
 
 An object with the request HTTP headers. The header names are lower-cased. Note that this method does not return security-related headers, including cookie-related ones. You can use [request.all_headers()](/api/class-request.mdx#request-all-headers) for complete list of headers that include `cookie` information.
 
@@ -198,7 +198,7 @@ request.headers
 
 ### is_navigation_request {#request-is-navigation-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.is_navigation_request</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.is_navigation_request</x-search>
 
 Whether this request is driving frame's navigation.
 
@@ -217,7 +217,7 @@ request.is_navigation_request()
 
 ### method {#request-method}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.method</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.method</x-search>
 
 Request's method (GET, POST, etc.)
 
@@ -234,7 +234,7 @@ request.method
 
 ### post_data {#request-post-data}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.post_data</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.post_data</x-search>
 
 Request's post body, if any.
 
@@ -251,7 +251,7 @@ request.post_data
 
 ### post_data_buffer {#request-post-data-buffer}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.post_data_buffer</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.post_data_buffer</x-search>
 
 Request's post body in a binary form, if any.
 
@@ -268,7 +268,7 @@ request.post_data_buffer
 
 ### post_data_json {#request-post-data-json}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.post_data_json</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.post_data_json</x-search>
 
 Returns parsed request's body for `form-urlencoded` and JSON as a fallback if any.
 
@@ -287,7 +287,7 @@ request.post_data_json
 
 ### redirected_from {#request-redirected-from}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.redirected_from</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.redirected_from</x-search>
 
 Request that was redirected by the server to this one, if any.
 
@@ -358,7 +358,7 @@ print(response.request.redirected_from) # None
 
 ### redirected_to {#request-redirected-to}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.redirected_to</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.redirected_to</x-search>
 
 New request issued by the browser if the server responded with redirect.
 
@@ -377,7 +377,7 @@ assert request.redirected_from.redirected_to == request
 
 ### resource_type {#request-resource-type}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.resource_type</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.resource_type</x-search>
 
 Contains the request's resource type as it was perceived by the rendering engine. ResourceType will be one of the following: `document`, `stylesheet`, `image`, `media`, `font`, `script`, `texttrack`, `xhr`, `fetch`, `eventsource`, `websocket`, `manifest`, `other`.
 
@@ -394,7 +394,7 @@ request.resource_type
 
 ### timing {#request-timing}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.timing</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.timing</x-search>
 
 Returns resource timing information for given request. Most of the timing values become available upon the response, `responseEnd` becomes available when request finishes. Find more information at [Resource Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming).
 
@@ -464,7 +464,7 @@ print(request.timing)
 
 ### url {#request-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>request.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>request.url</x-search>
 
 URL of the request.
 

--- a/python/docs/api/class-response.mdx
+++ b/python/docs/api/class-response.mdx
@@ -33,7 +33,7 @@ response.all_headers()
 
 ### body {#response-body}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.body</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.body</x-search>
 
 Returns the buffer with response body.
 
@@ -50,7 +50,7 @@ response.body()
 
 ### finished {#response-finished}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.finished</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.finished</x-search>
 
 Waits for this response to finish, returns always `null`.
 
@@ -134,7 +134,7 @@ response.headers_array()
 
 ### json {#response-json}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.json</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.json</x-search>
 
 Returns the JSON representation of response body.
 
@@ -207,7 +207,7 @@ response.server_addr()
 
 ### text {#response-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.text</x-search>
 
 Returns the text representation of response body.
 
@@ -226,7 +226,7 @@ response.text()
 
 ### frame {#response-frame}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.frame</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.frame</x-search>
 
 Returns the [Frame] that initiated this response.
 
@@ -260,7 +260,7 @@ response.from_service_worker
 
 ### headers {#response-headers}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.headers</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.headers</x-search>
 
 An object with the response HTTP headers. The header names are lower-cased. Note that this method does not return security-related headers, including cookie-related ones. You can use [response.all_headers()](/api/class-response.mdx#response-all-headers) for complete list of headers that include `cookie` information.
 
@@ -277,7 +277,7 @@ response.headers
 
 ### ok {#response-ok}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.ok</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.ok</x-search>
 
 Contains a boolean stating whether the response was successful (status in the range 200-299) or not.
 
@@ -294,7 +294,7 @@ response.ok
 
 ### request {#response-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.request</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.request</x-search>
 
 Returns the matching [Request] object.
 
@@ -311,7 +311,7 @@ response.request
 
 ### status {#response-status}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.status</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.status</x-search>
 
 Contains the status code of the response (e.g., 200 for a success).
 
@@ -328,7 +328,7 @@ response.status
 
 ### status_text {#response-status-text}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.status_text</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.status_text</x-search>
 
 Contains the status text of the response (e.g. usually an "OK" for a success).
 
@@ -345,7 +345,7 @@ response.status_text
 
 ### url {#response-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>response.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>response.url</x-search>
 
 Contains the URL of the response.
 

--- a/python/docs/api/class-route.mdx
+++ b/python/docs/api/class-route.mdx
@@ -18,7 +18,7 @@ Learn more about [networking](../network.mdx).
 
 ### abort {#route-abort}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.abort</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.abort</x-search>
 
 Aborts the route's request.
 
@@ -55,7 +55,7 @@ route.abort(**kwargs)
 
 ### continue_ {#route-continue}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.continue_</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.continue_</x-search>
 
 Continues route's request with optional overrides.
 
@@ -363,7 +363,7 @@ Note that `headers` option will apply to the fetched request as well as any redi
 
 ### fulfill {#route-fulfill}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.fulfill</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.fulfill</x-search>
 
 Fulfills route's request with given response.
 
@@ -459,7 +459,7 @@ await page.route("**/xhr_endpoint", lambda route: route.fulfill(path="mock_data.
 
 ### request {#route-request}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>route.request</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>route.request</x-search>
 
 A request to be routed.
 

--- a/python/docs/api/class-selectors.mdx
+++ b/python/docs/api/class-selectors.mdx
@@ -16,7 +16,7 @@ Selectors can be used to install custom selector engines. See [extensibility](..
 
 ### register {#selectors-register}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>selectors.register</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>selectors.register</x-search>
 
 Selectors must be registered before creating the page.
 

--- a/python/docs/api/class-touchscreen.mdx
+++ b/python/docs/api/class-touchscreen.mdx
@@ -16,7 +16,7 @@ The Touchscreen class operates in main-frame CSS pixels relative to the top-left
 
 ### tap {#touchscreen-tap}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>touchscreen.tap</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>touchscreen.tap</x-search>
 
 Dispatches a `touchstart` and `touchend` event with a single touch at the position (`x`,`y`).
 

--- a/python/docs/api/class-video.mdx
+++ b/python/docs/api/class-video.mdx
@@ -57,7 +57,7 @@ video.delete()
 
 ### path {#video-path}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>video.path</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>video.path</x-search>
 
 Returns the file system path this video will be recorded to. The video is guaranteed to be written to the filesystem upon closing the browser context. This method throws when connected remotely.
 

--- a/python/docs/api/class-websocket.mdx
+++ b/python/docs/api/class-websocket.mdx
@@ -16,7 +16,7 @@ The [WebSocket] class represents websocket connections in the page.
 
 ### expect_event {#web-socket-wait-for-event}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.expect_event</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.expect_event</x-search>
 
 Waits for event to fire and passes its value into the predicate function. Returns when the predicate returns truthy value. Will throw an error if the webSocket is closed before the event is fired. Returns the event data value.
 
@@ -45,7 +45,7 @@ web_socket.expect_event(event, **kwargs)
 
 ### wait_for_event {#web-socket-wait-for-event-2}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.wait_for_event</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.wait_for_event</x-search>
 
 :::note
 In most cases, you should use [web_socket.expect_event()](/api/class-websocket.mdx#web-socket-wait-for-event).
@@ -80,7 +80,7 @@ web_socket.wait_for_event(event, **kwargs)
 
 ### is_closed {#web-socket-is-closed}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.is_closed</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.is_closed</x-search>
 
 Indicates that the web socket has been closed.
 
@@ -97,7 +97,7 @@ web_socket.is_closed()
 
 ### url {#web-socket-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.url</x-search>
 
 Contains the URL of the WebSocket.
 
@@ -116,7 +116,7 @@ web_socket.url
 
 ### on("close") {#web-socket-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>webSocket.on("close")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>webSocket.on("close")</x-search>
 
 Fired when the websocket closes.
 

--- a/python/docs/api/class-worker.mdx
+++ b/python/docs/api/class-worker.mdx
@@ -28,7 +28,7 @@ for worker in page.workers:
 
 ### evaluate {#worker-evaluate}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.evaluate</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.evaluate</x-search>
 
 Returns the return value of `expression`.
 
@@ -58,7 +58,7 @@ worker.evaluate(expression, **kwargs)
 
 ### evaluate_handle {#worker-evaluate-handle}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.evaluate_handle</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.evaluate_handle</x-search>
 
 Returns the return value of `expression` as a [JSHandle].
 
@@ -90,7 +90,7 @@ worker.evaluate_handle(expression, **kwargs)
 
 ### url {#worker-url}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.url</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.url</x-search>
 
 **Usage**
 
@@ -107,7 +107,7 @@ worker.url
 
 ### on("close") {#worker-event-close}
 
-<font size="2" style={{position: "relative", top: "-20px"}}>Added in: v1.8</font><x-search>worker.on("close")</x-search>
+<font size="2" style={{position: "relative", top: "-20px"}}>Added before v1.9</font><x-search>worker.on("close")</x-search>
 
 Emitted when this dedicated [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) is terminated.
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -181,7 +181,7 @@ import HTMLCard from '@site/src/components/HTMLCard';
     writeFileSyncCached(path.join(this.outDir, 'api', `class-${clazz.name.toLowerCase()}.mdx`), this.mdxLinks(output));
   }
 
-  #formatSince(since) {
+  _formatSince(since) {
     if (since === 'v1.8')
       return 'Added before v1.9';
     return `Added in: ${since}`;
@@ -267,7 +267,7 @@ import HTMLCard from '@site/src/components/HTMLCard';
         const expressionNameForSearch = `<x-search>${clazz.varName}.${name}</x-search>`;
         sections.version.push({
           type: 'text',
-          text: `<font size="2" style={{position: "relative", top: "-20px"}}>${this.#formatSince(member.since)}</font>${expressionNameForSearch}`
+          text: `<font size="2" style={{position: "relative", top: "-20px"}}>${this._formatSince(member.since)}</font>${expressionNameForSearch}`
         });
 
         // Generate deprecations.
@@ -581,7 +581,7 @@ ${this.documentation.renderLinksInText(member.discouraged)}
       const hash = calculatePropertyHash(member, direction);
       linkTag = `<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="${hash}"/>`;
       if (member.enclosingMethod.since !== member.since)
-        sinceVersion = ` <font size="2">${this.#formatSince(member.since)}</font>`;
+        sinceVersion = ` <font size="2">${this._formatSince(member.since)}</font>`;
       linkAnchor = `<a href="#${hash}" class="list-anchor">#</a>`;
     }
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -181,6 +181,12 @@ import HTMLCard from '@site/src/components/HTMLCard';
     writeFileSyncCached(path.join(this.outDir, 'api', `class-${clazz.name.toLowerCase()}.mdx`), this.mdxLinks(output));
   }
 
+  #formatSince(since) {
+    if (since === 'v1.8')
+      return 'Added before v1.9';
+    return `Added in: ${since}`;
+  }
+
   /**
    * @param {docs.Class} clazz
    * @return {MarkdownNode[]}
@@ -261,7 +267,7 @@ import HTMLCard from '@site/src/components/HTMLCard';
         const expressionNameForSearch = `<x-search>${clazz.varName}.${name}</x-search>`;
         sections.version.push({
           type: 'text',
-          text: `<font size="2" style={{position: "relative", top: "-20px"}}>Added in: ${member.since}</font>${expressionNameForSearch}`
+          text: `<font size="2" style={{position: "relative", top: "-20px"}}>${this.#formatSince(member.since)}</font>${expressionNameForSearch}`
         });
 
         // Generate deprecations.
@@ -575,7 +581,7 @@ ${this.documentation.renderLinksInText(member.discouraged)}
       const hash = calculatePropertyHash(member, direction);
       linkTag = `<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="${hash}"/>`;
       if (member.enclosingMethod.since !== member.since)
-        sinceVersion = ` <font size="2">Added in: ${member.since}</font>`;
+        sinceVersion = ` <font size="2">${this.#formatSince(member.since)}</font>`;
       linkAnchor = `<a href="#${hash}" class="list-anchor">#</a>`;
     }
 


### PR DESCRIPTION
We didn't have versioning prior to v1.8. This PR makes our display of versions a little more accurate by changing all mentions of "Added in v1.8" to "Added before v1.9". Don't want people thinking that v1.8 was a huge release :D