### PR TITLE
chore: hide unreleased versions in release-notes

### DIFF
--- a/dotnet/docs/release-notes.mdx
+++ b/dotnet/docs/release-notes.mdx
@@ -7,45 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
 
-## Version 1.46
-
-### TLS Client Certificates
-
-Playwright now allows to supply client-side certificates, so that server can verify them, as specified by TLS Client Authentication.
-
-You can provide client certificates as a parameter of [Browser.NewContextAsync()](/api/class-browser.mdx#browser-new-context) and [ApiRequest.NewContextAsync()](/api/class-apirequest.mdx#api-request-new-context). The following snippet sets up a client certificate for `https://example.com`:
-
-```csharp
-var context = await Browser.NewContextAsync(new() {
-  ClientCertificates = [
-    new() {
-      Origin = "https://example.com",
-      CertPath = "client-certificates/cert.pem",
-      KeyPath = "client-certificates/key.pem",
-    }
-  ]
-});
-```
-
-### Trace Viewer Updates
-- Content of text attachments is now rendered inline in the attachments pane.
-- New setting to show/hide routing actions like [Route.ContinueAsync()](/api/class-route.mdx#route-continue).
-- Request method and status are shown in the network details tab.
-- New button to copy source file location to clipboard.
-- Metadata pane now displays the `BaseURL`.
-
-### Miscellaneous
-- New `maxRetries` option in [ApiRequestContext.FetchAsync()](/api/class-apirequestcontext.mdx#api-request-context-fetch) which retries on the `ECONNRESET` network error.
-
-### Browser Versions
-- Chromium 128.0.6613.18
-- Mozilla Firefox 128.0
-- WebKit 18.0
-
-This version was also tested against the following stable channels:
-- Google Chrome 127
-- Microsoft Edge 127
-
 ## Version 1.45
 
 ### Clock

--- a/java/docs/release-notes.mdx
+++ b/java/docs/release-notes.mdx
@@ -7,40 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
 
-## Version 1.46
-
-### TLS Client Certificates
-
-Playwright now allows to supply client-side certificates, so that server can verify them, as specified by TLS Client Authentication.
-
-You can provide client certificates as a parameter of [Browser.newContext()](/api/class-browser.mdx#browser-new-context) and [APIRequest.newContext()](/api/class-apirequest.mdx#api-request-new-context). The following snippet sets up a client certificate for `https://example.com`:
-
-```java
-BrowserContext context = browser.newContext(new Browser.NewContextOptions()
-    .setClientCertificates(asList(new ClientCertificate("https://example.com")
-          .setCertPath(Paths.get("client-certificates/cert.pem"))
-          .setKeyPath(Paths.get("client-certificates/key.pem")))));
-```
-
-### Trace Viewer Updates
-- Content of text attachments is now rendered inline in the attachments pane.
-- New setting to show/hide routing actions like [Route.resume()](/api/class-route.mdx#route-continue).
-- Request method and status are shown in the network details tab.
-- New button to copy source file location to clipboard.
-- Metadata pane now displays the `baseURL`.
-
-### Miscellaneous
-- New `maxRetries` option in [APIRequestContext.fetch()](/api/class-apirequestcontext.mdx#api-request-context-fetch) which retries on the `ECONNRESET` network error.
-
-### Browser Versions
-- Chromium 128.0.6613.18
-- Mozilla Firefox 128.0
-- WebKit 18.0
-
-This version was also tested against the following stable channels:
-- Google Chrome 127
-- Microsoft Edge 127
-
 ## Version 1.45
 
 ### Clock

--- a/python/docs/release-notes.mdx
+++ b/python/docs/release-notes.mdx
@@ -7,45 +7,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
 
-## Version 1.46
-
-### TLS Client Certificates
-
-Playwright now allows to supply client-side certificates, so that server can verify them, as specified by TLS Client Authentication.
-
-You can provide client certificates as a parameter of [browser.new_context()](/api/class-browser.mdx#browser-new-context) and [api_request.new_context()](/api/class-apirequest.mdx#api-request-new-context). The following snippet sets up a client certificate for `https://example.com`:
-
-```python
-context = browser.new_context(
-    client_certificates=[
-        {
-            "origin": "https://example.com",
-            "certPath": "client-certificates/cert.pem",
-            "keyPath": "client-certificates/key.pem",
-        }
-    ],
-)
-```
-
-### Trace Viewer Updates
-- Content of text attachments is now rendered inline in the attachments pane.
-- New setting to show/hide routing actions like [route.continue_()](/api/class-route.mdx#route-continue).
-- Request method and status are shown in the network details tab.
-- New button to copy source file location to clipboard.
-- Metadata pane now displays the `base_url`.
-
-### Miscellaneous
-- New `maxRetries` option in [api_request_context.fetch()](/api/class-apirequestcontext.mdx#api-request-context-fetch) which retries on the `ECONNRESET` network error.
-
-### Browser Versions
-- Chromium 128.0.6613.18
-- Mozilla Firefox 128.0
-- WebKit 18.0
-
-This version was also tested against the following stable channels:
-- Google Chrome 127
-- Microsoft Edge 127
-
 ## Version 1.45
 
 ### Clock

--- a/src/generator.js
+++ b/src/generator.js
@@ -423,6 +423,16 @@ ${this.documentation.renderLinksInText(member.discouraged)}
   generateDoc(name, outName) {
     const content = fs.readFileSync(path.join(this.srcDir, name)).toString();
     let nodes = this.filterForLanguage(md.parse(content));
+    if (outName === 'release-notes.mdx') {
+      nodes = nodes.filter(node => {
+        if (node.type !== 'h2')
+          return true;
+        if (!node.text.startsWith('Version '))
+          throw new Error('Unexpected release notes format');
+        const version = node.text.trim().substring('Version '.length);
+        return +version.split('.')[1] <= +this.version.split('.')[1];
+      })
+    }
     return this.generateDocFromMd(nodes, outName);
   }
 


### PR DESCRIPTION
Addresses e.g. https://github.com/microsoft/playwright-java/issues/1645

Another idea would be e.g. instead of hiding it, appending ` (to be released)` or something like that.