### PR TITLE
chore: generator anchors only for top level options

### DIFF
--- a/dotnet/docs/api/class-apirequest.mdx
+++ b/dotnet/docs/api/class-apirequest.mdx
@@ -35,19 +35,19 @@ await ApiRequest.NewContextAsync(options);
     * baseURL: `http://localhost:3000/foo/` and sending request to `./bar.html` results in `http://localhost:3000/foo/bar.html`
     * baseURL: `http://localhost:3000/foo` (without trailing slash) and navigating to `./bar.html` results in `http://localhost:3000/bar.html`
   - `ClientCertificates` [IEnumerable]?&lt;ClientCertificates&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-client-certificates"/><a href="#api-request-new-context-option-client-certificates" class="list-anchor">#</a>
-    - `Origin` [string] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origin"/><a href="#api-request-new-context-option-origin" class="list-anchor">#</a>
+    - `Origin` [string]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `CertPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-cert-path"/><a href="#api-request-new-context-option-cert-path" class="list-anchor">#</a>
+    - `CertPath` [string]? *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `KeyPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-key-path"/><a href="#api-request-new-context-option-key-path" class="list-anchor">#</a>
+    - `KeyPath` [string]? *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `PfxPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-pfx-path"/><a href="#api-request-new-context-option-pfx-path" class="list-anchor">#</a>
+    - `PfxPath` [string]? *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `Passphrase` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-passphrase"/><a href="#api-request-new-context-option-passphrase" class="list-anchor">#</a>
+    - `Passphrase` [string]? *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -69,16 +69,16 @@ await ApiRequest.NewContextAsync(options);
     
     An object containing additional HTTP headers to be sent with every request. Defaults to none.
   - `HttpCredentials` HttpCredentials? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-http-credentials"/><a href="#api-request-new-context-option-http-credentials" class="list-anchor">#</a>
-    - `Username` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-username"/><a href="#api-request-new-context-option-username" class="list-anchor">#</a>
+    - `Username` [string]
       
       
-    - `Password` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-password"/><a href="#api-request-new-context-option-password" class="list-anchor">#</a>
+    - `Password` [string]
       
       
-    - `Origin` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origin"/><a href="#api-request-new-context-option-origin" class="list-anchor">#</a>
+    - `Origin` [string]? *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `Send` `enum HttpCredentialsSend { Unauthorized, Always }?` *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-send"/><a href="#api-request-new-context-option-send" class="list-anchor">#</a>
+    - `Send` `enum HttpCredentialsSend { Unauthorized, Always }?` *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -87,16 +87,16 @@ await ApiRequest.NewContextAsync(options);
     
     Whether to ignore HTTPS errors when sending network requests. Defaults to `false`.
   - `Proxy` Proxy? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-proxy"/><a href="#api-request-new-context-option-proxy" class="list-anchor">#</a>
-    - `Server` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-server"/><a href="#api-request-new-context-option-server" class="list-anchor">#</a>
+    - `Server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `Bypass` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-bypass"/><a href="#api-request-new-context-option-bypass" class="list-anchor">#</a>
+    - `Bypass` [string]? *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `Username` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-username"/><a href="#api-request-new-context-option-username" class="list-anchor">#</a>
+    - `Username` [string]? *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `Password` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-password"/><a href="#api-request-new-context-option-password" class="list-anchor">#</a>
+    - `Password` [string]? *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     

--- a/dotnet/docs/api/class-browser.mdx
+++ b/dotnet/docs/api/class-browser.mdx
@@ -173,19 +173,19 @@ await browser.CloseAsync();
     
     Toggles bypassing page's Content-Security-Policy. Defaults to `false`.
   - `ClientCertificates` [IEnumerable]?&lt;ClientCertificates&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-client-certificates"/><a href="#browser-new-context-option-client-certificates" class="list-anchor">#</a>
-    - `Origin` [string] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origin"/><a href="#browser-new-context-option-origin" class="list-anchor">#</a>
+    - `Origin` [string]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `CertPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-cert-path"/><a href="#browser-new-context-option-cert-path" class="list-anchor">#</a>
+    - `CertPath` [string]? *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `KeyPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-key-path"/><a href="#browser-new-context-option-key-path" class="list-anchor">#</a>
+    - `KeyPath` [string]? *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `PfxPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-pfx-path"/><a href="#browser-new-context-option-pfx-path" class="list-anchor">#</a>
+    - `PfxPath` [string]? *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `Passphrase` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-passphrase"/><a href="#browser-new-context-option-passphrase" class="list-anchor">#</a>
+    - `Passphrase` [string]? *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -216,29 +216,29 @@ await browser.CloseAsync();
     
     Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [Page.EmulateMediaAsync()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'none'`.
   - `Geolocation` Geolocation? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-geolocation"/><a href="#browser-new-context-option-geolocation" class="list-anchor">#</a>
-    - `Latitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-latitude"/><a href="#browser-new-context-option-latitude" class="list-anchor">#</a>
+    - `Latitude` [float]
       
       Latitude between -90 and 90.
-    - `Longitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-longitude"/><a href="#browser-new-context-option-longitude" class="list-anchor">#</a>
+    - `Longitude` [float]
       
       Longitude between -180 and 180.
-    - `Accuracy` [float]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-accuracy"/><a href="#browser-new-context-option-accuracy" class="list-anchor">#</a>
+    - `Accuracy` [float]? *(optional)*
       
       Non-negative accuracy value. Defaults to `0`.
   - `HasTouch` [bool]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-has-touch"/><a href="#browser-new-context-option-has-touch" class="list-anchor">#</a>
     
     Specifies if viewport supports touch events. Defaults to false. Learn more about [mobile emulation](../emulation.mdx#devices).
   - `HttpCredentials` HttpCredentials? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-http-credentials"/><a href="#browser-new-context-option-http-credentials" class="list-anchor">#</a>
-    - `Username` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-username"/><a href="#browser-new-context-option-username" class="list-anchor">#</a>
+    - `Username` [string]
       
       
-    - `Password` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-password"/><a href="#browser-new-context-option-password" class="list-anchor">#</a>
+    - `Password` [string]
       
       
-    - `Origin` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origin"/><a href="#browser-new-context-option-origin" class="list-anchor">#</a>
+    - `Origin` [string]? *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `Send` `enum HttpCredentialsSend { Unauthorized, Always }?` *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-send"/><a href="#browser-new-context-option-send" class="list-anchor">#</a>
+    - `Send` `enum HttpCredentialsSend { Unauthorized, Always }?` *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -262,16 +262,16 @@ await browser.CloseAsync();
     
     A list of permissions to grant to all pages in this context. See [BrowserContext.GrantPermissionsAsync()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
   - `Proxy` Proxy? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-proxy"/><a href="#browser-new-context-option-proxy" class="list-anchor">#</a>
-    - `Server` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-server"/><a href="#browser-new-context-option-server" class="list-anchor">#</a>
+    - `Server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `Bypass` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-bypass"/><a href="#browser-new-context-option-bypass" class="list-anchor">#</a>
+    - `Bypass` [string]? *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `Username` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-username"/><a href="#browser-new-context-option-username" class="list-anchor">#</a>
+    - `Username` [string]? *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `Password` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-password"/><a href="#browser-new-context-option-password" class="list-anchor">#</a>
+    - `Password` [string]? *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
@@ -298,10 +298,10 @@ await browser.CloseAsync();
     
     Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure to call [BrowserContext.CloseAsync()](/api/class-browsercontext.mdx#browser-context-close) for videos to be saved.
   - `RecordVideoSize` RecordVideoSize? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-record-video-size"/><a href="#browser-new-context-option-record-video-size" class="list-anchor">#</a>
-    - `Width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+    - `Width` [int]
       
       Video frame width.
-    - `Height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+    - `Height` [int]
       
       Video frame height.
     
@@ -310,10 +310,10 @@ await browser.CloseAsync();
     
     Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [Page.EmulateMediaAsync()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'no-preference'`.
   - `ScreenSize` ScreenSize? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-screen"/><a href="#browser-new-context-option-screen" class="list-anchor">#</a>
-    - `Width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+    - `Width` [int]
       
       page width in pixels.
-    - `Height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+    - `Height` [int]
       
       page height in pixels.
     
@@ -339,10 +339,10 @@ await browser.CloseAsync();
     
     Specific user agent to use in this context.
   - `ViewportSize` ViewportSize? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-viewport"/><a href="#browser-new-context-option-viewport" class="list-anchor">#</a>
-    - `Width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+    - `Width` [int]
       
       page width in pixels.
-    - `Height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+    - `Height` [int]
       
       page height in pixels.
     
@@ -386,19 +386,19 @@ await Browser.NewPageAsync(options);
     
     Toggles bypassing page's Content-Security-Policy. Defaults to `false`.
   - `ClientCertificates` [IEnumerable]?&lt;ClientCertificates&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-client-certificates"/><a href="#browser-new-page-option-client-certificates" class="list-anchor">#</a>
-    - `Origin` [string] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origin"/><a href="#browser-new-page-option-origin" class="list-anchor">#</a>
+    - `Origin` [string]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `CertPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-cert-path"/><a href="#browser-new-page-option-cert-path" class="list-anchor">#</a>
+    - `CertPath` [string]? *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `KeyPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-key-path"/><a href="#browser-new-page-option-key-path" class="list-anchor">#</a>
+    - `KeyPath` [string]? *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `PfxPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-pfx-path"/><a href="#browser-new-page-option-pfx-path" class="list-anchor">#</a>
+    - `PfxPath` [string]? *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `Passphrase` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-passphrase"/><a href="#browser-new-page-option-passphrase" class="list-anchor">#</a>
+    - `Passphrase` [string]? *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -429,29 +429,29 @@ await Browser.NewPageAsync(options);
     
     Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [Page.EmulateMediaAsync()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'none'`.
   - `Geolocation` Geolocation? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-geolocation"/><a href="#browser-new-page-option-geolocation" class="list-anchor">#</a>
-    - `Latitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-latitude"/><a href="#browser-new-page-option-latitude" class="list-anchor">#</a>
+    - `Latitude` [float]
       
       Latitude between -90 and 90.
-    - `Longitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-longitude"/><a href="#browser-new-page-option-longitude" class="list-anchor">#</a>
+    - `Longitude` [float]
       
       Longitude between -180 and 180.
-    - `Accuracy` [float]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-accuracy"/><a href="#browser-new-page-option-accuracy" class="list-anchor">#</a>
+    - `Accuracy` [float]? *(optional)*
       
       Non-negative accuracy value. Defaults to `0`.
   - `HasTouch` [bool]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-has-touch"/><a href="#browser-new-page-option-has-touch" class="list-anchor">#</a>
     
     Specifies if viewport supports touch events. Defaults to false. Learn more about [mobile emulation](../emulation.mdx#devices).
   - `HttpCredentials` HttpCredentials? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-http-credentials"/><a href="#browser-new-page-option-http-credentials" class="list-anchor">#</a>
-    - `Username` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-username"/><a href="#browser-new-page-option-username" class="list-anchor">#</a>
+    - `Username` [string]
       
       
-    - `Password` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-password"/><a href="#browser-new-page-option-password" class="list-anchor">#</a>
+    - `Password` [string]
       
       
-    - `Origin` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origin"/><a href="#browser-new-page-option-origin" class="list-anchor">#</a>
+    - `Origin` [string]? *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `Send` `enum HttpCredentialsSend { Unauthorized, Always }?` *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-send"/><a href="#browser-new-page-option-send" class="list-anchor">#</a>
+    - `Send` `enum HttpCredentialsSend { Unauthorized, Always }?` *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -475,16 +475,16 @@ await Browser.NewPageAsync(options);
     
     A list of permissions to grant to all pages in this context. See [BrowserContext.GrantPermissionsAsync()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
   - `Proxy` Proxy? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-proxy"/><a href="#browser-new-page-option-proxy" class="list-anchor">#</a>
-    - `Server` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-server"/><a href="#browser-new-page-option-server" class="list-anchor">#</a>
+    - `Server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `Bypass` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-bypass"/><a href="#browser-new-page-option-bypass" class="list-anchor">#</a>
+    - `Bypass` [string]? *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `Username` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-username"/><a href="#browser-new-page-option-username" class="list-anchor">#</a>
+    - `Username` [string]? *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `Password` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-password"/><a href="#browser-new-page-option-password" class="list-anchor">#</a>
+    - `Password` [string]? *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
@@ -511,10 +511,10 @@ await Browser.NewPageAsync(options);
     
     Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure to call [BrowserContext.CloseAsync()](/api/class-browsercontext.mdx#browser-context-close) for videos to be saved.
   - `RecordVideoSize` RecordVideoSize? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-record-video-size"/><a href="#browser-new-page-option-record-video-size" class="list-anchor">#</a>
-    - `Width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+    - `Width` [int]
       
       Video frame width.
-    - `Height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+    - `Height` [int]
       
       Video frame height.
     
@@ -523,10 +523,10 @@ await Browser.NewPageAsync(options);
     
     Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [Page.EmulateMediaAsync()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'no-preference'`.
   - `ScreenSize` ScreenSize? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-screen"/><a href="#browser-new-page-option-screen" class="list-anchor">#</a>
-    - `Width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+    - `Width` [int]
       
       page width in pixels.
-    - `Height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+    - `Height` [int]
       
       page height in pixels.
     
@@ -552,10 +552,10 @@ await Browser.NewPageAsync(options);
     
     Specific user agent to use in this context.
   - `ViewportSize` ViewportSize? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-viewport"/><a href="#browser-new-page-option-viewport" class="list-anchor">#</a>
-    - `Width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+    - `Width` [int]
       
       page width in pixels.
-    - `Height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+    - `Height` [int]
       
       page height in pixels.
     

--- a/dotnet/docs/api/class-browsercontext.mdx
+++ b/dotnet/docs/api/class-browsercontext.mdx
@@ -44,31 +44,31 @@ await context.AddCookiesAsync(new[] { cookie1, cookie2 });
 
 **Arguments**
 - `cookies` [IEnumerable]&lt;`Cookie`&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-cookies"/><a href="#browser-context-add-cookies-option-cookies" class="list-anchor">#</a>
-  - `Name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-name"/><a href="#browser-context-add-cookies-option-name" class="list-anchor">#</a>
+  - `Name` [string]
     
     
-  - `Value` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-value"/><a href="#browser-context-add-cookies-option-value" class="list-anchor">#</a>
+  - `Value` [string]
     
     
-  - `Url` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-url"/><a href="#browser-context-add-cookies-option-url" class="list-anchor">#</a>
+  - `Url` [string]? *(optional)*
     
     Either url or domain / path are required. Optional.
-  - `Domain` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-domain"/><a href="#browser-context-add-cookies-option-domain" class="list-anchor">#</a>
+  - `Domain` [string]? *(optional)*
     
     For the cookie to apply to all subdomains as well, prefix domain with a dot, like this: ".example.com". Either url or domain / path are required. Optional.
-  - `Path` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-path"/><a href="#browser-context-add-cookies-option-path" class="list-anchor">#</a>
+  - `Path` [string]? *(optional)*
     
     Either url or domain / path are required Optional.
-  - `Expires` [float]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-expires"/><a href="#browser-context-add-cookies-option-expires" class="list-anchor">#</a>
+  - `Expires` [float]? *(optional)*
     
     Unix time in seconds. Optional.
-  - `HttpOnly` [bool]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-http-only"/><a href="#browser-context-add-cookies-option-http-only" class="list-anchor">#</a>
+  - `HttpOnly` [bool]? *(optional)*
     
     Optional.
-  - `Secure` [bool]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-secure"/><a href="#browser-context-add-cookies-option-secure" class="list-anchor">#</a>
+  - `Secure` [bool]? *(optional)*
     
     Optional.
-  - `SameSite` `enum SameSiteAttribute { Strict, Lax, None }?` *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-same-site"/><a href="#browser-context-add-cookies-option-same-site" class="list-anchor">#</a>
+  - `SameSite` `enum SameSiteAttribute { Strict, Lax, None }?` *(optional)*
     
     Optional.
 
@@ -839,13 +839,13 @@ Consider using [BrowserContext.GrantPermissionsAsync()](/api/class-browsercontex
 
 **Arguments**
 - `geolocation` Geolocation?<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-geolocation"/><a href="#browser-context-set-geolocation-option-geolocation" class="list-anchor">#</a>
-  - `Latitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-latitude"/><a href="#browser-context-set-geolocation-option-latitude" class="list-anchor">#</a>
+  - `Latitude` [float]
     
     Latitude between -90 and 90.
-  - `Longitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-longitude"/><a href="#browser-context-set-geolocation-option-longitude" class="list-anchor">#</a>
+  - `Longitude` [float]
     
     Longitude between -180 and 180.
-  - `Accuracy` [float]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-accuracy"/><a href="#browser-context-set-geolocation-option-accuracy" class="list-anchor">#</a>
+  - `Accuracy` [float]? *(optional)*
     
     Non-negative accuracy value. Defaults to `0`.
 

--- a/dotnet/docs/api/class-browsertype.mdx
+++ b/dotnet/docs/api/class-browsertype.mdx
@@ -211,16 +211,16 @@ var browser = await playwright.Chromium.LaunchAsync(new() {
     
     If `true`, Playwright does not pass its own configurations args and only uses the ones from `args`. Dangerous option; use with care.
   - `Proxy` Proxy? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-proxy"/><a href="#browser-type-launch-option-proxy" class="list-anchor">#</a>
-    - `Server` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-server"/><a href="#browser-type-launch-option-server" class="list-anchor">#</a>
+    - `Server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `Bypass` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-bypass"/><a href="#browser-type-launch-option-bypass" class="list-anchor">#</a>
+    - `Bypass` [string]? *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `Username` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-username"/><a href="#browser-type-launch-option-username" class="list-anchor">#</a>
+    - `Username` [string]? *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `Password` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-password"/><a href="#browser-type-launch-option-password" class="list-anchor">#</a>
+    - `Password` [string]? *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
@@ -285,19 +285,19 @@ await BrowserType.LaunchPersistentContextAsync(userDataDir, options);
     
     Enable Chromium sandboxing. Defaults to `false`.
   - `ClientCertificates` [IEnumerable]?&lt;ClientCertificates&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-client-certificates"/><a href="#browser-type-launch-persistent-context-option-client-certificates" class="list-anchor">#</a>
-    - `Origin` [string] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-origin"/><a href="#browser-type-launch-persistent-context-option-origin" class="list-anchor">#</a>
+    - `Origin` [string]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `CertPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-cert-path"/><a href="#browser-type-launch-persistent-context-option-cert-path" class="list-anchor">#</a>
+    - `CertPath` [string]? *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `KeyPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-key-path"/><a href="#browser-type-launch-persistent-context-option-key-path" class="list-anchor">#</a>
+    - `KeyPath` [string]? *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `PfxPath` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-pfx-path"/><a href="#browser-type-launch-persistent-context-option-pfx-path" class="list-anchor">#</a>
+    - `PfxPath` [string]? *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `Passphrase` [string]? *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-passphrase"/><a href="#browser-type-launch-persistent-context-option-passphrase" class="list-anchor">#</a>
+    - `Passphrase` [string]? *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -348,13 +348,13 @@ await BrowserType.LaunchPersistentContextAsync(userDataDir, options);
     
     Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [Page.EmulateMediaAsync()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'none'`.
   - `Geolocation` Geolocation? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-geolocation"/><a href="#browser-type-launch-persistent-context-option-geolocation" class="list-anchor">#</a>
-    - `Latitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-latitude"/><a href="#browser-type-launch-persistent-context-option-latitude" class="list-anchor">#</a>
+    - `Latitude` [float]
       
       Latitude between -90 and 90.
-    - `Longitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-longitude"/><a href="#browser-type-launch-persistent-context-option-longitude" class="list-anchor">#</a>
+    - `Longitude` [float]
       
       Longitude between -180 and 180.
-    - `Accuracy` [float]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-accuracy"/><a href="#browser-type-launch-persistent-context-option-accuracy" class="list-anchor">#</a>
+    - `Accuracy` [float]? *(optional)*
       
       Non-negative accuracy value. Defaults to `0`.
   - `HandleSIGHUP` [bool]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-handle-sighup"/><a href="#browser-type-launch-persistent-context-option-handle-sighup" class="list-anchor">#</a>
@@ -373,16 +373,16 @@ await BrowserType.LaunchPersistentContextAsync(userDataDir, options);
     
     Whether to run browser in headless mode. More details for [Chromium](https://developers.google.com/web/updates/2017/04/headless-chrome) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode). Defaults to `true` unless the `devtools` option is `true`.
   - `HttpCredentials` HttpCredentials? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-http-credentials"/><a href="#browser-type-launch-persistent-context-option-http-credentials" class="list-anchor">#</a>
-    - `Username` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-username"/><a href="#browser-type-launch-persistent-context-option-username" class="list-anchor">#</a>
+    - `Username` [string]
       
       
-    - `Password` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-password"/><a href="#browser-type-launch-persistent-context-option-password" class="list-anchor">#</a>
+    - `Password` [string]
       
       
-    - `Origin` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-origin"/><a href="#browser-type-launch-persistent-context-option-origin" class="list-anchor">#</a>
+    - `Origin` [string]? *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `Send` `enum HttpCredentialsSend { Unauthorized, Always }?` *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-send"/><a href="#browser-type-launch-persistent-context-option-send" class="list-anchor">#</a>
+    - `Send` `enum HttpCredentialsSend { Unauthorized, Always }?` *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -412,16 +412,16 @@ await BrowserType.LaunchPersistentContextAsync(userDataDir, options);
     
     A list of permissions to grant to all pages in this context. See [BrowserContext.GrantPermissionsAsync()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
   - `Proxy` Proxy? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-proxy"/><a href="#browser-type-launch-persistent-context-option-proxy" class="list-anchor">#</a>
-    - `Server` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-server"/><a href="#browser-type-launch-persistent-context-option-server" class="list-anchor">#</a>
+    - `Server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `Bypass` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-bypass"/><a href="#browser-type-launch-persistent-context-option-bypass" class="list-anchor">#</a>
+    - `Bypass` [string]? *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `Username` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-username"/><a href="#browser-type-launch-persistent-context-option-username" class="list-anchor">#</a>
+    - `Username` [string]? *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `Password` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-password"/><a href="#browser-type-launch-persistent-context-option-password" class="list-anchor">#</a>
+    - `Password` [string]? *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
@@ -443,10 +443,10 @@ await BrowserType.LaunchPersistentContextAsync(userDataDir, options);
     
     Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure to call [BrowserContext.CloseAsync()](/api/class-browsercontext.mdx#browser-context-close) for videos to be saved.
   - `RecordVideoSize` RecordVideoSize? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-record-video-size"/><a href="#browser-type-launch-persistent-context-option-record-video-size" class="list-anchor">#</a>
-    - `Width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+    - `Width` [int]
       
       Video frame width.
-    - `Height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+    - `Height` [int]
       
       Video frame height.
     
@@ -455,10 +455,10 @@ await BrowserType.LaunchPersistentContextAsync(userDataDir, options);
     
     Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [Page.EmulateMediaAsync()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'no-preference'`.
   - `ScreenSize` ScreenSize? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-screen"/><a href="#browser-type-launch-persistent-context-option-screen" class="list-anchor">#</a>
-    - `Width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+    - `Width` [int]
       
       page width in pixels.
-    - `Height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+    - `Height` [int]
       
       page height in pixels.
     
@@ -487,10 +487,10 @@ await BrowserType.LaunchPersistentContextAsync(userDataDir, options);
     
     Specific user agent to use in this context.
   - `ViewportSize` ViewportSize? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-viewport"/><a href="#browser-type-launch-persistent-context-option-viewport" class="list-anchor">#</a>
-    - `Width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+    - `Width` [int]
       
       page width in pixels.
-    - `Height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+    - `Height` [int]
       
       page height in pixels.
     

--- a/dotnet/docs/api/class-elementhandle.mdx
+++ b/dotnet/docs/api/class-elementhandle.mdx
@@ -196,10 +196,10 @@ await ElementHandle.CheckAsync(options);
     
     This option has no effect.
   - `Position` Position? *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-position"/><a href="#element-handle-check-option-position" class="list-anchor">#</a>
-    - `X` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-x"/><a href="#element-handle-check-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-y"/><a href="#element-handle-check-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -268,10 +268,10 @@ await ElementHandle.ClickAsync(options);
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-position"/><a href="#element-handle-click-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-x"/><a href="#element-handle-click-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-y"/><a href="#element-handle-click-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -340,10 +340,10 @@ await ElementHandle.DblClickAsync(options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-position"/><a href="#element-handle-dblclick-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-x"/><a href="#element-handle-dblclick-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-y"/><a href="#element-handle-dblclick-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -647,10 +647,10 @@ await ElementHandle.HoverAsync(options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-position"/><a href="#element-handle-hover-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-x"/><a href="#element-handle-hover-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-y"/><a href="#element-handle-hover-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1145,13 +1145,13 @@ await handle.SelectOptionAsync(new[] {
 
 **Arguments**
 - `values` [string]? | [ElementHandle]? | [IEnumerable]?&lt;[string]&gt; | `SelectOption` | [IEnumerable]?&lt;[ElementHandle]&gt; | [IEnumerable]?&lt;`SelectOption`&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-values"/><a href="#element-handle-select-option-option-values" class="list-anchor">#</a>
-  - `Value` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-value"/><a href="#element-handle-select-option-option-value" class="list-anchor">#</a>
+  - `Value` [string]? *(optional)*
     
     Matches by `option.value`. Optional.
-  - `Label` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-label"/><a href="#element-handle-select-option-option-label" class="list-anchor">#</a>
+  - `Label` [string]? *(optional)*
     
     Matches by `option.label`. Optional.
-  - `Index` [int]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-index"/><a href="#element-handle-select-option-option-index" class="list-anchor">#</a>
+  - `Index` [int]? *(optional)*
     
     Matches by the index. Optional.
   
@@ -1256,10 +1256,10 @@ await ElementHandle.SetCheckedAsync(checked, options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-position"/><a href="#element-handle-set-checked-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-x"/><a href="#element-handle-set-checked-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-y"/><a href="#element-handle-set-checked-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1298,13 +1298,13 @@ await ElementHandle.SetInputFilesAsync(files, options);
 
 **Arguments**
 - `files` [string] | [IEnumerable]&lt;[string]&gt; | `FilePayload` | [IEnumerable]&lt;`FilePayload`&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-files"/><a href="#element-handle-set-input-files-option-files" class="list-anchor">#</a>
-  - `Name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-name"/><a href="#element-handle-set-input-files-option-name" class="list-anchor">#</a>
+  - `Name` [string]
     
     File name
-  - `MimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-mime-type"/><a href="#element-handle-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `MimeType` [string]
     
     File type
-  - `Buffer` [byte]&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-buffer"/><a href="#element-handle-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `Buffer` [byte]&#91;&#93;
     
     File content
 - `options` `ElementHandleSetInputFilesOptions?` *(optional)*
@@ -1372,10 +1372,10 @@ await ElementHandle.TapAsync(options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-position"/><a href="#element-handle-tap-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-x"/><a href="#element-handle-tap-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-y"/><a href="#element-handle-tap-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1499,10 +1499,10 @@ await ElementHandle.UncheckAsync(options);
     
     This option has no effect.
   - `Position` Position? *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-position"/><a href="#element-handle-uncheck-option-position" class="list-anchor">#</a>
-    - `X` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-x"/><a href="#element-handle-uncheck-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-y"/><a href="#element-handle-uncheck-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/dotnet/docs/api/class-filechooser.mdx
+++ b/dotnet/docs/api/class-filechooser.mdx
@@ -87,13 +87,13 @@ await FileChooser.SetFilesAsync(files, options);
 
 **Arguments**
 - `files` [string] | [IEnumerable]&lt;[string]&gt; | `FilePayload` | [IEnumerable]&lt;`FilePayload`&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-files"/><a href="#file-chooser-set-files-option-files" class="list-anchor">#</a>
-  - `Name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-name"/><a href="#file-chooser-set-files-option-name" class="list-anchor">#</a>
+  - `Name` [string]
     
     File name
-  - `MimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-mime-type"/><a href="#file-chooser-set-files-option-mime-type" class="list-anchor">#</a>
+  - `MimeType` [string]
     
     File type
-  - `Buffer` [byte]&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-buffer"/><a href="#file-chooser-set-files-option-buffer" class="list-anchor">#</a>
+  - `Buffer` [byte]&#91;&#93;
     
     File content
 - `options` `FileChooserSetFilesOptions?` *(optional)*

--- a/dotnet/docs/api/class-formdata.mdx
+++ b/dotnet/docs/api/class-formdata.mdx
@@ -54,13 +54,13 @@ FormData.Append(name, value);
   
   Field name.
 - `value` [string] | [bool] | [int] | Value<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-append-option-value"/><a href="#form-data-append-option-value" class="list-anchor">#</a>
-  - `Name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-append-option-name"/><a href="#form-data-append-option-name" class="list-anchor">#</a>
+  - `Name` [string]
     
     File name
-  - `MimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-append-option-mime-type"/><a href="#form-data-append-option-mime-type" class="list-anchor">#</a>
+  - `MimeType` [string]
     
     File type
-  - `Buffer` [byte]&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-append-option-buffer"/><a href="#form-data-append-option-buffer" class="list-anchor">#</a>
+  - `Buffer` [byte]&#91;&#93;
     
     File content
   
@@ -103,13 +103,13 @@ FormData.Set(name, value);
   
   Field name.
 - `value` [string] | [bool] | [int] | Value<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-set-option-value"/><a href="#form-data-set-option-value" class="list-anchor">#</a>
-  - `Name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-set-option-name"/><a href="#form-data-set-option-name" class="list-anchor">#</a>
+  - `Name` [string]
     
     File name
-  - `MimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-set-option-mime-type"/><a href="#form-data-set-option-mime-type" class="list-anchor">#</a>
+  - `MimeType` [string]
     
     File type
-  - `Buffer` [byte]&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-set-option-buffer"/><a href="#form-data-set-option-buffer" class="list-anchor">#</a>
+  - `Buffer` [byte]&#91;&#93;
     
     File content
   

--- a/dotnet/docs/api/class-frame.mdx
+++ b/dotnet/docs/api/class-frame.mdx
@@ -174,10 +174,10 @@ await Frame.DragAndDropAsync(source, target, options);
     
     This option has no effect.
   - `SourcePosition` SourcePosition? *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-source-position"/><a href="#frame-drag-and-drop-option-source-position" class="list-anchor">#</a>
-    - `X` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-x"/><a href="#frame-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-y"/><a href="#frame-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -185,10 +185,10 @@ await Frame.DragAndDropAsync(source, target, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `TargetPosition` TargetPosition? *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-target-position"/><a href="#frame-drag-and-drop-option-target-position" class="list-anchor">#</a>
-    - `X` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-x"/><a href="#frame-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-y"/><a href="#frame-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -1106,10 +1106,10 @@ await Frame.CheckAsync(selector, options);
     
     This option has no effect.
   - `Position` Position? *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-position"/><a href="#frame-check-option-position" class="list-anchor">#</a>
-    - `X` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-x"/><a href="#frame-check-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-y"/><a href="#frame-check-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1183,10 +1183,10 @@ await Frame.ClickAsync(selector, options);
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-position"/><a href="#frame-click-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-x"/><a href="#frame-click-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-y"/><a href="#frame-click-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1260,10 +1260,10 @@ await Frame.DblClickAsync(selector, options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-position"/><a href="#frame-dblclick-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-x"/><a href="#frame-dblclick-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-y"/><a href="#frame-dblclick-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1604,10 +1604,10 @@ await Frame.HoverAsync(selector, options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-position"/><a href="#frame-hover-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-x"/><a href="#frame-hover-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-y"/><a href="#frame-hover-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2198,13 +2198,13 @@ await frame.SelectOptionAsync("select#colors", new[] { "red", "green", "blue" })
   
   A selector to query for.
 - `values` [string]? | [ElementHandle]? | [IEnumerable]?&lt;[string]&gt; | `SelectOption` | [IEnumerable]?&lt;[ElementHandle]&gt; | [IEnumerable]?&lt;`SelectOption`&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-values"/><a href="#frame-select-option-option-values" class="list-anchor">#</a>
-  - `Value` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-value"/><a href="#frame-select-option-option-value" class="list-anchor">#</a>
+  - `Value` [string]? *(optional)*
     
     Matches by `option.value`. Optional.
-  - `Label` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-label"/><a href="#frame-select-option-option-label" class="list-anchor">#</a>
+  - `Label` [string]? *(optional)*
     
     Matches by `option.label`. Optional.
-  - `Index` [int]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-index"/><a href="#frame-select-option-option-index" class="list-anchor">#</a>
+  - `Index` [int]? *(optional)*
     
     Matches by the index. Optional.
   
@@ -2281,10 +2281,10 @@ await Frame.SetCheckedAsync(selector, checked, options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-position"/><a href="#frame-set-checked-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-x"/><a href="#frame-set-checked-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-y"/><a href="#frame-set-checked-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2329,13 +2329,13 @@ await Frame.SetInputFilesAsync(selector, files, options);
   
   A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
 - `files` [string] | [IEnumerable]&lt;[string]&gt; | `FilePayload` | [IEnumerable]&lt;`FilePayload`&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-files"/><a href="#frame-set-input-files-option-files" class="list-anchor">#</a>
-  - `Name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-name"/><a href="#frame-set-input-files-option-name" class="list-anchor">#</a>
+  - `Name` [string]
     
     File name
-  - `MimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-mime-type"/><a href="#frame-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `MimeType` [string]
     
     File type
-  - `Buffer` [byte]&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-buffer"/><a href="#frame-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `Buffer` [byte]&#91;&#93;
     
     File content
 - `options` `FrameSetInputFilesOptions?` *(optional)*
@@ -2408,10 +2408,10 @@ await Frame.TapAsync(selector, options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-position"/><a href="#frame-tap-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-x"/><a href="#frame-tap-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-y"/><a href="#frame-tap-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2558,10 +2558,10 @@ await Frame.UncheckAsync(selector, options);
     
     This option has no effect.
   - `Position` Position? *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-position"/><a href="#frame-uncheck-option-position" class="list-anchor">#</a>
-    - `X` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-x"/><a href="#frame-uncheck-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-y"/><a href="#frame-uncheck-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/dotnet/docs/api/class-locator.mdx
+++ b/dotnet/docs/api/class-locator.mdx
@@ -197,10 +197,10 @@ await page.GetByRole(AriaRole.Checkbox).CheckAsync();
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-position"/><a href="#locator-check-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-x"/><a href="#locator-check-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-y"/><a href="#locator-check-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -319,10 +319,10 @@ await page.Locator("canvas").ClickAsync(new() {
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-position"/><a href="#locator-click-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-x"/><a href="#locator-click-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-y"/><a href="#locator-click-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -430,10 +430,10 @@ await Locator.DblClickAsync(options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-position"/><a href="#locator-dblclick-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-x"/><a href="#locator-dblclick-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-y"/><a href="#locator-dblclick-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -559,18 +559,18 @@ await source.DragToAsync(target, new()
     
     This option has no effect.
   - `SourcePosition` SourcePosition? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-source-position"/><a href="#locator-drag-to-option-source-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-x"/><a href="#locator-drag-to-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-y"/><a href="#locator-drag-to-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
   - `TargetPosition` TargetPosition? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-target-position"/><a href="#locator-drag-to-option-target-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-x"/><a href="#locator-drag-to-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-y"/><a href="#locator-drag-to-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -1259,10 +1259,10 @@ await page.GetByRole(AriaRole.Link).HoverAsync();
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-position"/><a href="#locator-hover-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-x"/><a href="#locator-hover-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-y"/><a href="#locator-hover-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1897,13 +1897,13 @@ await element.SelectOptionAsync(new[] { "red", "green", "blue" });
 
 **Arguments**
 - `values` [string]? | [ElementHandle]? | [IEnumerable]?&lt;[string]&gt; | `SelectOption` | [IEnumerable]?&lt;[ElementHandle]&gt; | [IEnumerable]?&lt;`SelectOption`&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-values"/><a href="#locator-select-option-option-values" class="list-anchor">#</a>
-  - `Value` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-value"/><a href="#locator-select-option-option-value" class="list-anchor">#</a>
+  - `Value` [string]? *(optional)*
     
     Matches by `option.value`. Optional.
-  - `Label` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-label"/><a href="#locator-select-option-option-label" class="list-anchor">#</a>
+  - `Label` [string]? *(optional)*
     
     Matches by `option.label`. Optional.
-  - `Index` [int]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-index"/><a href="#locator-select-option-option-index" class="list-anchor">#</a>
+  - `Index` [int]? *(optional)*
     
     Matches by the index. Optional.
   
@@ -1996,10 +1996,10 @@ await page.GetByRole(AriaRole.Checkbox).SetCheckedAsync(true);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-position"/><a href="#locator-set-checked-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-x"/><a href="#locator-set-checked-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-y"/><a href="#locator-set-checked-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2059,13 +2059,13 @@ await page.GetByLabel("Upload file").SetInputFilesAsync(new FilePayload
 
 **Arguments**
 - `files` [string] | [IEnumerable]&lt;[string]&gt; | `FilePayload` | [IEnumerable]&lt;`FilePayload`&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-files"/><a href="#locator-set-input-files-option-files" class="list-anchor">#</a>
-  - `Name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-name"/><a href="#locator-set-input-files-option-name" class="list-anchor">#</a>
+  - `Name` [string]
     
     File name
-  - `MimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-mime-type"/><a href="#locator-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `MimeType` [string]
     
     File type
-  - `Buffer` [byte]&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-buffer"/><a href="#locator-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `Buffer` [byte]&#91;&#93;
     
     File content
 - `options` `LocatorSetInputFilesOptions?` *(optional)*
@@ -2121,10 +2121,10 @@ await Locator.TapAsync(options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-position"/><a href="#locator-tap-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-x"/><a href="#locator-tap-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-y"/><a href="#locator-tap-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2208,10 +2208,10 @@ await page.GetByRole(AriaRole.Checkbox).UncheckAsync();
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-position"/><a href="#locator-uncheck-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-x"/><a href="#locator-uncheck-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-y"/><a href="#locator-uncheck-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/dotnet/docs/api/class-page.mdx
+++ b/dotnet/docs/api/class-page.mdx
@@ -360,10 +360,10 @@ await Page.DragAndDropAsync("#source", "#target", new()
     
     This option has no effect.
   - `SourcePosition` SourcePosition? *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-source-position"/><a href="#page-drag-and-drop-option-source-position" class="list-anchor">#</a>
-    - `X` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-x"/><a href="#page-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-y"/><a href="#page-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -371,10 +371,10 @@ await Page.DragAndDropAsync("#source", "#target", new()
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `TargetPosition` TargetPosition? *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-target-position"/><a href="#page-drag-and-drop-option-target-position" class="list-anchor">#</a>
-    - `X` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-x"/><a href="#page-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-y"/><a href="#page-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -1404,16 +1404,16 @@ The `format` options are:
     
     Paper orientation. Defaults to `false`.
   - `Margin` Margin? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-margin"/><a href="#page-pdf-option-margin" class="list-anchor">#</a>
-    - `Top` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-top"/><a href="#page-pdf-option-top" class="list-anchor">#</a>
+    - `Top` [string]? *(optional)*
       
       Top margin, accepts values labeled with units. Defaults to `0`.
-    - `Right` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-right"/><a href="#page-pdf-option-right" class="list-anchor">#</a>
+    - `Right` [string]? *(optional)*
       
       Right margin, accepts values labeled with units. Defaults to `0`.
-    - `Bottom` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-bottom"/><a href="#page-pdf-option-bottom" class="list-anchor">#</a>
+    - `Bottom` [string]? *(optional)*
       
       Bottom margin, accepts values labeled with units. Defaults to `0`.
-    - `Left` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-left"/><a href="#page-pdf-option-left" class="list-anchor">#</a>
+    - `Left` [string]? *(optional)*
       
       Left margin, accepts values labeled with units. Defaults to `0`.
     
@@ -2197,16 +2197,16 @@ await Page.ScreenshotAsync(options);
     
     When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be changed.  Defaults to `"hide"`.
   - `Clip` Clip? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-clip"/><a href="#page-screenshot-option-clip" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-x"/><a href="#page-screenshot-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       x-coordinate of top-left corner of clip area
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-y"/><a href="#page-screenshot-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       y-coordinate of top-left corner of clip area
-    - `Width` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-width"/><a href="#page-screenshot-option-width" class="list-anchor">#</a>
+    - `Width` [float]
       
       width of clipping area
-    - `Height` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-height"/><a href="#page-screenshot-option-height" class="list-anchor">#</a>
+    - `Height` [float]
       
       height of clipping area
     
@@ -3197,10 +3197,10 @@ await Page.CheckAsync(selector, options);
     
     This option has no effect.
   - `Position` Position? *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-position"/><a href="#page-check-option-position" class="list-anchor">#</a>
-    - `X` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-x"/><a href="#page-check-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-y"/><a href="#page-check-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3274,10 +3274,10 @@ await Page.ClickAsync(selector, options);
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-position"/><a href="#page-click-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-x"/><a href="#page-click-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-y"/><a href="#page-click-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3351,10 +3351,10 @@ await Page.DblClickAsync(selector, options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-position"/><a href="#page-dblclick-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-x"/><a href="#page-dblclick-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-y"/><a href="#page-dblclick-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3690,10 +3690,10 @@ await Page.HoverAsync(selector, options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-position"/><a href="#page-hover-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-x"/><a href="#page-hover-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-y"/><a href="#page-hover-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -4317,13 +4317,13 @@ await page.SelectOptionAsync("select#colors", new[] { "red", "green", "blue" });
   
   A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
 - `values` [string]? | [ElementHandle]? | [IEnumerable]?&lt;[string]&gt; | `SelectOption` | [IEnumerable]?&lt;[ElementHandle]&gt; | [IEnumerable]?&lt;`SelectOption`&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-values"/><a href="#page-select-option-option-values" class="list-anchor">#</a>
-  - `Value` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-value"/><a href="#page-select-option-option-value" class="list-anchor">#</a>
+  - `Value` [string]? *(optional)*
     
     Matches by `option.value`. Optional.
-  - `Label` [string]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-label"/><a href="#page-select-option-option-label" class="list-anchor">#</a>
+  - `Label` [string]? *(optional)*
     
     Matches by `option.label`. Optional.
-  - `Index` [int]? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-index"/><a href="#page-select-option-option-index" class="list-anchor">#</a>
+  - `Index` [int]? *(optional)*
     
     Matches by the index. Optional.
   
@@ -4400,10 +4400,10 @@ await Page.SetCheckedAsync(selector, checked, options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-position"/><a href="#page-set-checked-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-x"/><a href="#page-set-checked-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-y"/><a href="#page-set-checked-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -4448,13 +4448,13 @@ await Page.SetInputFilesAsync(selector, files, options);
   
   A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
 - `files` [string] | [IEnumerable]&lt;[string]&gt; | `FilePayload` | [IEnumerable]&lt;`FilePayload`&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-files"/><a href="#page-set-input-files-option-files" class="list-anchor">#</a>
-  - `Name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-name"/><a href="#page-set-input-files-option-name" class="list-anchor">#</a>
+  - `Name` [string]
     
     File name
-  - `MimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-mime-type"/><a href="#page-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `MimeType` [string]
     
     File type
-  - `Buffer` [byte]&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-buffer"/><a href="#page-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `Buffer` [byte]&#91;&#93;
     
     File content
 - `options` `PageSetInputFilesOptions?` *(optional)*
@@ -4527,10 +4527,10 @@ await Page.TapAsync(selector, options);
     
     This option has no effect.
   - `Position` Position? *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-position"/><a href="#page-tap-option-position" class="list-anchor">#</a>
-    - `X` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-x"/><a href="#page-tap-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-y"/><a href="#page-tap-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -4677,10 +4677,10 @@ await Page.UncheckAsync(selector, options);
     
     This option has no effect.
   - `Position` Position? *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-position"/><a href="#page-uncheck-option-position" class="list-anchor">#</a>
-    - `X` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-x"/><a href="#page-uncheck-option-x" class="list-anchor">#</a>
+    - `X` [float]
       
       
-    - `Y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-y"/><a href="#page-uncheck-option-y" class="list-anchor">#</a>
+    - `Y` [float]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/java/docs/api/class-apirequest.mdx
+++ b/java/docs/api/class-apirequest.mdx
@@ -36,19 +36,19 @@ APIRequest.newContext(options);
     * baseURL: `http://localhost:3000/foo/` and sending request to `./bar.html` results in `http://localhost:3000/foo/bar.html`
     * baseURL: `http://localhost:3000/foo` (without trailing slash) and navigating to `./bar.html` results in `http://localhost:3000/bar.html`
   - `setClientCertificates` [List]&lt;ClientCertificates&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-client-certificates"/><a href="#api-request-new-context-option-client-certificates" class="list-anchor">#</a>
-    - `setOrigin` [String] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origin"/><a href="#api-request-new-context-option-origin" class="list-anchor">#</a>
+    - `setOrigin` [String]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `setCertPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-cert-path"/><a href="#api-request-new-context-option-cert-path" class="list-anchor">#</a>
+    - `setCertPath` [Path] *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `setKeyPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-key-path"/><a href="#api-request-new-context-option-key-path" class="list-anchor">#</a>
+    - `setKeyPath` [Path] *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `setPfxPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-pfx-path"/><a href="#api-request-new-context-option-pfx-path" class="list-anchor">#</a>
+    - `setPfxPath` [Path] *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `setPassphrase` [String] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-passphrase"/><a href="#api-request-new-context-option-passphrase" class="list-anchor">#</a>
+    - `setPassphrase` [String] *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -70,16 +70,16 @@ APIRequest.newContext(options);
     
     An object containing additional HTTP headers to be sent with every request. Defaults to none.
   - `setHttpCredentials` HttpCredentials *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-http-credentials"/><a href="#api-request-new-context-option-http-credentials" class="list-anchor">#</a>
-    - `setUsername` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-username"/><a href="#api-request-new-context-option-username" class="list-anchor">#</a>
+    - `setUsername` [String]
       
       
-    - `setPassword` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-password"/><a href="#api-request-new-context-option-password" class="list-anchor">#</a>
+    - `setPassword` [String]
       
       
-    - `setOrigin` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origin"/><a href="#api-request-new-context-option-origin" class="list-anchor">#</a>
+    - `setOrigin` [String] *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `setSend` `enum HttpCredentialsSend { UNAUTHORIZED, ALWAYS }` *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-send"/><a href="#api-request-new-context-option-send" class="list-anchor">#</a>
+    - `setSend` `enum HttpCredentialsSend { UNAUTHORIZED, ALWAYS }` *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -88,16 +88,16 @@ APIRequest.newContext(options);
     
     Whether to ignore HTTPS errors when sending network requests. Defaults to `false`.
   - `setProxy` Proxy *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-proxy"/><a href="#api-request-new-context-option-proxy" class="list-anchor">#</a>
-    - `setServer` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-server"/><a href="#api-request-new-context-option-server" class="list-anchor">#</a>
+    - `setServer` [String]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `setBypass` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-bypass"/><a href="#api-request-new-context-option-bypass" class="list-anchor">#</a>
+    - `setBypass` [String] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `setUsername` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-username"/><a href="#api-request-new-context-option-username" class="list-anchor">#</a>
+    - `setUsername` [String] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `setPassword` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-password"/><a href="#api-request-new-context-option-password" class="list-anchor">#</a>
+    - `setPassword` [String] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     

--- a/java/docs/api/class-browser.mdx
+++ b/java/docs/api/class-browser.mdx
@@ -177,19 +177,19 @@ browser.close();
     
     Toggles bypassing page's Content-Security-Policy. Defaults to `false`.
   - `setClientCertificates` [List]&lt;ClientCertificates&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-client-certificates"/><a href="#browser-new-context-option-client-certificates" class="list-anchor">#</a>
-    - `setOrigin` [String] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origin"/><a href="#browser-new-context-option-origin" class="list-anchor">#</a>
+    - `setOrigin` [String]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `setCertPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-cert-path"/><a href="#browser-new-context-option-cert-path" class="list-anchor">#</a>
+    - `setCertPath` [Path] *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `setKeyPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-key-path"/><a href="#browser-new-context-option-key-path" class="list-anchor">#</a>
+    - `setKeyPath` [Path] *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `setPfxPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-pfx-path"/><a href="#browser-new-context-option-pfx-path" class="list-anchor">#</a>
+    - `setPfxPath` [Path] *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `setPassphrase` [String] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-passphrase"/><a href="#browser-new-context-option-passphrase" class="list-anchor">#</a>
+    - `setPassphrase` [String] *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -220,29 +220,29 @@ browser.close();
     
     Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [Page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'none'`.
   - `setGeolocation` Geolocation *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-geolocation"/><a href="#browser-new-context-option-geolocation" class="list-anchor">#</a>
-    - `setLatitude` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-latitude"/><a href="#browser-new-context-option-latitude" class="list-anchor">#</a>
+    - `setLatitude` [double]
       
       Latitude between -90 and 90.
-    - `setLongitude` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-longitude"/><a href="#browser-new-context-option-longitude" class="list-anchor">#</a>
+    - `setLongitude` [double]
       
       Longitude between -180 and 180.
-    - `setAccuracy` [double] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-accuracy"/><a href="#browser-new-context-option-accuracy" class="list-anchor">#</a>
+    - `setAccuracy` [double] *(optional)*
       
       Non-negative accuracy value. Defaults to `0`.
   - `setHasTouch` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-has-touch"/><a href="#browser-new-context-option-has-touch" class="list-anchor">#</a>
     
     Specifies if viewport supports touch events. Defaults to false. Learn more about [mobile emulation](../emulation.mdx#devices).
   - `setHttpCredentials` HttpCredentials *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-http-credentials"/><a href="#browser-new-context-option-http-credentials" class="list-anchor">#</a>
-    - `setUsername` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-username"/><a href="#browser-new-context-option-username" class="list-anchor">#</a>
+    - `setUsername` [String]
       
       
-    - `setPassword` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-password"/><a href="#browser-new-context-option-password" class="list-anchor">#</a>
+    - `setPassword` [String]
       
       
-    - `setOrigin` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origin"/><a href="#browser-new-context-option-origin" class="list-anchor">#</a>
+    - `setOrigin` [String] *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `setSend` `enum HttpCredentialsSend { UNAUTHORIZED, ALWAYS }` *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-send"/><a href="#browser-new-context-option-send" class="list-anchor">#</a>
+    - `setSend` `enum HttpCredentialsSend { UNAUTHORIZED, ALWAYS }` *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -266,16 +266,16 @@ browser.close();
     
     A list of permissions to grant to all pages in this context. See [BrowserContext.grantPermissions()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
   - `setProxy` Proxy *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-proxy"/><a href="#browser-new-context-option-proxy" class="list-anchor">#</a>
-    - `setServer` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-server"/><a href="#browser-new-context-option-server" class="list-anchor">#</a>
+    - `setServer` [String]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `setBypass` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-bypass"/><a href="#browser-new-context-option-bypass" class="list-anchor">#</a>
+    - `setBypass` [String] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `setUsername` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-username"/><a href="#browser-new-context-option-username" class="list-anchor">#</a>
+    - `setUsername` [String] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `setPassword` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-password"/><a href="#browser-new-context-option-password" class="list-anchor">#</a>
+    - `setPassword` [String] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
@@ -302,10 +302,10 @@ browser.close();
     
     Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure to call [BrowserContext.close()](/api/class-browsercontext.mdx#browser-context-close) for videos to be saved.
   - `setRecordVideoSize` RecordVideoSize *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-record-video-size"/><a href="#browser-new-context-option-record-video-size" class="list-anchor">#</a>
-    - `setWidth` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+    - `setWidth` [int]
       
       Video frame width.
-    - `setHeight` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+    - `setHeight` [int]
       
       Video frame height.
     
@@ -314,10 +314,10 @@ browser.close();
     
     Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [Page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'no-preference'`.
   - `setScreenSize` ScreenSize *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-screen"/><a href="#browser-new-context-option-screen" class="list-anchor">#</a>
-    - `setWidth` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+    - `setWidth` [int]
       
       page width in pixels.
-    - `setHeight` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+    - `setHeight` [int]
       
       page height in pixels.
     
@@ -343,10 +343,10 @@ browser.close();
     
     Specific user agent to use in this context.
   - `setViewportSize` [null] | ViewportSize *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-viewport"/><a href="#browser-new-context-option-viewport" class="list-anchor">#</a>
-    - `setWidth` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+    - `setWidth` [int]
       
       page width in pixels.
-    - `setHeight` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+    - `setHeight` [int]
       
       page height in pixels.
     
@@ -391,19 +391,19 @@ Browser.newPage(options);
     
     Toggles bypassing page's Content-Security-Policy. Defaults to `false`.
   - `setClientCertificates` [List]&lt;ClientCertificates&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-client-certificates"/><a href="#browser-new-page-option-client-certificates" class="list-anchor">#</a>
-    - `setOrigin` [String] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origin"/><a href="#browser-new-page-option-origin" class="list-anchor">#</a>
+    - `setOrigin` [String]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `setCertPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-cert-path"/><a href="#browser-new-page-option-cert-path" class="list-anchor">#</a>
+    - `setCertPath` [Path] *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `setKeyPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-key-path"/><a href="#browser-new-page-option-key-path" class="list-anchor">#</a>
+    - `setKeyPath` [Path] *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `setPfxPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-pfx-path"/><a href="#browser-new-page-option-pfx-path" class="list-anchor">#</a>
+    - `setPfxPath` [Path] *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `setPassphrase` [String] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-passphrase"/><a href="#browser-new-page-option-passphrase" class="list-anchor">#</a>
+    - `setPassphrase` [String] *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -434,29 +434,29 @@ Browser.newPage(options);
     
     Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [Page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'none'`.
   - `setGeolocation` Geolocation *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-geolocation"/><a href="#browser-new-page-option-geolocation" class="list-anchor">#</a>
-    - `setLatitude` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-latitude"/><a href="#browser-new-page-option-latitude" class="list-anchor">#</a>
+    - `setLatitude` [double]
       
       Latitude between -90 and 90.
-    - `setLongitude` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-longitude"/><a href="#browser-new-page-option-longitude" class="list-anchor">#</a>
+    - `setLongitude` [double]
       
       Longitude between -180 and 180.
-    - `setAccuracy` [double] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-accuracy"/><a href="#browser-new-page-option-accuracy" class="list-anchor">#</a>
+    - `setAccuracy` [double] *(optional)*
       
       Non-negative accuracy value. Defaults to `0`.
   - `setHasTouch` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-has-touch"/><a href="#browser-new-page-option-has-touch" class="list-anchor">#</a>
     
     Specifies if viewport supports touch events. Defaults to false. Learn more about [mobile emulation](../emulation.mdx#devices).
   - `setHttpCredentials` HttpCredentials *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-http-credentials"/><a href="#browser-new-page-option-http-credentials" class="list-anchor">#</a>
-    - `setUsername` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-username"/><a href="#browser-new-page-option-username" class="list-anchor">#</a>
+    - `setUsername` [String]
       
       
-    - `setPassword` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-password"/><a href="#browser-new-page-option-password" class="list-anchor">#</a>
+    - `setPassword` [String]
       
       
-    - `setOrigin` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origin"/><a href="#browser-new-page-option-origin" class="list-anchor">#</a>
+    - `setOrigin` [String] *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `setSend` `enum HttpCredentialsSend { UNAUTHORIZED, ALWAYS }` *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-send"/><a href="#browser-new-page-option-send" class="list-anchor">#</a>
+    - `setSend` `enum HttpCredentialsSend { UNAUTHORIZED, ALWAYS }` *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -480,16 +480,16 @@ Browser.newPage(options);
     
     A list of permissions to grant to all pages in this context. See [BrowserContext.grantPermissions()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
   - `setProxy` Proxy *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-proxy"/><a href="#browser-new-page-option-proxy" class="list-anchor">#</a>
-    - `setServer` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-server"/><a href="#browser-new-page-option-server" class="list-anchor">#</a>
+    - `setServer` [String]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `setBypass` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-bypass"/><a href="#browser-new-page-option-bypass" class="list-anchor">#</a>
+    - `setBypass` [String] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `setUsername` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-username"/><a href="#browser-new-page-option-username" class="list-anchor">#</a>
+    - `setUsername` [String] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `setPassword` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-password"/><a href="#browser-new-page-option-password" class="list-anchor">#</a>
+    - `setPassword` [String] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
@@ -516,10 +516,10 @@ Browser.newPage(options);
     
     Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure to call [BrowserContext.close()](/api/class-browsercontext.mdx#browser-context-close) for videos to be saved.
   - `setRecordVideoSize` RecordVideoSize *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-record-video-size"/><a href="#browser-new-page-option-record-video-size" class="list-anchor">#</a>
-    - `setWidth` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+    - `setWidth` [int]
       
       Video frame width.
-    - `setHeight` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+    - `setHeight` [int]
       
       Video frame height.
     
@@ -528,10 +528,10 @@ Browser.newPage(options);
     
     Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [Page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'no-preference'`.
   - `setScreenSize` ScreenSize *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-screen"/><a href="#browser-new-page-option-screen" class="list-anchor">#</a>
-    - `setWidth` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+    - `setWidth` [int]
       
       page width in pixels.
-    - `setHeight` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+    - `setHeight` [int]
       
       page height in pixels.
     
@@ -557,10 +557,10 @@ Browser.newPage(options);
     
     Specific user agent to use in this context.
   - `setViewportSize` [null] | ViewportSize *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-viewport"/><a href="#browser-new-page-option-viewport" class="list-anchor">#</a>
-    - `setWidth` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+    - `setWidth` [int]
       
       page width in pixels.
-    - `setHeight` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+    - `setHeight` [int]
       
       page height in pixels.
     

--- a/java/docs/api/class-browsercontext.mdx
+++ b/java/docs/api/class-browsercontext.mdx
@@ -42,31 +42,31 @@ browserContext.addCookies(Arrays.asList(cookieObject1, cookieObject2));
 
 **Arguments**
 - `cookies` [List]&lt;`Cookie`&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-cookies"/><a href="#browser-context-add-cookies-option-cookies" class="list-anchor">#</a>
-  - `setName` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-name"/><a href="#browser-context-add-cookies-option-name" class="list-anchor">#</a>
+  - `setName` [String]
     
     
-  - `setValue` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-value"/><a href="#browser-context-add-cookies-option-value" class="list-anchor">#</a>
+  - `setValue` [String]
     
     
-  - `setUrl` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-url"/><a href="#browser-context-add-cookies-option-url" class="list-anchor">#</a>
+  - `setUrl` [String] *(optional)*
     
     Either url or domain / path are required. Optional.
-  - `setDomain` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-domain"/><a href="#browser-context-add-cookies-option-domain" class="list-anchor">#</a>
+  - `setDomain` [String] *(optional)*
     
     For the cookie to apply to all subdomains as well, prefix domain with a dot, like this: ".example.com". Either url or domain / path are required. Optional.
-  - `setPath` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-path"/><a href="#browser-context-add-cookies-option-path" class="list-anchor">#</a>
+  - `setPath` [String] *(optional)*
     
     Either url or domain / path are required Optional.
-  - `setExpires` [double] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-expires"/><a href="#browser-context-add-cookies-option-expires" class="list-anchor">#</a>
+  - `setExpires` [double] *(optional)*
     
     Unix time in seconds. Optional.
-  - `setHttpOnly` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-http-only"/><a href="#browser-context-add-cookies-option-http-only" class="list-anchor">#</a>
+  - `setHttpOnly` [boolean] *(optional)*
     
     Optional.
-  - `setSecure` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-secure"/><a href="#browser-context-add-cookies-option-secure" class="list-anchor">#</a>
+  - `setSecure` [boolean] *(optional)*
     
     Optional.
-  - `setSameSite` `enum SameSiteAttribute { STRICT, LAX, NONE }` *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-same-site"/><a href="#browser-context-add-cookies-option-same-site" class="list-anchor">#</a>
+  - `setSameSite` `enum SameSiteAttribute { STRICT, LAX, NONE }` *(optional)*
     
     Optional.
 
@@ -736,13 +736,13 @@ Consider using [BrowserContext.grantPermissions()](/api/class-browsercontext.mdx
 
 **Arguments**
 - `geolocation` [null] | Geolocation<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-geolocation"/><a href="#browser-context-set-geolocation-option-geolocation" class="list-anchor">#</a>
-  - `setLatitude` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-latitude"/><a href="#browser-context-set-geolocation-option-latitude" class="list-anchor">#</a>
+  - `setLatitude` [double]
     
     Latitude between -90 and 90.
-  - `setLongitude` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-longitude"/><a href="#browser-context-set-geolocation-option-longitude" class="list-anchor">#</a>
+  - `setLongitude` [double]
     
     Longitude between -180 and 180.
-  - `setAccuracy` [double] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-accuracy"/><a href="#browser-context-set-geolocation-option-accuracy" class="list-anchor">#</a>
+  - `setAccuracy` [double] *(optional)*
     
     Non-negative accuracy value. Defaults to `0`.
 

--- a/java/docs/api/class-browsertype.mdx
+++ b/java/docs/api/class-browsertype.mdx
@@ -210,16 +210,16 @@ Browser browser = chromium.launch(new BrowserType.LaunchOptions()
     
     If `true`, Playwright does not pass its own configurations args and only uses the ones from `args`. Dangerous option; use with care.
   - `setProxy` Proxy *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-proxy"/><a href="#browser-type-launch-option-proxy" class="list-anchor">#</a>
-    - `setServer` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-server"/><a href="#browser-type-launch-option-server" class="list-anchor">#</a>
+    - `setServer` [String]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `setBypass` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-bypass"/><a href="#browser-type-launch-option-bypass" class="list-anchor">#</a>
+    - `setBypass` [String] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `setUsername` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-username"/><a href="#browser-type-launch-option-username" class="list-anchor">#</a>
+    - `setUsername` [String] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `setPassword` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-password"/><a href="#browser-type-launch-option-password" class="list-anchor">#</a>
+    - `setPassword` [String] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
@@ -285,19 +285,19 @@ BrowserType.launchPersistentContext(userDataDir, options);
     
     Enable Chromium sandboxing. Defaults to `false`.
   - `setClientCertificates` [List]&lt;ClientCertificates&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-client-certificates"/><a href="#browser-type-launch-persistent-context-option-client-certificates" class="list-anchor">#</a>
-    - `setOrigin` [String] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-origin"/><a href="#browser-type-launch-persistent-context-option-origin" class="list-anchor">#</a>
+    - `setOrigin` [String]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `setCertPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-cert-path"/><a href="#browser-type-launch-persistent-context-option-cert-path" class="list-anchor">#</a>
+    - `setCertPath` [Path] *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `setKeyPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-key-path"/><a href="#browser-type-launch-persistent-context-option-key-path" class="list-anchor">#</a>
+    - `setKeyPath` [Path] *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `setPfxPath` [Path] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-pfx-path"/><a href="#browser-type-launch-persistent-context-option-pfx-path" class="list-anchor">#</a>
+    - `setPfxPath` [Path] *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `setPassphrase` [String] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-passphrase"/><a href="#browser-type-launch-persistent-context-option-passphrase" class="list-anchor">#</a>
+    - `setPassphrase` [String] *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -348,13 +348,13 @@ BrowserType.launchPersistentContext(userDataDir, options);
     
     Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [Page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'none'`.
   - `setGeolocation` Geolocation *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-geolocation"/><a href="#browser-type-launch-persistent-context-option-geolocation" class="list-anchor">#</a>
-    - `setLatitude` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-latitude"/><a href="#browser-type-launch-persistent-context-option-latitude" class="list-anchor">#</a>
+    - `setLatitude` [double]
       
       Latitude between -90 and 90.
-    - `setLongitude` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-longitude"/><a href="#browser-type-launch-persistent-context-option-longitude" class="list-anchor">#</a>
+    - `setLongitude` [double]
       
       Longitude between -180 and 180.
-    - `setAccuracy` [double] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-accuracy"/><a href="#browser-type-launch-persistent-context-option-accuracy" class="list-anchor">#</a>
+    - `setAccuracy` [double] *(optional)*
       
       Non-negative accuracy value. Defaults to `0`.
   - `setHandleSIGHUP` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-handle-sighup"/><a href="#browser-type-launch-persistent-context-option-handle-sighup" class="list-anchor">#</a>
@@ -373,16 +373,16 @@ BrowserType.launchPersistentContext(userDataDir, options);
     
     Whether to run browser in headless mode. More details for [Chromium](https://developers.google.com/web/updates/2017/04/headless-chrome) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode). Defaults to `true` unless the `devtools` option is `true`.
   - `setHttpCredentials` HttpCredentials *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-http-credentials"/><a href="#browser-type-launch-persistent-context-option-http-credentials" class="list-anchor">#</a>
-    - `setUsername` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-username"/><a href="#browser-type-launch-persistent-context-option-username" class="list-anchor">#</a>
+    - `setUsername` [String]
       
       
-    - `setPassword` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-password"/><a href="#browser-type-launch-persistent-context-option-password" class="list-anchor">#</a>
+    - `setPassword` [String]
       
       
-    - `setOrigin` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-origin"/><a href="#browser-type-launch-persistent-context-option-origin" class="list-anchor">#</a>
+    - `setOrigin` [String] *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `setSend` `enum HttpCredentialsSend { UNAUTHORIZED, ALWAYS }` *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-send"/><a href="#browser-type-launch-persistent-context-option-send" class="list-anchor">#</a>
+    - `setSend` `enum HttpCredentialsSend { UNAUTHORIZED, ALWAYS }` *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -412,16 +412,16 @@ BrowserType.launchPersistentContext(userDataDir, options);
     
     A list of permissions to grant to all pages in this context. See [BrowserContext.grantPermissions()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
   - `setProxy` Proxy *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-proxy"/><a href="#browser-type-launch-persistent-context-option-proxy" class="list-anchor">#</a>
-    - `setServer` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-server"/><a href="#browser-type-launch-persistent-context-option-server" class="list-anchor">#</a>
+    - `setServer` [String]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `setBypass` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-bypass"/><a href="#browser-type-launch-persistent-context-option-bypass" class="list-anchor">#</a>
+    - `setBypass` [String] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `setUsername` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-username"/><a href="#browser-type-launch-persistent-context-option-username" class="list-anchor">#</a>
+    - `setUsername` [String] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `setPassword` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-password"/><a href="#browser-type-launch-persistent-context-option-password" class="list-anchor">#</a>
+    - `setPassword` [String] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
@@ -443,10 +443,10 @@ BrowserType.launchPersistentContext(userDataDir, options);
     
     Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure to call [BrowserContext.close()](/api/class-browsercontext.mdx#browser-context-close) for videos to be saved.
   - `setRecordVideoSize` RecordVideoSize *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-record-video-size"/><a href="#browser-type-launch-persistent-context-option-record-video-size" class="list-anchor">#</a>
-    - `setWidth` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+    - `setWidth` [int]
       
       Video frame width.
-    - `setHeight` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+    - `setHeight` [int]
       
       Video frame height.
     
@@ -455,10 +455,10 @@ BrowserType.launchPersistentContext(userDataDir, options);
     
     Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [Page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'no-preference'`.
   - `setScreenSize` ScreenSize *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-screen"/><a href="#browser-type-launch-persistent-context-option-screen" class="list-anchor">#</a>
-    - `setWidth` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+    - `setWidth` [int]
       
       page width in pixels.
-    - `setHeight` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+    - `setHeight` [int]
       
       page height in pixels.
     
@@ -487,10 +487,10 @@ BrowserType.launchPersistentContext(userDataDir, options);
     
     Specific user agent to use in this context.
   - `setViewportSize` [null] | ViewportSize *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-viewport"/><a href="#browser-type-launch-persistent-context-option-viewport" class="list-anchor">#</a>
-    - `setWidth` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+    - `setWidth` [int]
       
       page width in pixels.
-    - `setHeight` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+    - `setHeight` [int]
       
       page height in pixels.
     

--- a/java/docs/api/class-elementhandle.mdx
+++ b/java/docs/api/class-elementhandle.mdx
@@ -198,10 +198,10 @@ ElementHandle.check(options);
     
     This option has no effect.
   - `setPosition` Position *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-position"/><a href="#element-handle-check-option-position" class="list-anchor">#</a>
-    - `setX` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-x"/><a href="#element-handle-check-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-y"/><a href="#element-handle-check-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -271,10 +271,10 @@ ElementHandle.click(options);
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-position"/><a href="#element-handle-click-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-x"/><a href="#element-handle-click-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-y"/><a href="#element-handle-click-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -344,10 +344,10 @@ ElementHandle.dblclick(options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-position"/><a href="#element-handle-dblclick-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-x"/><a href="#element-handle-dblclick-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-y"/><a href="#element-handle-dblclick-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -653,10 +653,10 @@ ElementHandle.hover(options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-position"/><a href="#element-handle-hover-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-x"/><a href="#element-handle-hover-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-y"/><a href="#element-handle-hover-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1150,13 +1150,13 @@ handle.selectOption(new String[] {"red", "green", "blue"});
 
 **Arguments**
 - `values` [null] | [String] | [ElementHandle] | [String]&#91;&#93; | `SelectOption` | [ElementHandle]&#91;&#93; | `SelectOption`&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-values"/><a href="#element-handle-select-option-option-values" class="list-anchor">#</a>
-  - `setValue` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-value"/><a href="#element-handle-select-option-option-value" class="list-anchor">#</a>
+  - `setValue` [String] *(optional)*
     
     Matches by `option.value`. Optional.
-  - `setLabel` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-label"/><a href="#element-handle-select-option-option-label" class="list-anchor">#</a>
+  - `setLabel` [String] *(optional)*
     
     Matches by `option.label`. Optional.
-  - `setIndex` [int] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-index"/><a href="#element-handle-select-option-option-index" class="list-anchor">#</a>
+  - `setIndex` [int] *(optional)*
     
     Matches by the index. Optional.
   
@@ -1263,10 +1263,10 @@ ElementHandle.setChecked(checked, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-position"/><a href="#element-handle-set-checked-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-x"/><a href="#element-handle-set-checked-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-y"/><a href="#element-handle-set-checked-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1306,13 +1306,13 @@ ElementHandle.setInputFiles(files, options);
 
 **Arguments**
 - `files` [Path] | [Path]&#91;&#93; | `FilePayload` | `FilePayload`&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-files"/><a href="#element-handle-set-input-files-option-files" class="list-anchor">#</a>
-  - `setName` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-name"/><a href="#element-handle-set-input-files-option-name" class="list-anchor">#</a>
+  - `setName` [String]
     
     File name
-  - `setMimeType` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-mime-type"/><a href="#element-handle-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `setMimeType` [String]
     
     File type
-  - `setBuffer` [byte&#91;&#93;]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-buffer"/><a href="#element-handle-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `setBuffer` [byte&#91;&#93;]
     
     File content
 - `options` `ElementHandle.SetInputFilesOptions` *(optional)*
@@ -1381,10 +1381,10 @@ ElementHandle.tap(options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-position"/><a href="#element-handle-tap-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-x"/><a href="#element-handle-tap-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-y"/><a href="#element-handle-tap-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1509,10 +1509,10 @@ ElementHandle.uncheck(options);
     
     This option has no effect.
   - `setPosition` Position *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-position"/><a href="#element-handle-uncheck-option-position" class="list-anchor">#</a>
-    - `setX` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-x"/><a href="#element-handle-uncheck-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-y"/><a href="#element-handle-uncheck-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/java/docs/api/class-filechooser.mdx
+++ b/java/docs/api/class-filechooser.mdx
@@ -85,13 +85,13 @@ FileChooser.setFiles(files, options);
 
 **Arguments**
 - `files` [Path] | [Path]&#91;&#93; | `FilePayload` | `FilePayload`&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-files"/><a href="#file-chooser-set-files-option-files" class="list-anchor">#</a>
-  - `setName` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-name"/><a href="#file-chooser-set-files-option-name" class="list-anchor">#</a>
+  - `setName` [String]
     
     File name
-  - `setMimeType` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-mime-type"/><a href="#file-chooser-set-files-option-mime-type" class="list-anchor">#</a>
+  - `setMimeType` [String]
     
     File type
-  - `setBuffer` [byte&#91;&#93;]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-buffer"/><a href="#file-chooser-set-files-option-buffer" class="list-anchor">#</a>
+  - `setBuffer` [byte&#91;&#93;]
     
     File content
 - `options` `FileChooser.SetFilesOptions` *(optional)*

--- a/java/docs/api/class-formdata.mdx
+++ b/java/docs/api/class-formdata.mdx
@@ -56,13 +56,13 @@ FormData.append(name, value);
   
   Field name.
 - `value` [String] | [boolean] | [int] | [Path] | Value<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-append-option-value"/><a href="#form-data-append-option-value" class="list-anchor">#</a>
-  - `setName` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-append-option-name"/><a href="#form-data-append-option-name" class="list-anchor">#</a>
+  - `setName` [String]
     
     File name
-  - `setMimeType` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-append-option-mime-type"/><a href="#form-data-append-option-mime-type" class="list-anchor">#</a>
+  - `setMimeType` [String]
     
     File type
-  - `setBuffer` [byte&#91;&#93;]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-append-option-buffer"/><a href="#form-data-append-option-buffer" class="list-anchor">#</a>
+  - `setBuffer` [byte&#91;&#93;]
     
     File content
   
@@ -121,13 +121,13 @@ FormData.set(name, value);
   
   Field name.
 - `value` [String] | [boolean] | [int] | [Path] | Value<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-set-option-value"/><a href="#form-data-set-option-value" class="list-anchor">#</a>
-  - `setName` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-set-option-name"/><a href="#form-data-set-option-name" class="list-anchor">#</a>
+  - `setName` [String]
     
     File name
-  - `setMimeType` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-set-option-mime-type"/><a href="#form-data-set-option-mime-type" class="list-anchor">#</a>
+  - `setMimeType` [String]
     
     File type
-  - `setBuffer` [byte&#91;&#93;]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="form-data-set-option-buffer"/><a href="#form-data-set-option-buffer" class="list-anchor">#</a>
+  - `setBuffer` [byte&#91;&#93;]
     
     File content
   

--- a/java/docs/api/class-frame.mdx
+++ b/java/docs/api/class-frame.mdx
@@ -174,10 +174,10 @@ Frame.dragAndDrop(source, target, options);
     
     This option has no effect.
   - `setSourcePosition` SourcePosition *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-source-position"/><a href="#frame-drag-and-drop-option-source-position" class="list-anchor">#</a>
-    - `setX` [double] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-x"/><a href="#frame-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-y"/><a href="#frame-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -185,10 +185,10 @@ Frame.dragAndDrop(source, target, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTargetPosition` TargetPosition *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-target-position"/><a href="#frame-drag-and-drop-option-target-position" class="list-anchor">#</a>
-    - `setX` [double] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-x"/><a href="#frame-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-y"/><a href="#frame-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -1111,10 +1111,10 @@ Frame.check(selector, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-position"/><a href="#frame-check-option-position" class="list-anchor">#</a>
-    - `setX` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-x"/><a href="#frame-check-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-y"/><a href="#frame-check-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1189,10 +1189,10 @@ Frame.click(selector, options);
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-position"/><a href="#frame-click-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-x"/><a href="#frame-click-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-y"/><a href="#frame-click-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1267,10 +1267,10 @@ Frame.dblclick(selector, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-position"/><a href="#frame-dblclick-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-x"/><a href="#frame-dblclick-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-y"/><a href="#frame-dblclick-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1617,10 +1617,10 @@ Frame.hover(selector, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-position"/><a href="#frame-hover-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-x"/><a href="#frame-hover-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-y"/><a href="#frame-hover-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2114,13 +2114,13 @@ frame.selectOption("select#colors", new String[] {"red", "green", "blue"});
   
   A selector to query for.
 - `values` [null] | [String] | [ElementHandle] | [String]&#91;&#93; | `SelectOption` | [ElementHandle]&#91;&#93; | `SelectOption`&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-values"/><a href="#frame-select-option-option-values" class="list-anchor">#</a>
-  - `setValue` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-value"/><a href="#frame-select-option-option-value" class="list-anchor">#</a>
+  - `setValue` [String] *(optional)*
     
     Matches by `option.value`. Optional.
-  - `setLabel` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-label"/><a href="#frame-select-option-option-label" class="list-anchor">#</a>
+  - `setLabel` [String] *(optional)*
     
     Matches by `option.label`. Optional.
-  - `setIndex` [int] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-index"/><a href="#frame-select-option-option-index" class="list-anchor">#</a>
+  - `setIndex` [int] *(optional)*
     
     Matches by the index. Optional.
   
@@ -2198,10 +2198,10 @@ Frame.setChecked(selector, checked, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-position"/><a href="#frame-set-checked-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-x"/><a href="#frame-set-checked-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-y"/><a href="#frame-set-checked-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2247,13 +2247,13 @@ Frame.setInputFiles(selector, files, options);
   
   A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
 - `files` [Path] | [Path]&#91;&#93; | `FilePayload` | `FilePayload`&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-files"/><a href="#frame-set-input-files-option-files" class="list-anchor">#</a>
-  - `setName` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-name"/><a href="#frame-set-input-files-option-name" class="list-anchor">#</a>
+  - `setName` [String]
     
     File name
-  - `setMimeType` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-mime-type"/><a href="#frame-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `setMimeType` [String]
     
     File type
-  - `setBuffer` [byte&#91;&#93;]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-buffer"/><a href="#frame-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `setBuffer` [byte&#91;&#93;]
     
     File content
 - `options` `Frame.SetInputFilesOptions` *(optional)*
@@ -2327,10 +2327,10 @@ Frame.tap(selector, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-position"/><a href="#frame-tap-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-x"/><a href="#frame-tap-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-y"/><a href="#frame-tap-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2479,10 +2479,10 @@ Frame.uncheck(selector, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-position"/><a href="#frame-uncheck-option-position" class="list-anchor">#</a>
-    - `setX` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-x"/><a href="#frame-uncheck-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-y"/><a href="#frame-uncheck-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/java/docs/api/class-locator.mdx
+++ b/java/docs/api/class-locator.mdx
@@ -198,10 +198,10 @@ page.getByRole(AriaRole.CHECKBOX).check();
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-position"/><a href="#locator-check-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-x"/><a href="#locator-check-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-y"/><a href="#locator-check-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -319,10 +319,10 @@ page.locator("canvas").click(new Locator.ClickOptions()
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-position"/><a href="#locator-click-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-x"/><a href="#locator-click-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-y"/><a href="#locator-click-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -431,10 +431,10 @@ Locator.dblclick(options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-position"/><a href="#locator-dblclick-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-x"/><a href="#locator-dblclick-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-y"/><a href="#locator-dblclick-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -557,18 +557,18 @@ source.dragTo(target, new Locator.DragToOptions()
     
     This option has no effect.
   - `setSourcePosition` SourcePosition *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-source-position"/><a href="#locator-drag-to-option-source-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-x"/><a href="#locator-drag-to-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-y"/><a href="#locator-drag-to-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
   - `setTargetPosition` TargetPosition *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-target-position"/><a href="#locator-drag-to-option-target-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-x"/><a href="#locator-drag-to-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-y"/><a href="#locator-drag-to-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -1258,10 +1258,10 @@ page.getByRole(AriaRole.LINK).hover();
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-position"/><a href="#locator-hover-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-x"/><a href="#locator-hover-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-y"/><a href="#locator-hover-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1899,13 +1899,13 @@ element.selectOption(new String[] {"red", "green", "blue"});
 
 **Arguments**
 - `values` [null] | [String] | [ElementHandle] | [String]&#91;&#93; | `SelectOption` | [ElementHandle]&#91;&#93; | `SelectOption`&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-values"/><a href="#locator-select-option-option-values" class="list-anchor">#</a>
-  - `setValue` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-value"/><a href="#locator-select-option-option-value" class="list-anchor">#</a>
+  - `setValue` [String] *(optional)*
     
     Matches by `option.value`. Optional.
-  - `setLabel` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-label"/><a href="#locator-select-option-option-label" class="list-anchor">#</a>
+  - `setLabel` [String] *(optional)*
     
     Matches by `option.label`. Optional.
-  - `setIndex` [int] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-index"/><a href="#locator-select-option-option-index" class="list-anchor">#</a>
+  - `setIndex` [int] *(optional)*
     
     Matches by the index. Optional.
   
@@ -1999,10 +1999,10 @@ page.getByRole(AriaRole.CHECKBOX).setChecked(true);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-position"/><a href="#locator-set-checked-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-x"/><a href="#locator-set-checked-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-y"/><a href="#locator-set-checked-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2058,13 +2058,13 @@ page.getByLabel("Upload file").setInputFiles(new FilePayload(
 
 **Arguments**
 - `files` [Path] | [Path]&#91;&#93; | `FilePayload` | `FilePayload`&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-files"/><a href="#locator-set-input-files-option-files" class="list-anchor">#</a>
-  - `setName` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-name"/><a href="#locator-set-input-files-option-name" class="list-anchor">#</a>
+  - `setName` [String]
     
     File name
-  - `setMimeType` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-mime-type"/><a href="#locator-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `setMimeType` [String]
     
     File type
-  - `setBuffer` [byte&#91;&#93;]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-buffer"/><a href="#locator-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `setBuffer` [byte&#91;&#93;]
     
     File content
 - `options` `Locator.SetInputFilesOptions` *(optional)*
@@ -2121,10 +2121,10 @@ Locator.tap(options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-position"/><a href="#locator-tap-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-x"/><a href="#locator-tap-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-y"/><a href="#locator-tap-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2209,10 +2209,10 @@ page.getByRole(AriaRole.CHECKBOX).uncheck();
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-position"/><a href="#locator-uncheck-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-x"/><a href="#locator-uncheck-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-y"/><a href="#locator-uncheck-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/java/docs/api/class-page.mdx
+++ b/java/docs/api/class-page.mdx
@@ -361,10 +361,10 @@ page.dragAndDrop("#source", '#target', new Page.DragAndDropOptions()
     
     This option has no effect.
   - `setSourcePosition` SourcePosition *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-source-position"/><a href="#page-drag-and-drop-option-source-position" class="list-anchor">#</a>
-    - `setX` [double] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-x"/><a href="#page-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-y"/><a href="#page-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -372,10 +372,10 @@ page.dragAndDrop("#source", '#target', new Page.DragAndDropOptions()
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `setTargetPosition` TargetPosition *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-target-position"/><a href="#page-drag-and-drop-option-target-position" class="list-anchor">#</a>
-    - `setX` [double] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-x"/><a href="#page-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-y"/><a href="#page-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -1457,16 +1457,16 @@ The `format` options are:
     
     Paper orientation. Defaults to `false`.
   - `setMargin` Margin *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-margin"/><a href="#page-pdf-option-margin" class="list-anchor">#</a>
-    - `setTop` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-top"/><a href="#page-pdf-option-top" class="list-anchor">#</a>
+    - `setTop` [String] *(optional)*
       
       Top margin, accepts values labeled with units. Defaults to `0`.
-    - `setRight` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-right"/><a href="#page-pdf-option-right" class="list-anchor">#</a>
+    - `setRight` [String] *(optional)*
       
       Right margin, accepts values labeled with units. Defaults to `0`.
-    - `setBottom` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-bottom"/><a href="#page-pdf-option-bottom" class="list-anchor">#</a>
+    - `setBottom` [String] *(optional)*
       
       Bottom margin, accepts values labeled with units. Defaults to `0`.
-    - `setLeft` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-left"/><a href="#page-pdf-option-left" class="list-anchor">#</a>
+    - `setLeft` [String] *(optional)*
       
       Left margin, accepts values labeled with units. Defaults to `0`.
     
@@ -1720,16 +1720,16 @@ Page.screenshot(options);
     
     When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be changed.  Defaults to `"hide"`.
   - `setClip` Clip *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-clip"/><a href="#page-screenshot-option-clip" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-x"/><a href="#page-screenshot-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       x-coordinate of top-left corner of clip area
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-y"/><a href="#page-screenshot-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       y-coordinate of top-left corner of clip area
-    - `setWidth` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-width"/><a href="#page-screenshot-option-width" class="list-anchor">#</a>
+    - `setWidth` [double]
       
       width of clipping area
-    - `setHeight` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-height"/><a href="#page-screenshot-option-height" class="list-anchor">#</a>
+    - `setHeight` [double]
       
       height of clipping area
     
@@ -3040,10 +3040,10 @@ Page.check(selector, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-position"/><a href="#page-check-option-position" class="list-anchor">#</a>
-    - `setX` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-x"/><a href="#page-check-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-y"/><a href="#page-check-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3118,10 +3118,10 @@ Page.click(selector, options);
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-position"/><a href="#page-click-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-x"/><a href="#page-click-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-y"/><a href="#page-click-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3196,10 +3196,10 @@ Page.dblclick(selector, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-position"/><a href="#page-dblclick-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-x"/><a href="#page-dblclick-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-y"/><a href="#page-dblclick-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3542,10 +3542,10 @@ Page.hover(selector, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-position"/><a href="#page-hover-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-x"/><a href="#page-hover-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-y"/><a href="#page-hover-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -4072,13 +4072,13 @@ page.selectOption("select#colors", new String[] {"red", "green", "blue"});
   
   A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
 - `values` [null] | [String] | [ElementHandle] | [String]&#91;&#93; | `SelectOption` | [ElementHandle]&#91;&#93; | `SelectOption`&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-values"/><a href="#page-select-option-option-values" class="list-anchor">#</a>
-  - `setValue` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-value"/><a href="#page-select-option-option-value" class="list-anchor">#</a>
+  - `setValue` [String] *(optional)*
     
     Matches by `option.value`. Optional.
-  - `setLabel` [String] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-label"/><a href="#page-select-option-option-label" class="list-anchor">#</a>
+  - `setLabel` [String] *(optional)*
     
     Matches by `option.label`. Optional.
-  - `setIndex` [int] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-index"/><a href="#page-select-option-option-index" class="list-anchor">#</a>
+  - `setIndex` [int] *(optional)*
     
     Matches by the index. Optional.
   
@@ -4156,10 +4156,10 @@ Page.setChecked(selector, checked, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-position"/><a href="#page-set-checked-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-x"/><a href="#page-set-checked-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-y"/><a href="#page-set-checked-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -4205,13 +4205,13 @@ Page.setInputFiles(selector, files, options);
   
   A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
 - `files` [Path] | [Path]&#91;&#93; | `FilePayload` | `FilePayload`&#91;&#93;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-files"/><a href="#page-set-input-files-option-files" class="list-anchor">#</a>
-  - `setName` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-name"/><a href="#page-set-input-files-option-name" class="list-anchor">#</a>
+  - `setName` [String]
     
     File name
-  - `setMimeType` [String]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-mime-type"/><a href="#page-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `setMimeType` [String]
     
     File type
-  - `setBuffer` [byte&#91;&#93;]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-buffer"/><a href="#page-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `setBuffer` [byte&#91;&#93;]
     
     File content
 - `options` `Page.SetInputFilesOptions` *(optional)*
@@ -4285,10 +4285,10 @@ Page.tap(selector, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-position"/><a href="#page-tap-option-position" class="list-anchor">#</a>
-    - `setX` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-x"/><a href="#page-tap-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-y"/><a href="#page-tap-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -4437,10 +4437,10 @@ Page.uncheck(selector, options);
     
     This option has no effect.
   - `setPosition` Position *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-position"/><a href="#page-uncheck-option-position" class="list-anchor">#</a>
-    - `setX` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-x"/><a href="#page-uncheck-option-x" class="list-anchor">#</a>
+    - `setX` [double]
       
       
-    - `setY` [double] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-y"/><a href="#page-uncheck-option-y" class="list-anchor">#</a>
+    - `setY` [double]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/nodejs/docs/api/class-androiddevice.mdx
+++ b/nodejs/docs/api/class-androiddevice.mdx
@@ -49,10 +49,10 @@ await androidDevice.drag(selector, dest, options);
   
   Selector to drag.
 - `dest` [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-drag-option-dest"/><a href="#android-device-drag-option-dest" class="list-anchor">#</a>
-  - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-drag-option-x"/><a href="#android-device-drag-option-x" class="list-anchor">#</a>
+  - `x` [number]
     
     
-  - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-drag-option-y"/><a href="#android-device-drag-option-y" class="list-anchor">#</a>
+  - `y` [number]
     
     
   Point to drag to.
@@ -231,29 +231,29 @@ await androidDevice.launchBrowser(options);
     
     Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'none'`.
   - `geolocation` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-geolocation"/><a href="#android-device-launch-browser-option-geolocation" class="list-anchor">#</a>
-    - `latitude` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-latitude"/><a href="#android-device-launch-browser-option-latitude" class="list-anchor">#</a>
+    - `latitude` [number]
       
       Latitude between -90 and 90.
-    - `longitude` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-longitude"/><a href="#android-device-launch-browser-option-longitude" class="list-anchor">#</a>
+    - `longitude` [number]
       
       Longitude between -180 and 180.
-    - `accuracy` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-accuracy"/><a href="#android-device-launch-browser-option-accuracy" class="list-anchor">#</a>
+    - `accuracy` [number] *(optional)*
       
       Non-negative accuracy value. Defaults to `0`.
   - `hasTouch` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-has-touch"/><a href="#android-device-launch-browser-option-has-touch" class="list-anchor">#</a>
     
     Specifies if viewport supports touch events. Defaults to false. Learn more about [mobile emulation](../emulation.mdx#devices).
   - `httpCredentials` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-http-credentials"/><a href="#android-device-launch-browser-option-http-credentials" class="list-anchor">#</a>
-    - `username` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-username"/><a href="#android-device-launch-browser-option-username" class="list-anchor">#</a>
+    - `username` [string]
       
       
-    - `password` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-password"/><a href="#android-device-launch-browser-option-password" class="list-anchor">#</a>
+    - `password` [string]
       
       
-    - `origin` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-origin"/><a href="#android-device-launch-browser-option-origin" class="list-anchor">#</a>
+    - `origin` [string] *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `send` "unauthorized" | "always" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-send"/><a href="#android-device-launch-browser-option-send" class="list-anchor">#</a>
+    - `send` "unauthorized" | "always" *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -280,47 +280,47 @@ await androidDevice.launchBrowser(options);
     
     A list of permissions to grant to all pages in this context. See [browserContext.grantPermissions()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
   - `proxy` [Object] *(optional)* <font size="2">Added in: v1.29</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-proxy"/><a href="#android-device-launch-browser-option-proxy" class="list-anchor">#</a>
-    - `server` [string] <font size="2">Added in: v1.29</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-server"/><a href="#android-device-launch-browser-option-server" class="list-anchor">#</a>
+    - `server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `bypass` [string] *(optional)* <font size="2">Added in: v1.29</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-bypass"/><a href="#android-device-launch-browser-option-bypass" class="list-anchor">#</a>
+    - `bypass` [string] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `username` [string] *(optional)* <font size="2">Added in: v1.29</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-username"/><a href="#android-device-launch-browser-option-username" class="list-anchor">#</a>
+    - `username` [string] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `password` [string] *(optional)* <font size="2">Added in: v1.29</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-password"/><a href="#android-device-launch-browser-option-password" class="list-anchor">#</a>
+    - `password` [string] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
     Network proxy settings.
   - `recordHar` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-record-har"/><a href="#android-device-launch-browser-option-record-har" class="list-anchor">#</a>
-    - `omitContent` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-omit-content"/><a href="#android-device-launch-browser-option-omit-content" class="list-anchor">#</a>
+    - `omitContent` [boolean] *(optional)*
       
       Optional setting to control whether to omit request content from the HAR. Defaults to `false`. Deprecated, use `content` policy instead.
-    - `content` "omit" | "embed" | "attach" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-content"/><a href="#android-device-launch-browser-option-content" class="list-anchor">#</a>
+    - `content` "omit" | "embed" | "attach" *(optional)*
       
       Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output files and to `embed` for all other file extensions.
-    - `path` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-path"/><a href="#android-device-launch-browser-option-path" class="list-anchor">#</a>
+    - `path` [string]
       
       Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by default.
-    - `mode` "full" | "minimal" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-mode"/><a href="#android-device-launch-browser-option-mode" class="list-anchor">#</a>
+    - `mode` "full" | "minimal" *(optional)*
       
       When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
-    - `urlFilter` [string] | [RegExp] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-url-filter"/><a href="#android-device-launch-browser-option-url-filter" class="list-anchor">#</a>
+    - `urlFilter` [string] | [RegExp] *(optional)*
       
       A glob or regex pattern to filter requests that are stored in the HAR. When a `baseURL` via the context options was provided and the passed URL is a path, it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor. Defaults to none.
     
     Enables [HAR](http://www.softwareishard.com/blog/har-12-spec) recording for all pages into `recordHar.path` file. If not specified, the HAR is not recorded. Make sure to await [browserContext.close()](/api/class-browsercontext.mdx#browser-context-close) for the HAR to be saved.
   - `recordVideo` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-record-video"/><a href="#android-device-launch-browser-option-record-video" class="list-anchor">#</a>
-    - `dir` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-dir"/><a href="#android-device-launch-browser-option-dir" class="list-anchor">#</a>
+    - `dir` [string]
       
       Path to the directory to put videos into.
-    - `size` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-size"/><a href="#android-device-launch-browser-option-size" class="list-anchor">#</a>
-      - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-width"/><a href="#android-device-launch-browser-option-width" class="list-anchor">#</a>
+    - `size` [Object] *(optional)*
+      - `width` [number]
         
         Video frame width.
-      - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-height"/><a href="#android-device-launch-browser-option-height" class="list-anchor">#</a>
+      - `height` [number]
         
         Video frame height.
       
@@ -331,10 +331,10 @@ await androidDevice.launchBrowser(options);
     
     Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'no-preference'`.
   - `screen` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-screen"/><a href="#android-device-launch-browser-option-screen" class="list-anchor">#</a>
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-width"/><a href="#android-device-launch-browser-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       page width in pixels.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-height"/><a href="#android-device-launch-browser-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       page height in pixels.
     
@@ -359,10 +359,10 @@ await androidDevice.launchBrowser(options);
     Use `recordVideo` instead.
     :::
     
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-width"/><a href="#android-device-launch-browser-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       Video frame width.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-height"/><a href="#android-device-launch-browser-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-videos-path"/><a href="#android-device-launch-browser-option-videos-path" class="list-anchor">#</a>
@@ -372,10 +372,10 @@ await androidDevice.launchBrowser(options);
     :::
     
   - `viewport` [null] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-viewport"/><a href="#android-device-launch-browser-option-viewport" class="list-anchor">#</a>
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-width"/><a href="#android-device-launch-browser-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       page width in pixels.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-launch-browser-option-height"/><a href="#android-device-launch-browser-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       page height in pixels.
     
@@ -814,10 +814,10 @@ await androidDevice.waitForEvent(event, optionsOrPredicate);
   
   Event name, same one typically passed into `*.on(event)`.
 - `optionsOrPredicate` [function] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-wait-for-event-option-options-or-predicate"/><a href="#android-device-wait-for-event-option-options-or-predicate" class="list-anchor">#</a>
-  - `predicate` [function]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-wait-for-event-option-predicate"/><a href="#android-device-wait-for-event-option-predicate" class="list-anchor">#</a>
+  - `predicate` [function]
     
     receives the event data and resolves to truthy value when the waiting should resolve.
-  - `timeout` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-wait-for-event-option-timeout"/><a href="#android-device-wait-for-event-option-timeout" class="list-anchor">#</a>
+  - `timeout` [number] *(optional)*
     
     maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [androidDevice.setDefaultTimeout()](/api/class-androiddevice.mdx#android-device-set-default-timeout).
   
@@ -843,10 +843,10 @@ await androidDevice.webView(selector, options);
 
 **Arguments**
 - `selector` [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-web-view-option-selector"/><a href="#android-device-web-view-option-selector" class="list-anchor">#</a>
-  - `pkg` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-web-view-option-pkg"/><a href="#android-device-web-view-option-pkg" class="list-anchor">#</a>
+  - `pkg` [string] *(optional)*
     
     Optional Package identifier.
-  - `socketName` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-device-web-view-option-socket-name"/><a href="#android-device-web-view-option-socket-name" class="list-anchor">#</a>
+  - `socketName` [string] *(optional)*
     
     Optional webview socket name.
 - `options` [Object] *(optional)*

--- a/nodejs/docs/api/class-androidinput.mdx
+++ b/nodejs/docs/api/class-androidinput.mdx
@@ -26,18 +26,18 @@ await androidInput.drag(from, to, steps);
 
 **Arguments**
 - `from` [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-drag-option-from"/><a href="#android-input-drag-option-from" class="list-anchor">#</a>
-  - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-drag-option-x"/><a href="#android-input-drag-option-x" class="list-anchor">#</a>
+  - `x` [number]
     
     
-  - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-drag-option-y"/><a href="#android-input-drag-option-y" class="list-anchor">#</a>
+  - `y` [number]
     
     
   The start point of the drag.
 - `to` [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-drag-option-to"/><a href="#android-input-drag-option-to" class="list-anchor">#</a>
-  - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-drag-option-x"/><a href="#android-input-drag-option-x" class="list-anchor">#</a>
+  - `x` [number]
     
     
-  - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-drag-option-y"/><a href="#android-input-drag-option-y" class="list-anchor">#</a>
+  - `y` [number]
     
     
   The end point of the drag.
@@ -86,18 +86,18 @@ await androidInput.swipe(from, segments, steps);
 
 **Arguments**
 - `from` [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-swipe-option-from"/><a href="#android-input-swipe-option-from" class="list-anchor">#</a>
-  - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-swipe-option-x"/><a href="#android-input-swipe-option-x" class="list-anchor">#</a>
+  - `x` [number]
     
     
-  - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-swipe-option-y"/><a href="#android-input-swipe-option-y" class="list-anchor">#</a>
+  - `y` [number]
     
     
   The point to start swiping from.
 - `segments` [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-swipe-option-segments"/><a href="#android-input-swipe-option-segments" class="list-anchor">#</a>
-  - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-swipe-option-x"/><a href="#android-input-swipe-option-x" class="list-anchor">#</a>
+  - `x` [number]
     
     
-  - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-swipe-option-y"/><a href="#android-input-swipe-option-y" class="list-anchor">#</a>
+  - `y` [number]
     
     
   Points following the `from` point in the swipe gesture.
@@ -124,10 +124,10 @@ await androidInput.tap(point);
 
 **Arguments**
 - `point` [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-tap-option-point"/><a href="#android-input-tap-option-point" class="list-anchor">#</a>
-  - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-tap-option-x"/><a href="#android-input-tap-option-x" class="list-anchor">#</a>
+  - `x` [number]
     
     
-  - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="android-input-tap-option-y"/><a href="#android-input-tap-option-y" class="list-anchor">#</a>
+  - `y` [number]
     
     
   The point to tap at.

--- a/nodejs/docs/api/class-apirequest.mdx
+++ b/nodejs/docs/api/class-apirequest.mdx
@@ -36,19 +36,19 @@ await apiRequest.newContext(options);
     * baseURL: `http://localhost:3000/foo/` and sending request to `./bar.html` results in `http://localhost:3000/foo/bar.html`
     * baseURL: `http://localhost:3000/foo` (without trailing slash) and navigating to `./bar.html` results in `http://localhost:3000/bar.html`
   - `clientCertificates` [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-client-certificates"/><a href="#api-request-new-context-option-client-certificates" class="list-anchor">#</a>
-    - `origin` [string] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origin"/><a href="#api-request-new-context-option-origin" class="list-anchor">#</a>
+    - `origin` [string]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `certPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-cert-path"/><a href="#api-request-new-context-option-cert-path" class="list-anchor">#</a>
+    - `certPath` [string] *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `keyPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-key-path"/><a href="#api-request-new-context-option-key-path" class="list-anchor">#</a>
+    - `keyPath` [string] *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `pfxPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-pfx-path"/><a href="#api-request-new-context-option-pfx-path" class="list-anchor">#</a>
+    - `pfxPath` [string] *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `passphrase` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-passphrase"/><a href="#api-request-new-context-option-passphrase" class="list-anchor">#</a>
+    - `passphrase` [string] *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -70,16 +70,16 @@ await apiRequest.newContext(options);
     
     An object containing additional HTTP headers to be sent with every request. Defaults to none.
   - `httpCredentials` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-http-credentials"/><a href="#api-request-new-context-option-http-credentials" class="list-anchor">#</a>
-    - `username` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-username"/><a href="#api-request-new-context-option-username" class="list-anchor">#</a>
+    - `username` [string]
       
       
-    - `password` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-password"/><a href="#api-request-new-context-option-password" class="list-anchor">#</a>
+    - `password` [string]
       
       
-    - `origin` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origin"/><a href="#api-request-new-context-option-origin" class="list-anchor">#</a>
+    - `origin` [string] *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `send` "unauthorized" | "always" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-send"/><a href="#api-request-new-context-option-send" class="list-anchor">#</a>
+    - `send` "unauthorized" | "always" *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -88,56 +88,56 @@ await apiRequest.newContext(options);
     
     Whether to ignore HTTPS errors when sending network requests. Defaults to `false`.
   - `proxy` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-proxy"/><a href="#api-request-new-context-option-proxy" class="list-anchor">#</a>
-    - `server` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-server"/><a href="#api-request-new-context-option-server" class="list-anchor">#</a>
+    - `server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `bypass` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-bypass"/><a href="#api-request-new-context-option-bypass" class="list-anchor">#</a>
+    - `bypass` [string] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `username` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-username"/><a href="#api-request-new-context-option-username" class="list-anchor">#</a>
+    - `username` [string] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `password` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-password"/><a href="#api-request-new-context-option-password" class="list-anchor">#</a>
+    - `password` [string] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
     Network proxy settings.
   - `storageState` [string] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-storage-state"/><a href="#api-request-new-context-option-storage-state" class="list-anchor">#</a>
-    - `cookies` [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-cookies"/><a href="#api-request-new-context-option-cookies" class="list-anchor">#</a>
-      - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-name"/><a href="#api-request-new-context-option-name" class="list-anchor">#</a>
+    - `cookies` [Array]&lt;[Object]&gt;
+      - `name` [string]
         
         
-      - `value` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-value"/><a href="#api-request-new-context-option-value" class="list-anchor">#</a>
+      - `value` [string]
         
         
-      - `domain` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-domain"/><a href="#api-request-new-context-option-domain" class="list-anchor">#</a>
+      - `domain` [string]
         
         
-      - `path` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-path"/><a href="#api-request-new-context-option-path" class="list-anchor">#</a>
+      - `path` [string]
         
         
-      - `expires` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-expires"/><a href="#api-request-new-context-option-expires" class="list-anchor">#</a>
+      - `expires` [number]
         
         Unix time in seconds.
-      - `httpOnly` [boolean]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-http-only"/><a href="#api-request-new-context-option-http-only" class="list-anchor">#</a>
+      - `httpOnly` [boolean]
         
         
-      - `secure` [boolean]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-secure"/><a href="#api-request-new-context-option-secure" class="list-anchor">#</a>
+      - `secure` [boolean]
         
         
-      - `sameSite` "Strict" | "Lax" | "None"<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-same-site"/><a href="#api-request-new-context-option-same-site" class="list-anchor">#</a>
+      - `sameSite` "Strict" | "Lax" | "None"
         
         
       
-    - `origins` [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origins"/><a href="#api-request-new-context-option-origins" class="list-anchor">#</a>
-      - `origin` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origin"/><a href="#api-request-new-context-option-origin" class="list-anchor">#</a>
+    - `origins` [Array]&lt;[Object]&gt;
+      - `origin` [string]
         
         
-      - `localStorage` [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-local-storage"/><a href="#api-request-new-context-option-local-storage" class="list-anchor">#</a>
-        - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-name"/><a href="#api-request-new-context-option-name" class="list-anchor">#</a>
+      - `localStorage` [Array]&lt;[Object]&gt;
+        - `name` [string]
           
           
-        - `value` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-value"/><a href="#api-request-new-context-option-value" class="list-anchor">#</a>
+        - `value` [string]
           
           
         

--- a/nodejs/docs/api/class-apirequestcontext.mdx
+++ b/nodejs/docs/api/class-apirequestcontext.mdx
@@ -62,13 +62,13 @@ await apiRequestContext.delete(url, options);
     
     Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
   - `multipart` [FormData] | [Object]&lt;[string], [string] | [number] | [boolean] | [ReadStream] | [Object]&gt; *(optional)* <font size="2">Added in: v1.17</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-delete-option-multipart"/><a href="#api-request-context-delete-option-multipart" class="list-anchor">#</a>
-    - `name` [string] <font size="2">Added in: v1.17</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-delete-option-name"/><a href="#api-request-context-delete-option-name" class="list-anchor">#</a>
+    - `name` [string]
       
       File name
-    - `mimeType` [string] <font size="2">Added in: v1.17</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-delete-option-mime-type"/><a href="#api-request-context-delete-option-mime-type" class="list-anchor">#</a>
+    - `mimeType` [string]
       
       File type
-    - `buffer` [Buffer] <font size="2">Added in: v1.17</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-delete-option-buffer"/><a href="#api-request-context-delete-option-buffer" class="list-anchor">#</a>
+    - `buffer` [Buffer]
       
       File content
     
@@ -173,13 +173,13 @@ await request.fetch('https://example.com/api/uploadForm', {
     
     If set changes the fetch method (e.g. [PUT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT) or [POST](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST)). If not specified, GET method is used.
   - `multipart` [FormData] | [Object]&lt;[string], [string] | [number] | [boolean] | [ReadStream] | [Object]&gt; *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-fetch-option-multipart"/><a href="#api-request-context-fetch-option-multipart" class="list-anchor">#</a>
-    - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-fetch-option-name"/><a href="#api-request-context-fetch-option-name" class="list-anchor">#</a>
+    - `name` [string]
       
       File name
-    - `mimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-fetch-option-mime-type"/><a href="#api-request-context-fetch-option-mime-type" class="list-anchor">#</a>
+    - `mimeType` [string]
       
       File type
-    - `buffer` [Buffer]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-fetch-option-buffer"/><a href="#api-request-context-fetch-option-buffer" class="list-anchor">#</a>
+    - `buffer` [Buffer]
       
       File content
     
@@ -254,13 +254,13 @@ await request.get('https://example.com/api/getText', { params: queryString });
     
     Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
   - `multipart` [FormData] | [Object]&lt;[string], [string] | [number] | [boolean] | [ReadStream] | [Object]&gt; *(optional)* <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-get-option-multipart"/><a href="#api-request-context-get-option-multipart" class="list-anchor">#</a>
-    - `name` [string] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-get-option-name"/><a href="#api-request-context-get-option-name" class="list-anchor">#</a>
+    - `name` [string]
       
       File name
-    - `mimeType` [string] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-get-option-mime-type"/><a href="#api-request-context-get-option-mime-type" class="list-anchor">#</a>
+    - `mimeType` [string]
       
       File type
-    - `buffer` [Buffer] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-get-option-buffer"/><a href="#api-request-context-get-option-buffer" class="list-anchor">#</a>
+    - `buffer` [Buffer]
       
       File content
     
@@ -317,13 +317,13 @@ await apiRequestContext.head(url, options);
     
     Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
   - `multipart` [FormData] | [Object]&lt;[string], [string] | [number] | [boolean] | [ReadStream] | [Object]&gt; *(optional)* <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-head-option-multipart"/><a href="#api-request-context-head-option-multipart" class="list-anchor">#</a>
-    - `name` [string] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-head-option-name"/><a href="#api-request-context-head-option-name" class="list-anchor">#</a>
+    - `name` [string]
       
       File name
-    - `mimeType` [string] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-head-option-mime-type"/><a href="#api-request-context-head-option-mime-type" class="list-anchor">#</a>
+    - `mimeType` [string]
       
       File type
-    - `buffer` [Buffer] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-head-option-buffer"/><a href="#api-request-context-head-option-buffer" class="list-anchor">#</a>
+    - `buffer` [Buffer]
       
       File content
     
@@ -380,13 +380,13 @@ await apiRequestContext.patch(url, options);
     
     Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
   - `multipart` [FormData] | [Object]&lt;[string], [string] | [number] | [boolean] | [ReadStream] | [Object]&gt; *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-patch-option-multipart"/><a href="#api-request-context-patch-option-multipart" class="list-anchor">#</a>
-    - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-patch-option-name"/><a href="#api-request-context-patch-option-name" class="list-anchor">#</a>
+    - `name` [string]
       
       File name
-    - `mimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-patch-option-mime-type"/><a href="#api-request-context-patch-option-mime-type" class="list-anchor">#</a>
+    - `mimeType` [string]
       
       File type
-    - `buffer` [Buffer]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-patch-option-buffer"/><a href="#api-request-context-patch-option-buffer" class="list-anchor">#</a>
+    - `buffer` [Buffer]
       
       File content
     
@@ -474,13 +474,13 @@ await request.post('https://example.com/api/uploadForm', {
     
     Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
   - `multipart` [FormData] | [Object]&lt;[string], [string] | [number] | [boolean] | [ReadStream] | [Object]&gt; *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-post-option-multipart"/><a href="#api-request-context-post-option-multipart" class="list-anchor">#</a>
-    - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-post-option-name"/><a href="#api-request-context-post-option-name" class="list-anchor">#</a>
+    - `name` [string]
       
       File name
-    - `mimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-post-option-mime-type"/><a href="#api-request-context-post-option-mime-type" class="list-anchor">#</a>
+    - `mimeType` [string]
       
       File type
-    - `buffer` [Buffer]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-post-option-buffer"/><a href="#api-request-context-post-option-buffer" class="list-anchor">#</a>
+    - `buffer` [Buffer]
       
       File content
     
@@ -537,13 +537,13 @@ await apiRequestContext.put(url, options);
     
     Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
   - `multipart` [FormData] | [Object]&lt;[string], [string] | [number] | [boolean] | [ReadStream] | [Object]&gt; *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-put-option-multipart"/><a href="#api-request-context-put-option-multipart" class="list-anchor">#</a>
-    - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-put-option-name"/><a href="#api-request-context-put-option-name" class="list-anchor">#</a>
+    - `name` [string]
       
       File name
-    - `mimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-put-option-mime-type"/><a href="#api-request-context-put-option-mime-type" class="list-anchor">#</a>
+    - `mimeType` [string]
       
       File type
-    - `buffer` [Buffer]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-put-option-buffer"/><a href="#api-request-context-put-option-buffer" class="list-anchor">#</a>
+    - `buffer` [Buffer]
       
       File content
     

--- a/nodejs/docs/api/class-browser.mdx
+++ b/nodejs/docs/api/class-browser.mdx
@@ -175,19 +175,19 @@ If directly using this method to create [BrowserContext]s, it is best practice t
     
     Toggles bypassing page's Content-Security-Policy. Defaults to `false`.
   - `clientCertificates` [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-client-certificates"/><a href="#browser-new-context-option-client-certificates" class="list-anchor">#</a>
-    - `origin` [string] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origin"/><a href="#browser-new-context-option-origin" class="list-anchor">#</a>
+    - `origin` [string]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `certPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-cert-path"/><a href="#browser-new-context-option-cert-path" class="list-anchor">#</a>
+    - `certPath` [string] *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `keyPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-key-path"/><a href="#browser-new-context-option-key-path" class="list-anchor">#</a>
+    - `keyPath` [string] *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `pfxPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-pfx-path"/><a href="#browser-new-context-option-pfx-path" class="list-anchor">#</a>
+    - `pfxPath` [string] *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `passphrase` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-passphrase"/><a href="#browser-new-context-option-passphrase" class="list-anchor">#</a>
+    - `passphrase` [string] *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -218,29 +218,29 @@ If directly using this method to create [BrowserContext]s, it is best practice t
     
     Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'none'`.
   - `geolocation` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-geolocation"/><a href="#browser-new-context-option-geolocation" class="list-anchor">#</a>
-    - `latitude` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-latitude"/><a href="#browser-new-context-option-latitude" class="list-anchor">#</a>
+    - `latitude` [number]
       
       Latitude between -90 and 90.
-    - `longitude` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-longitude"/><a href="#browser-new-context-option-longitude" class="list-anchor">#</a>
+    - `longitude` [number]
       
       Longitude between -180 and 180.
-    - `accuracy` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-accuracy"/><a href="#browser-new-context-option-accuracy" class="list-anchor">#</a>
+    - `accuracy` [number] *(optional)*
       
       Non-negative accuracy value. Defaults to `0`.
   - `hasTouch` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-has-touch"/><a href="#browser-new-context-option-has-touch" class="list-anchor">#</a>
     
     Specifies if viewport supports touch events. Defaults to false. Learn more about [mobile emulation](../emulation.mdx#devices).
   - `httpCredentials` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-http-credentials"/><a href="#browser-new-context-option-http-credentials" class="list-anchor">#</a>
-    - `username` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-username"/><a href="#browser-new-context-option-username" class="list-anchor">#</a>
+    - `username` [string]
       
       
-    - `password` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-password"/><a href="#browser-new-context-option-password" class="list-anchor">#</a>
+    - `password` [string]
       
       
-    - `origin` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origin"/><a href="#browser-new-context-option-origin" class="list-anchor">#</a>
+    - `origin` [string] *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `send` "unauthorized" | "always" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-send"/><a href="#browser-new-context-option-send" class="list-anchor">#</a>
+    - `send` "unauthorized" | "always" *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -267,16 +267,16 @@ If directly using this method to create [BrowserContext]s, it is best practice t
     
     A list of permissions to grant to all pages in this context. See [browserContext.grantPermissions()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
   - `proxy` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-proxy"/><a href="#browser-new-context-option-proxy" class="list-anchor">#</a>
-    - `server` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-server"/><a href="#browser-new-context-option-server" class="list-anchor">#</a>
+    - `server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `bypass` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-bypass"/><a href="#browser-new-context-option-bypass" class="list-anchor">#</a>
+    - `bypass` [string] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `username` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-username"/><a href="#browser-new-context-option-username" class="list-anchor">#</a>
+    - `username` [string] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `password` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-password"/><a href="#browser-new-context-option-password" class="list-anchor">#</a>
+    - `password` [string] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
@@ -287,32 +287,32 @@ If directly using this method to create [BrowserContext]s, it is best practice t
     :::
     
   - `recordHar` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-record-har"/><a href="#browser-new-context-option-record-har" class="list-anchor">#</a>
-    - `omitContent` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-omit-content"/><a href="#browser-new-context-option-omit-content" class="list-anchor">#</a>
+    - `omitContent` [boolean] *(optional)*
       
       Optional setting to control whether to omit request content from the HAR. Defaults to `false`. Deprecated, use `content` policy instead.
-    - `content` "omit" | "embed" | "attach" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-content"/><a href="#browser-new-context-option-content" class="list-anchor">#</a>
+    - `content` "omit" | "embed" | "attach" *(optional)*
       
       Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output files and to `embed` for all other file extensions.
-    - `path` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-path"/><a href="#browser-new-context-option-path" class="list-anchor">#</a>
+    - `path` [string]
       
       Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by default.
-    - `mode` "full" | "minimal" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-mode"/><a href="#browser-new-context-option-mode" class="list-anchor">#</a>
+    - `mode` "full" | "minimal" *(optional)*
       
       When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
-    - `urlFilter` [string] | [RegExp] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-url-filter"/><a href="#browser-new-context-option-url-filter" class="list-anchor">#</a>
+    - `urlFilter` [string] | [RegExp] *(optional)*
       
       A glob or regex pattern to filter requests that are stored in the HAR. When a `baseURL` via the context options was provided and the passed URL is a path, it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor. Defaults to none.
     
     Enables [HAR](http://www.softwareishard.com/blog/har-12-spec) recording for all pages into `recordHar.path` file. If not specified, the HAR is not recorded. Make sure to await [browserContext.close()](/api/class-browsercontext.mdx#browser-context-close) for the HAR to be saved.
   - `recordVideo` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-record-video"/><a href="#browser-new-context-option-record-video" class="list-anchor">#</a>
-    - `dir` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-dir"/><a href="#browser-new-context-option-dir" class="list-anchor">#</a>
+    - `dir` [string]
       
       Path to the directory to put videos into.
-    - `size` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-size"/><a href="#browser-new-context-option-size" class="list-anchor">#</a>
-      - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+    - `size` [Object] *(optional)*
+      - `width` [number]
         
         Video frame width.
-      - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+      - `height` [number]
         
         Video frame height.
       
@@ -323,10 +323,10 @@ If directly using this method to create [BrowserContext]s, it is best practice t
     
     Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'no-preference'`.
   - `screen` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-screen"/><a href="#browser-new-context-option-screen" class="list-anchor">#</a>
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       page width in pixels.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       page height in pixels.
     
@@ -337,42 +337,42 @@ If directly using this method to create [BrowserContext]s, it is best practice t
     * `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
     * `'block'`: Playwright will block all registration of Service Workers.
   - `storageState` [string] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-storage-state"/><a href="#browser-new-context-option-storage-state" class="list-anchor">#</a>
-    - `cookies` [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-cookies"/><a href="#browser-new-context-option-cookies" class="list-anchor">#</a>
-      - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-name"/><a href="#browser-new-context-option-name" class="list-anchor">#</a>
+    - `cookies` [Array]&lt;[Object]&gt;
+      - `name` [string]
         
         
-      - `value` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-value"/><a href="#browser-new-context-option-value" class="list-anchor">#</a>
+      - `value` [string]
         
         
-      - `domain` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-domain"/><a href="#browser-new-context-option-domain" class="list-anchor">#</a>
+      - `domain` [string]
         
         Domain and path are required. For the cookie to apply to all subdomains as well, prefix domain with a dot, like this: ".example.com"
-      - `path` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-path"/><a href="#browser-new-context-option-path" class="list-anchor">#</a>
+      - `path` [string]
         
         Domain and path are required
-      - `expires` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-expires"/><a href="#browser-new-context-option-expires" class="list-anchor">#</a>
+      - `expires` [number]
         
         Unix time in seconds.
-      - `httpOnly` [boolean]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-http-only"/><a href="#browser-new-context-option-http-only" class="list-anchor">#</a>
+      - `httpOnly` [boolean]
         
         
-      - `secure` [boolean]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-secure"/><a href="#browser-new-context-option-secure" class="list-anchor">#</a>
+      - `secure` [boolean]
         
         
-      - `sameSite` "Strict" | "Lax" | "None"<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-same-site"/><a href="#browser-new-context-option-same-site" class="list-anchor">#</a>
+      - `sameSite` "Strict" | "Lax" | "None"
         
         sameSite flag
       
       Cookies to set for context
-    - `origins` [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origins"/><a href="#browser-new-context-option-origins" class="list-anchor">#</a>
-      - `origin` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origin"/><a href="#browser-new-context-option-origin" class="list-anchor">#</a>
+    - `origins` [Array]&lt;[Object]&gt;
+      - `origin` [string]
         
         
-      - `localStorage` [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-local-storage"/><a href="#browser-new-context-option-local-storage" class="list-anchor">#</a>
-        - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-name"/><a href="#browser-new-context-option-name" class="list-anchor">#</a>
+      - `localStorage` [Array]&lt;[Object]&gt;
+        - `name` [string]
           
           
-        - `value` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-value"/><a href="#browser-new-context-option-value" class="list-anchor">#</a>
+        - `value` [string]
           
           
         
@@ -396,10 +396,10 @@ If directly using this method to create [BrowserContext]s, it is best practice t
     Use `recordVideo` instead.
     :::
     
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       Video frame width.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-videos-path"/><a href="#browser-new-context-option-videos-path" class="list-anchor">#</a>
@@ -409,10 +409,10 @@ If directly using this method to create [BrowserContext]s, it is best practice t
     :::
     
   - `viewport` [null] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-viewport"/><a href="#browser-new-context-option-viewport" class="list-anchor">#</a>
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       page width in pixels.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       page height in pixels.
     
@@ -457,19 +457,19 @@ await browser.newPage(options);
     
     Toggles bypassing page's Content-Security-Policy. Defaults to `false`.
   - `clientCertificates` [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-client-certificates"/><a href="#browser-new-page-option-client-certificates" class="list-anchor">#</a>
-    - `origin` [string] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origin"/><a href="#browser-new-page-option-origin" class="list-anchor">#</a>
+    - `origin` [string]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `certPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-cert-path"/><a href="#browser-new-page-option-cert-path" class="list-anchor">#</a>
+    - `certPath` [string] *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `keyPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-key-path"/><a href="#browser-new-page-option-key-path" class="list-anchor">#</a>
+    - `keyPath` [string] *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `pfxPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-pfx-path"/><a href="#browser-new-page-option-pfx-path" class="list-anchor">#</a>
+    - `pfxPath` [string] *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `passphrase` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-passphrase"/><a href="#browser-new-page-option-passphrase" class="list-anchor">#</a>
+    - `passphrase` [string] *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -500,29 +500,29 @@ await browser.newPage(options);
     
     Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'none'`.
   - `geolocation` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-geolocation"/><a href="#browser-new-page-option-geolocation" class="list-anchor">#</a>
-    - `latitude` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-latitude"/><a href="#browser-new-page-option-latitude" class="list-anchor">#</a>
+    - `latitude` [number]
       
       Latitude between -90 and 90.
-    - `longitude` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-longitude"/><a href="#browser-new-page-option-longitude" class="list-anchor">#</a>
+    - `longitude` [number]
       
       Longitude between -180 and 180.
-    - `accuracy` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-accuracy"/><a href="#browser-new-page-option-accuracy" class="list-anchor">#</a>
+    - `accuracy` [number] *(optional)*
       
       Non-negative accuracy value. Defaults to `0`.
   - `hasTouch` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-has-touch"/><a href="#browser-new-page-option-has-touch" class="list-anchor">#</a>
     
     Specifies if viewport supports touch events. Defaults to false. Learn more about [mobile emulation](../emulation.mdx#devices).
   - `httpCredentials` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-http-credentials"/><a href="#browser-new-page-option-http-credentials" class="list-anchor">#</a>
-    - `username` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-username"/><a href="#browser-new-page-option-username" class="list-anchor">#</a>
+    - `username` [string]
       
       
-    - `password` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-password"/><a href="#browser-new-page-option-password" class="list-anchor">#</a>
+    - `password` [string]
       
       
-    - `origin` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origin"/><a href="#browser-new-page-option-origin" class="list-anchor">#</a>
+    - `origin` [string] *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `send` "unauthorized" | "always" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-send"/><a href="#browser-new-page-option-send" class="list-anchor">#</a>
+    - `send` "unauthorized" | "always" *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -549,16 +549,16 @@ await browser.newPage(options);
     
     A list of permissions to grant to all pages in this context. See [browserContext.grantPermissions()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
   - `proxy` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-proxy"/><a href="#browser-new-page-option-proxy" class="list-anchor">#</a>
-    - `server` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-server"/><a href="#browser-new-page-option-server" class="list-anchor">#</a>
+    - `server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `bypass` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-bypass"/><a href="#browser-new-page-option-bypass" class="list-anchor">#</a>
+    - `bypass` [string] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `username` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-username"/><a href="#browser-new-page-option-username" class="list-anchor">#</a>
+    - `username` [string] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `password` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-password"/><a href="#browser-new-page-option-password" class="list-anchor">#</a>
+    - `password` [string] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
@@ -569,32 +569,32 @@ await browser.newPage(options);
     :::
     
   - `recordHar` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-record-har"/><a href="#browser-new-page-option-record-har" class="list-anchor">#</a>
-    - `omitContent` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-omit-content"/><a href="#browser-new-page-option-omit-content" class="list-anchor">#</a>
+    - `omitContent` [boolean] *(optional)*
       
       Optional setting to control whether to omit request content from the HAR. Defaults to `false`. Deprecated, use `content` policy instead.
-    - `content` "omit" | "embed" | "attach" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-content"/><a href="#browser-new-page-option-content" class="list-anchor">#</a>
+    - `content` "omit" | "embed" | "attach" *(optional)*
       
       Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output files and to `embed` for all other file extensions.
-    - `path` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-path"/><a href="#browser-new-page-option-path" class="list-anchor">#</a>
+    - `path` [string]
       
       Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by default.
-    - `mode` "full" | "minimal" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-mode"/><a href="#browser-new-page-option-mode" class="list-anchor">#</a>
+    - `mode` "full" | "minimal" *(optional)*
       
       When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
-    - `urlFilter` [string] | [RegExp] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-url-filter"/><a href="#browser-new-page-option-url-filter" class="list-anchor">#</a>
+    - `urlFilter` [string] | [RegExp] *(optional)*
       
       A glob or regex pattern to filter requests that are stored in the HAR. When a `baseURL` via the context options was provided and the passed URL is a path, it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor. Defaults to none.
     
     Enables [HAR](http://www.softwareishard.com/blog/har-12-spec) recording for all pages into `recordHar.path` file. If not specified, the HAR is not recorded. Make sure to await [browserContext.close()](/api/class-browsercontext.mdx#browser-context-close) for the HAR to be saved.
   - `recordVideo` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-record-video"/><a href="#browser-new-page-option-record-video" class="list-anchor">#</a>
-    - `dir` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-dir"/><a href="#browser-new-page-option-dir" class="list-anchor">#</a>
+    - `dir` [string]
       
       Path to the directory to put videos into.
-    - `size` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-size"/><a href="#browser-new-page-option-size" class="list-anchor">#</a>
-      - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+    - `size` [Object] *(optional)*
+      - `width` [number]
         
         Video frame width.
-      - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+      - `height` [number]
         
         Video frame height.
       
@@ -605,10 +605,10 @@ await browser.newPage(options);
     
     Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'no-preference'`.
   - `screen` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-screen"/><a href="#browser-new-page-option-screen" class="list-anchor">#</a>
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       page width in pixels.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       page height in pixels.
     
@@ -619,42 +619,42 @@ await browser.newPage(options);
     * `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
     * `'block'`: Playwright will block all registration of Service Workers.
   - `storageState` [string] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-storage-state"/><a href="#browser-new-page-option-storage-state" class="list-anchor">#</a>
-    - `cookies` [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-cookies"/><a href="#browser-new-page-option-cookies" class="list-anchor">#</a>
-      - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-name"/><a href="#browser-new-page-option-name" class="list-anchor">#</a>
+    - `cookies` [Array]&lt;[Object]&gt;
+      - `name` [string]
         
         
-      - `value` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-value"/><a href="#browser-new-page-option-value" class="list-anchor">#</a>
+      - `value` [string]
         
         
-      - `domain` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-domain"/><a href="#browser-new-page-option-domain" class="list-anchor">#</a>
+      - `domain` [string]
         
         Domain and path are required. For the cookie to apply to all subdomains as well, prefix domain with a dot, like this: ".example.com"
-      - `path` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-path"/><a href="#browser-new-page-option-path" class="list-anchor">#</a>
+      - `path` [string]
         
         Domain and path are required
-      - `expires` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-expires"/><a href="#browser-new-page-option-expires" class="list-anchor">#</a>
+      - `expires` [number]
         
         Unix time in seconds.
-      - `httpOnly` [boolean]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-http-only"/><a href="#browser-new-page-option-http-only" class="list-anchor">#</a>
+      - `httpOnly` [boolean]
         
         
-      - `secure` [boolean]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-secure"/><a href="#browser-new-page-option-secure" class="list-anchor">#</a>
+      - `secure` [boolean]
         
         
-      - `sameSite` "Strict" | "Lax" | "None"<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-same-site"/><a href="#browser-new-page-option-same-site" class="list-anchor">#</a>
+      - `sameSite` "Strict" | "Lax" | "None"
         
         sameSite flag
       
       Cookies to set for context
-    - `origins` [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origins"/><a href="#browser-new-page-option-origins" class="list-anchor">#</a>
-      - `origin` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origin"/><a href="#browser-new-page-option-origin" class="list-anchor">#</a>
+    - `origins` [Array]&lt;[Object]&gt;
+      - `origin` [string]
         
         
-      - `localStorage` [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-local-storage"/><a href="#browser-new-page-option-local-storage" class="list-anchor">#</a>
-        - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-name"/><a href="#browser-new-page-option-name" class="list-anchor">#</a>
+      - `localStorage` [Array]&lt;[Object]&gt;
+        - `name` [string]
           
           
-        - `value` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-value"/><a href="#browser-new-page-option-value" class="list-anchor">#</a>
+        - `value` [string]
           
           
         
@@ -678,10 +678,10 @@ await browser.newPage(options);
     Use `recordVideo` instead.
     :::
     
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       Video frame width.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-videos-path"/><a href="#browser-new-page-option-videos-path" class="list-anchor">#</a>
@@ -691,10 +691,10 @@ await browser.newPage(options);
     :::
     
   - `viewport` [null] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-viewport"/><a href="#browser-new-page-option-viewport" class="list-anchor">#</a>
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       page width in pixels.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       page height in pixels.
     

--- a/nodejs/docs/api/class-browsercontext.mdx
+++ b/nodejs/docs/api/class-browsercontext.mdx
@@ -42,31 +42,31 @@ await browserContext.addCookies([cookieObject1, cookieObject2]);
 
 **Arguments**
 - `cookies` [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-cookies"/><a href="#browser-context-add-cookies-option-cookies" class="list-anchor">#</a>
-  - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-name"/><a href="#browser-context-add-cookies-option-name" class="list-anchor">#</a>
+  - `name` [string]
     
     
-  - `value` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-value"/><a href="#browser-context-add-cookies-option-value" class="list-anchor">#</a>
+  - `value` [string]
     
     
-  - `url` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-url"/><a href="#browser-context-add-cookies-option-url" class="list-anchor">#</a>
+  - `url` [string] *(optional)*
     
     Either url or domain / path are required. Optional.
-  - `domain` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-domain"/><a href="#browser-context-add-cookies-option-domain" class="list-anchor">#</a>
+  - `domain` [string] *(optional)*
     
     For the cookie to apply to all subdomains as well, prefix domain with a dot, like this: ".example.com". Either url or domain / path are required. Optional.
-  - `path` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-path"/><a href="#browser-context-add-cookies-option-path" class="list-anchor">#</a>
+  - `path` [string] *(optional)*
     
     Either url or domain / path are required Optional.
-  - `expires` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-expires"/><a href="#browser-context-add-cookies-option-expires" class="list-anchor">#</a>
+  - `expires` [number] *(optional)*
     
     Unix time in seconds. Optional.
-  - `httpOnly` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-http-only"/><a href="#browser-context-add-cookies-option-http-only" class="list-anchor">#</a>
+  - `httpOnly` [boolean] *(optional)*
     
     Optional.
-  - `secure` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-secure"/><a href="#browser-context-add-cookies-option-secure" class="list-anchor">#</a>
+  - `secure` [boolean] *(optional)*
     
     Optional.
-  - `sameSite` "Strict" | "Lax" | "None" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-same-site"/><a href="#browser-context-add-cookies-option-same-site" class="list-anchor">#</a>
+  - `sameSite` "Strict" | "Lax" | "None" *(optional)*
     
     Optional.
 
@@ -107,10 +107,10 @@ The order of evaluation of multiple scripts installed via [browserContext.addIni
 
 **Arguments**
 - `script` [function] | [string] | [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-init-script-option-script"/><a href="#browser-context-add-init-script-option-script" class="list-anchor">#</a>
-  - `path` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-init-script-option-path"/><a href="#browser-context-add-init-script-option-path" class="list-anchor">#</a>
+  - `path` [string] *(optional)*
     
     Path to the JavaScript file. If `path` is a relative path, then it is resolved relative to the current working directory. Optional.
-  - `content` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-init-script-option-content"/><a href="#browser-context-add-init-script-option-content" class="list-anchor">#</a>
+  - `content` [string] *(optional)*
     
     Raw script content. Optional.
   
@@ -757,13 +757,13 @@ Consider using [browserContext.grantPermissions()](/api/class-browsercontext.mdx
 
 **Arguments**
 - `geolocation` [null] | [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-geolocation"/><a href="#browser-context-set-geolocation-option-geolocation" class="list-anchor">#</a>
-  - `latitude` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-latitude"/><a href="#browser-context-set-geolocation-option-latitude" class="list-anchor">#</a>
+  - `latitude` [number]
     
     Latitude between -90 and 90.
-  - `longitude` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-longitude"/><a href="#browser-context-set-geolocation-option-longitude" class="list-anchor">#</a>
+  - `longitude` [number]
     
     Longitude between -180 and 180.
-  - `accuracy` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-accuracy"/><a href="#browser-context-set-geolocation-option-accuracy" class="list-anchor">#</a>
+  - `accuracy` [number] *(optional)*
     
     Non-negative accuracy value. Defaults to `0`.
 
@@ -926,10 +926,10 @@ const page = await pagePromise;
   
   Event name, same one would pass into `browserContext.on(event)`.
 - `optionsOrPredicate` [function] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-wait-for-event-option-options-or-predicate"/><a href="#browser-context-wait-for-event-option-options-or-predicate" class="list-anchor">#</a>
-  - `predicate` [function]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-wait-for-event-option-predicate"/><a href="#browser-context-wait-for-event-option-predicate" class="list-anchor">#</a>
+  - `predicate` [function]
     
     Receives the event data and resolves to truthy value when the waiting should resolve.
-  - `timeout` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-wait-for-event-option-timeout"/><a href="#browser-context-wait-for-event-option-timeout" class="list-anchor">#</a>
+  - `timeout` [number] *(optional)*
     
     Maximum time to wait for in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout` option in the config, or by using the [browserContext.setDefaultTimeout()](/api/class-browsercontext.mdx#browser-context-set-default-timeout) method.
   
@@ -1253,10 +1253,10 @@ await browserContext.setHTTPCredentials(httpCredentials);
 
 **Arguments**
 - `httpCredentials` [null] | [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-http-credentials-option-http-credentials"/><a href="#browser-context-set-http-credentials-option-http-credentials" class="list-anchor">#</a>
-  - `username` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-http-credentials-option-username"/><a href="#browser-context-set-http-credentials-option-username" class="list-anchor">#</a>
+  - `username` [string]
     
     
-  - `password` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-http-credentials-option-password"/><a href="#browser-context-set-http-credentials-option-password" class="list-anchor">#</a>
+  - `password` [string]
     
     
 **Returns**

--- a/nodejs/docs/api/class-browsertype.mdx
+++ b/nodejs/docs/api/class-browsertype.mdx
@@ -214,16 +214,16 @@ const browser = await chromium.launch({  // Or 'firefox' or 'webkit'.
     
     Logger sink for Playwright logging.
   - `proxy` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-proxy"/><a href="#browser-type-launch-option-proxy" class="list-anchor">#</a>
-    - `server` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-server"/><a href="#browser-type-launch-option-server" class="list-anchor">#</a>
+    - `server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `bypass` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-bypass"/><a href="#browser-type-launch-option-bypass" class="list-anchor">#</a>
+    - `bypass` [string] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `username` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-username"/><a href="#browser-type-launch-option-username" class="list-anchor">#</a>
+    - `username` [string] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `password` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-password"/><a href="#browser-type-launch-option-password" class="list-anchor">#</a>
+    - `password` [string] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
@@ -289,19 +289,19 @@ await browserType.launchPersistentContext(userDataDir, options);
     
     Enable Chromium sandboxing. Defaults to `false`.
   - `clientCertificates` [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-client-certificates"/><a href="#browser-type-launch-persistent-context-option-client-certificates" class="list-anchor">#</a>
-    - `origin` [string] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-origin"/><a href="#browser-type-launch-persistent-context-option-origin" class="list-anchor">#</a>
+    - `origin` [string]
       
       Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-    - `certPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-cert-path"/><a href="#browser-type-launch-persistent-context-option-cert-path" class="list-anchor">#</a>
+    - `certPath` [string] *(optional)*
       
       Path to the file with the certificate in PEM format.
-    - `keyPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-key-path"/><a href="#browser-type-launch-persistent-context-option-key-path" class="list-anchor">#</a>
+    - `keyPath` [string] *(optional)*
       
       Path to the file with the private key in PEM format.
-    - `pfxPath` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-pfx-path"/><a href="#browser-type-launch-persistent-context-option-pfx-path" class="list-anchor">#</a>
+    - `pfxPath` [string] *(optional)*
       
       Path to the PFX or PKCS12 encoded private key and certificate chain.
-    - `passphrase` [string] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-passphrase"/><a href="#browser-type-launch-persistent-context-option-passphrase" class="list-anchor">#</a>
+    - `passphrase` [string] *(optional)*
       
       Passphrase for the private key (PEM or PFX).
     
@@ -352,13 +352,13 @@ await browserType.launchPersistentContext(userDataDir, options);
     
     Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'none'`.
   - `geolocation` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-geolocation"/><a href="#browser-type-launch-persistent-context-option-geolocation" class="list-anchor">#</a>
-    - `latitude` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-latitude"/><a href="#browser-type-launch-persistent-context-option-latitude" class="list-anchor">#</a>
+    - `latitude` [number]
       
       Latitude between -90 and 90.
-    - `longitude` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-longitude"/><a href="#browser-type-launch-persistent-context-option-longitude" class="list-anchor">#</a>
+    - `longitude` [number]
       
       Longitude between -180 and 180.
-    - `accuracy` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-accuracy"/><a href="#browser-type-launch-persistent-context-option-accuracy" class="list-anchor">#</a>
+    - `accuracy` [number] *(optional)*
       
       Non-negative accuracy value. Defaults to `0`.
   - `handleSIGHUP` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-handle-sighup"/><a href="#browser-type-launch-persistent-context-option-handle-sighup" class="list-anchor">#</a>
@@ -377,16 +377,16 @@ await browserType.launchPersistentContext(userDataDir, options);
     
     Whether to run browser in headless mode. More details for [Chromium](https://developers.google.com/web/updates/2017/04/headless-chrome) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode). Defaults to `true` unless the `devtools` option is `true`.
   - `httpCredentials` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-http-credentials"/><a href="#browser-type-launch-persistent-context-option-http-credentials" class="list-anchor">#</a>
-    - `username` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-username"/><a href="#browser-type-launch-persistent-context-option-username" class="list-anchor">#</a>
+    - `username` [string]
       
       
-    - `password` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-password"/><a href="#browser-type-launch-persistent-context-option-password" class="list-anchor">#</a>
+    - `password` [string]
       
       
-    - `origin` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-origin"/><a href="#browser-type-launch-persistent-context-option-origin" class="list-anchor">#</a>
+    - `origin` [string] *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `send` "unauthorized" | "always" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-send"/><a href="#browser-type-launch-persistent-context-option-send" class="list-anchor">#</a>
+    - `send` "unauthorized" | "always" *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -416,47 +416,47 @@ await browserType.launchPersistentContext(userDataDir, options);
     
     A list of permissions to grant to all pages in this context. See [browserContext.grantPermissions()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
   - `proxy` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-proxy"/><a href="#browser-type-launch-persistent-context-option-proxy" class="list-anchor">#</a>
-    - `server` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-server"/><a href="#browser-type-launch-persistent-context-option-server" class="list-anchor">#</a>
+    - `server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `bypass` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-bypass"/><a href="#browser-type-launch-persistent-context-option-bypass" class="list-anchor">#</a>
+    - `bypass` [string] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `username` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-username"/><a href="#browser-type-launch-persistent-context-option-username" class="list-anchor">#</a>
+    - `username` [string] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `password` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-password"/><a href="#browser-type-launch-persistent-context-option-password" class="list-anchor">#</a>
+    - `password` [string] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     
     Network proxy settings.
   - `recordHar` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-record-har"/><a href="#browser-type-launch-persistent-context-option-record-har" class="list-anchor">#</a>
-    - `omitContent` [boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-omit-content"/><a href="#browser-type-launch-persistent-context-option-omit-content" class="list-anchor">#</a>
+    - `omitContent` [boolean] *(optional)*
       
       Optional setting to control whether to omit request content from the HAR. Defaults to `false`. Deprecated, use `content` policy instead.
-    - `content` "omit" | "embed" | "attach" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-content"/><a href="#browser-type-launch-persistent-context-option-content" class="list-anchor">#</a>
+    - `content` "omit" | "embed" | "attach" *(optional)*
       
       Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output files and to `embed` for all other file extensions.
-    - `path` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-path"/><a href="#browser-type-launch-persistent-context-option-path" class="list-anchor">#</a>
+    - `path` [string]
       
       Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by default.
-    - `mode` "full" | "minimal" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-mode"/><a href="#browser-type-launch-persistent-context-option-mode" class="list-anchor">#</a>
+    - `mode` "full" | "minimal" *(optional)*
       
       When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
-    - `urlFilter` [string] | [RegExp] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-url-filter"/><a href="#browser-type-launch-persistent-context-option-url-filter" class="list-anchor">#</a>
+    - `urlFilter` [string] | [RegExp] *(optional)*
       
       A glob or regex pattern to filter requests that are stored in the HAR. When a `baseURL` via the context options was provided and the passed URL is a path, it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor. Defaults to none.
     
     Enables [HAR](http://www.softwareishard.com/blog/har-12-spec) recording for all pages into `recordHar.path` file. If not specified, the HAR is not recorded. Make sure to await [browserContext.close()](/api/class-browsercontext.mdx#browser-context-close) for the HAR to be saved.
   - `recordVideo` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-record-video"/><a href="#browser-type-launch-persistent-context-option-record-video" class="list-anchor">#</a>
-    - `dir` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-dir"/><a href="#browser-type-launch-persistent-context-option-dir" class="list-anchor">#</a>
+    - `dir` [string]
       
       Path to the directory to put videos into.
-    - `size` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-size"/><a href="#browser-type-launch-persistent-context-option-size" class="list-anchor">#</a>
-      - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+    - `size` [Object] *(optional)*
+      - `width` [number]
         
         Video frame width.
-      - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+      - `height` [number]
         
         Video frame height.
       
@@ -467,10 +467,10 @@ await browserType.launchPersistentContext(userDataDir, options);
     
     Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [page.emulateMedia()](/api/class-page.mdx#page-emulate-media) for more details. Passing `null` resets emulation to system defaults. Defaults to `'no-preference'`.
   - `screen` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-screen"/><a href="#browser-type-launch-persistent-context-option-screen" class="list-anchor">#</a>
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       page width in pixels.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       page height in pixels.
     
@@ -504,10 +504,10 @@ await browserType.launchPersistentContext(userDataDir, options);
     Use `recordVideo` instead.
     :::
     
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       Video frame width.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       Video frame height.
   - `videosPath` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-videos-path"/><a href="#browser-type-launch-persistent-context-option-videos-path" class="list-anchor">#</a>
@@ -517,10 +517,10 @@ await browserType.launchPersistentContext(userDataDir, options);
     :::
     
   - `viewport` [null] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-viewport"/><a href="#browser-type-launch-persistent-context-option-viewport" class="list-anchor">#</a>
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       page width in pixels.
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       page height in pixels.
     
@@ -618,16 +618,16 @@ const { chromium } = require('playwright');  // Or 'webkit' or 'firefox'.
     
     Port to use for the web socket. Defaults to 0 that picks any available port.
   - `proxy` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-server-option-proxy"/><a href="#browser-type-launch-server-option-proxy" class="list-anchor">#</a>
-    - `server` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-server-option-server"/><a href="#browser-type-launch-server-option-server" class="list-anchor">#</a>
+    - `server` [string]
       
       Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-    - `bypass` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-server-option-bypass"/><a href="#browser-type-launch-server-option-bypass" class="list-anchor">#</a>
+    - `bypass` [string] *(optional)*
       
       Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-    - `username` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-server-option-username"/><a href="#browser-type-launch-server-option-username" class="list-anchor">#</a>
+    - `username` [string] *(optional)*
       
       Optional username to use if HTTP proxy requires authentication.
-    - `password` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-server-option-password"/><a href="#browser-type-launch-server-option-password" class="list-anchor">#</a>
+    - `password` [string] *(optional)*
       
       Optional password to use if HTTP proxy requires authentication.
     

--- a/nodejs/docs/api/class-electron.mdx
+++ b/nodejs/docs/api/class-electron.mdx
@@ -100,26 +100,26 @@ await electron.launch(options);
     
     An object containing additional HTTP headers to be sent with every request. Defaults to none.
   - `geolocation` [Object] *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-geolocation"/><a href="#electron-launch-option-geolocation" class="list-anchor">#</a>
-    - `latitude` [number] <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-latitude"/><a href="#electron-launch-option-latitude" class="list-anchor">#</a>
+    - `latitude` [number]
       
       Latitude between -90 and 90.
-    - `longitude` [number] <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-longitude"/><a href="#electron-launch-option-longitude" class="list-anchor">#</a>
+    - `longitude` [number]
       
       Longitude between -180 and 180.
-    - `accuracy` [number] *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-accuracy"/><a href="#electron-launch-option-accuracy" class="list-anchor">#</a>
+    - `accuracy` [number] *(optional)*
       
       Non-negative accuracy value. Defaults to `0`.
   - `httpCredentials` [Object] *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-http-credentials"/><a href="#electron-launch-option-http-credentials" class="list-anchor">#</a>
-    - `username` [string] <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-username"/><a href="#electron-launch-option-username" class="list-anchor">#</a>
+    - `username` [string]
       
       
-    - `password` [string] <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-password"/><a href="#electron-launch-option-password" class="list-anchor">#</a>
+    - `password` [string]
       
       
-    - `origin` [string] *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-origin"/><a href="#electron-launch-option-origin" class="list-anchor">#</a>
+    - `origin` [string] *(optional)*
       
       Restrain sending http credentials on specific origin (scheme://host:port).
-    - `send` "unauthorized" | "always" *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-send"/><a href="#electron-launch-option-send" class="list-anchor">#</a>
+    - `send` "unauthorized" | "always" *(optional)*
       
       This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
     
@@ -134,32 +134,32 @@ await electron.launch(options);
     
     Whether to emulate network being offline. Defaults to `false`. Learn more about [network emulation](../emulation.mdx#offline).
   - `recordHar` [Object] *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-record-har"/><a href="#electron-launch-option-record-har" class="list-anchor">#</a>
-    - `omitContent` [boolean] *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-omit-content"/><a href="#electron-launch-option-omit-content" class="list-anchor">#</a>
+    - `omitContent` [boolean] *(optional)*
       
       Optional setting to control whether to omit request content from the HAR. Defaults to `false`. Deprecated, use `content` policy instead.
-    - `content` "omit" | "embed" | "attach" *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-content"/><a href="#electron-launch-option-content" class="list-anchor">#</a>
+    - `content` "omit" | "embed" | "attach" *(optional)*
       
       Optional setting to control resource content management. If `omit` is specified, content is not persisted. If `attach` is specified, resources are persisted as separate files or entries in the ZIP archive. If `embed` is specified, content is stored inline the HAR file as per HAR specification. Defaults to `attach` for `.zip` output files and to `embed` for all other file extensions.
-    - `path` [string] <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-path"/><a href="#electron-launch-option-path" class="list-anchor">#</a>
+    - `path` [string]
       
       Path on the filesystem to write the HAR file to. If the file name ends with `.zip`, `content: 'attach'` is used by default.
-    - `mode` "full" | "minimal" *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-mode"/><a href="#electron-launch-option-mode" class="list-anchor">#</a>
+    - `mode` "full" | "minimal" *(optional)*
       
       When set to `minimal`, only record information necessary for routing from HAR. This omits sizes, timing, page, cookies, security and other types of HAR information that are not used when replaying from HAR. Defaults to `full`.
-    - `urlFilter` [string] | [RegExp] *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-url-filter"/><a href="#electron-launch-option-url-filter" class="list-anchor">#</a>
+    - `urlFilter` [string] | [RegExp] *(optional)*
       
       A glob or regex pattern to filter requests that are stored in the HAR. When a `baseURL` via the context options was provided and the passed URL is a path, it gets merged via the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor. Defaults to none.
     
     Enables [HAR](http://www.softwareishard.com/blog/har-12-spec) recording for all pages into `recordHar.path` file. If not specified, the HAR is not recorded. Make sure to await [browserContext.close()](/api/class-browsercontext.mdx#browser-context-close) for the HAR to be saved.
   - `recordVideo` [Object] *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-record-video"/><a href="#electron-launch-option-record-video" class="list-anchor">#</a>
-    - `dir` [string] <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-dir"/><a href="#electron-launch-option-dir" class="list-anchor">#</a>
+    - `dir` [string]
       
       Path to the directory to put videos into.
-    - `size` [Object] *(optional)* <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-size"/><a href="#electron-launch-option-size" class="list-anchor">#</a>
-      - `width` [number] <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-width"/><a href="#electron-launch-option-width" class="list-anchor">#</a>
+    - `size` [Object] *(optional)*
+      - `width` [number]
         
         Video frame width.
-      - `height` [number] <font size="2">Added in: v1.12</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-launch-option-height"/><a href="#electron-launch-option-height" class="list-anchor">#</a>
+      - `height` [number]
         
         Video frame height.
       

--- a/nodejs/docs/api/class-electronapplication.mdx
+++ b/nodejs/docs/api/class-electronapplication.mdx
@@ -223,10 +223,10 @@ const window = await windowPromise;
   
   Event name, same one typically passed into `*.on(event)`.
 - `optionsOrPredicate` [function] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-application-wait-for-event-option-options-or-predicate"/><a href="#electron-application-wait-for-event-option-options-or-predicate" class="list-anchor">#</a>
-  - `predicate` [function]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-application-wait-for-event-option-predicate"/><a href="#electron-application-wait-for-event-option-predicate" class="list-anchor">#</a>
+  - `predicate` [function]
     
     receives the event data and resolves to truthy value when the waiting should resolve.
-  - `timeout` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="electron-application-wait-for-event-option-timeout"/><a href="#electron-application-wait-for-event-option-timeout" class="list-anchor">#</a>
+  - `timeout` [number] *(optional)*
     
     maximum time to wait for in milliseconds. Defaults to `30000` (30 seconds). Pass `0` to disable timeout. The default value can be changed by using the [browserContext.setDefaultTimeout()](/api/class-browsercontext.mdx#browser-context-set-default-timeout).
   

--- a/nodejs/docs/api/class-elementhandle.mdx
+++ b/nodejs/docs/api/class-elementhandle.mdx
@@ -348,10 +348,10 @@ await elementHandle.check(options);
     
     This option has no effect.
   - `position` [Object] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-position"/><a href="#element-handle-check-option-position" class="list-anchor">#</a>
-    - `x` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-x"/><a href="#element-handle-check-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-y"/><a href="#element-handle-check-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -421,10 +421,10 @@ await elementHandle.click(options);
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-position"/><a href="#element-handle-click-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-x"/><a href="#element-handle-click-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-y"/><a href="#element-handle-click-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -494,10 +494,10 @@ await elementHandle.dblclick(options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-position"/><a href="#element-handle-dblclick-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-x"/><a href="#element-handle-dblclick-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-y"/><a href="#element-handle-dblclick-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -713,10 +713,10 @@ await elementHandle.hover(options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-position"/><a href="#element-handle-hover-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-x"/><a href="#element-handle-hover-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-y"/><a href="#element-handle-hover-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1154,13 +1154,13 @@ handle.selectOption(['red', 'green', 'blue']);
 
 **Arguments**
 - `values` [null] | [string] | [ElementHandle] | [Array]&lt;[string]&gt; | [Object] | [Array]&lt;[ElementHandle]&gt; | [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-values"/><a href="#element-handle-select-option-option-values" class="list-anchor">#</a>
-  - `value` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-value"/><a href="#element-handle-select-option-option-value" class="list-anchor">#</a>
+  - `value` [string] *(optional)*
     
     Matches by `option.value`. Optional.
-  - `label` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-label"/><a href="#element-handle-select-option-option-label" class="list-anchor">#</a>
+  - `label` [string] *(optional)*
     
     Matches by `option.label`. Optional.
-  - `index` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-select-option-option-index"/><a href="#element-handle-select-option-option-index" class="list-anchor">#</a>
+  - `index` [number] *(optional)*
     
     Matches by the index. Optional.
   
@@ -1267,10 +1267,10 @@ await elementHandle.setChecked(checked, options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-position"/><a href="#element-handle-set-checked-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-x"/><a href="#element-handle-set-checked-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-y"/><a href="#element-handle-set-checked-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1310,13 +1310,13 @@ await elementHandle.setInputFiles(files, options);
 
 **Arguments**
 - `files` [string] | [Array]&lt;[string]&gt; | [Object] | [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-files"/><a href="#element-handle-set-input-files-option-files" class="list-anchor">#</a>
-  - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-name"/><a href="#element-handle-set-input-files-option-name" class="list-anchor">#</a>
+  - `name` [string]
     
     File name
-  - `mimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-mime-type"/><a href="#element-handle-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [string]
     
     File type
-  - `buffer` [Buffer]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-buffer"/><a href="#element-handle-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `buffer` [Buffer]
     
     File content
 - `options` [Object] *(optional)*
@@ -1385,10 +1385,10 @@ await elementHandle.tap(options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-position"/><a href="#element-handle-tap-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-x"/><a href="#element-handle-tap-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-y"/><a href="#element-handle-tap-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1513,10 +1513,10 @@ await elementHandle.uncheck(options);
     
     This option has no effect.
   - `position` [Object] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-position"/><a href="#element-handle-uncheck-option-position" class="list-anchor">#</a>
-    - `x` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-x"/><a href="#element-handle-uncheck-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-y"/><a href="#element-handle-uncheck-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/nodejs/docs/api/class-filechooser.mdx
+++ b/nodejs/docs/api/class-filechooser.mdx
@@ -88,13 +88,13 @@ await fileChooser.setFiles(files, options);
 
 **Arguments**
 - `files` [string] | [Array]&lt;[string]&gt; | [Object] | [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-files"/><a href="#file-chooser-set-files-option-files" class="list-anchor">#</a>
-  - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-name"/><a href="#file-chooser-set-files-option-name" class="list-anchor">#</a>
+  - `name` [string]
     
     File name
-  - `mimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-mime-type"/><a href="#file-chooser-set-files-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [string]
     
     File type
-  - `buffer` [Buffer]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-buffer"/><a href="#file-chooser-set-files-option-buffer" class="list-anchor">#</a>
+  - `buffer` [Buffer]
     
     File content
 - `options` [Object] *(optional)*

--- a/nodejs/docs/api/class-frame.mdx
+++ b/nodejs/docs/api/class-frame.mdx
@@ -169,10 +169,10 @@ await frame.dragAndDrop(source, target, options);
     
     This option has no effect.
   - `sourcePosition` [Object] *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-source-position"/><a href="#frame-drag-and-drop-option-source-position" class="list-anchor">#</a>
-    - `x` [number] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-x"/><a href="#frame-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-y"/><a href="#frame-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -180,10 +180,10 @@ await frame.dragAndDrop(source, target, options);
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `targetPosition` [Object] *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-target-position"/><a href="#frame-drag-and-drop-option-target-position" class="list-anchor">#</a>
-    - `x` [number] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-x"/><a href="#frame-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-y"/><a href="#frame-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -1270,10 +1270,10 @@ await frame.check(selector, options);
     
     This option has no effect.
   - `position` [Object] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-position"/><a href="#frame-check-option-position" class="list-anchor">#</a>
-    - `x` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-x"/><a href="#frame-check-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-y"/><a href="#frame-check-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1348,10 +1348,10 @@ await frame.click(selector, options);
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-position"/><a href="#frame-click-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-x"/><a href="#frame-click-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-y"/><a href="#frame-click-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1426,10 +1426,10 @@ await frame.dblclick(selector, options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-position"/><a href="#frame-dblclick-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-x"/><a href="#frame-dblclick-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-y"/><a href="#frame-dblclick-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1690,10 +1690,10 @@ await frame.hover(selector, options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-position"/><a href="#frame-hover-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-x"/><a href="#frame-hover-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-y"/><a href="#frame-hover-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2114,13 +2114,13 @@ frame.selectOption('select#colors', 'red', 'green', 'blue');
   
   A selector to query for.
 - `values` [null] | [string] | [ElementHandle] | [Array]&lt;[string]&gt; | [Object] | [Array]&lt;[ElementHandle]&gt; | [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-values"/><a href="#frame-select-option-option-values" class="list-anchor">#</a>
-  - `value` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-value"/><a href="#frame-select-option-option-value" class="list-anchor">#</a>
+  - `value` [string] *(optional)*
     
     Matches by `option.value`. Optional.
-  - `label` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-label"/><a href="#frame-select-option-option-label" class="list-anchor">#</a>
+  - `label` [string] *(optional)*
     
     Matches by `option.label`. Optional.
-  - `index` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-select-option-option-index"/><a href="#frame-select-option-option-index" class="list-anchor">#</a>
+  - `index` [number] *(optional)*
     
     Matches by the index. Optional.
   
@@ -2198,10 +2198,10 @@ await frame.setChecked(selector, checked, options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-position"/><a href="#frame-set-checked-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-x"/><a href="#frame-set-checked-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-y"/><a href="#frame-set-checked-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2247,13 +2247,13 @@ await frame.setInputFiles(selector, files, options);
   
   A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
 - `files` [string] | [Array]&lt;[string]&gt; | [Object] | [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-files"/><a href="#frame-set-input-files-option-files" class="list-anchor">#</a>
-  - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-name"/><a href="#frame-set-input-files-option-name" class="list-anchor">#</a>
+  - `name` [string]
     
     File name
-  - `mimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-mime-type"/><a href="#frame-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [string]
     
     File type
-  - `buffer` [Buffer]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-buffer"/><a href="#frame-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `buffer` [Buffer]
     
     File content
 - `options` [Object] *(optional)*
@@ -2327,10 +2327,10 @@ await frame.tap(selector, options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-position"/><a href="#frame-tap-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-x"/><a href="#frame-tap-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-y"/><a href="#frame-tap-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2479,10 +2479,10 @@ await frame.uncheck(selector, options);
     
     This option has no effect.
   - `position` [Object] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-position"/><a href="#frame-uncheck-option-position" class="list-anchor">#</a>
-    - `x` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-x"/><a href="#frame-uncheck-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-y"/><a href="#frame-uncheck-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/nodejs/docs/api/class-locator.mdx
+++ b/nodejs/docs/api/class-locator.mdx
@@ -198,10 +198,10 @@ await page.getByRole('checkbox').check();
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-position"/><a href="#locator-check-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-x"/><a href="#locator-check-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-y"/><a href="#locator-check-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -320,10 +320,10 @@ await page.locator('canvas').click({
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-position"/><a href="#locator-click-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-x"/><a href="#locator-click-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-y"/><a href="#locator-click-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -432,10 +432,10 @@ await locator.dblclick(options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-position"/><a href="#locator-dblclick-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-x"/><a href="#locator-dblclick-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-y"/><a href="#locator-dblclick-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -558,18 +558,18 @@ await source.dragTo(target, {
     
     This option has no effect.
   - `sourcePosition` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-source-position"/><a href="#locator-drag-to-option-source-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-x"/><a href="#locator-drag-to-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-y"/><a href="#locator-drag-to-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
   - `targetPosition` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-target-position"/><a href="#locator-drag-to-option-target-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-x"/><a href="#locator-drag-to-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-y"/><a href="#locator-drag-to-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -1262,10 +1262,10 @@ await page.getByRole('link').hover();
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-position"/><a href="#locator-hover-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-x"/><a href="#locator-hover-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-y"/><a href="#locator-hover-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1903,13 +1903,13 @@ element.selectOption(['red', 'green', 'blue']);
 
 **Arguments**
 - `values` [null] | [string] | [ElementHandle] | [Array]&lt;[string]&gt; | [Object] | [Array]&lt;[ElementHandle]&gt; | [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-values"/><a href="#locator-select-option-option-values" class="list-anchor">#</a>
-  - `value` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-value"/><a href="#locator-select-option-option-value" class="list-anchor">#</a>
+  - `value` [string] *(optional)*
     
     Matches by `option.value`. Optional.
-  - `label` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-label"/><a href="#locator-select-option-option-label" class="list-anchor">#</a>
+  - `label` [string] *(optional)*
     
     Matches by `option.label`. Optional.
-  - `index` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-select-option-option-index"/><a href="#locator-select-option-option-index" class="list-anchor">#</a>
+  - `index` [number] *(optional)*
     
     Matches by the index. Optional.
   
@@ -2003,10 +2003,10 @@ await page.getByRole('checkbox').setChecked(true);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-position"/><a href="#locator-set-checked-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-x"/><a href="#locator-set-checked-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-y"/><a href="#locator-set-checked-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2068,13 +2068,13 @@ await page.getByLabel('Upload file').setInputFiles({
 
 **Arguments**
 - `files` [string] | [Array]&lt;[string]&gt; | [Object] | [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-files"/><a href="#locator-set-input-files-option-files" class="list-anchor">#</a>
-  - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-name"/><a href="#locator-set-input-files-option-name" class="list-anchor">#</a>
+  - `name` [string]
     
     File name
-  - `mimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-mime-type"/><a href="#locator-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [string]
     
     File type
-  - `buffer` [Buffer]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-buffer"/><a href="#locator-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `buffer` [Buffer]
     
     File content
 - `options` [Object] *(optional)*
@@ -2131,10 +2131,10 @@ await locator.tap(options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-position"/><a href="#locator-tap-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-x"/><a href="#locator-tap-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-y"/><a href="#locator-tap-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2219,10 +2219,10 @@ await page.getByRole('checkbox').uncheck();
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-position"/><a href="#locator-uncheck-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-x"/><a href="#locator-uncheck-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-y"/><a href="#locator-uncheck-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/nodejs/docs/api/class-logger.mdx
+++ b/nodejs/docs/api/class-logger.mdx
@@ -73,7 +73,7 @@ logger.log(name, severity, message, args, hints);
   
   message arguments
 - `hints` [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="logger-log-option-hints"/><a href="#logger-log-option-hints" class="list-anchor">#</a>
-  - `color` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="logger-log-option-color"/><a href="#logger-log-option-color" class="list-anchor">#</a>
+  - `color` [string] *(optional)*
     
     Optional preferred logger color.
   

--- a/nodejs/docs/api/class-page.mdx
+++ b/nodejs/docs/api/class-page.mdx
@@ -84,10 +84,10 @@ The order of evaluation of multiple scripts installed via [browserContext.addIni
 
 **Arguments**
 - `script` [function] | [string] | [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-add-init-script-option-script"/><a href="#page-add-init-script-option-script" class="list-anchor">#</a>
-  - `path` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-add-init-script-option-path"/><a href="#page-add-init-script-option-path" class="list-anchor">#</a>
+  - `path` [string] *(optional)*
     
     Path to the JavaScript file. If `path` is a relative path, then it is resolved relative to the current working directory. Optional.
-  - `content` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-add-init-script-option-content"/><a href="#page-add-init-script-option-content" class="list-anchor">#</a>
+  - `content` [string] *(optional)*
     
     Raw script content. Optional.
   
@@ -373,10 +373,10 @@ await page.dragAndDrop('#source', '#target', {
     
     This option has no effect.
   - `sourcePosition` [Object] *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-source-position"/><a href="#page-drag-and-drop-option-source-position" class="list-anchor">#</a>
-    - `x` [number] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-x"/><a href="#page-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-y"/><a href="#page-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -384,10 +384,10 @@ await page.dragAndDrop('#source', '#target', {
     
     When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
   - `targetPosition` [Object] *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-target-position"/><a href="#page-drag-and-drop-option-target-position" class="list-anchor">#</a>
-    - `x` [number] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-x"/><a href="#page-drag-and-drop-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-y"/><a href="#page-drag-and-drop-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -690,10 +690,10 @@ const frame = page.frame({ url: /.*domain.*/ });
 
 **Arguments**
 - `frameSelector` [string] | [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-frame-option-frame-selector"/><a href="#page-frame-option-frame-selector" class="list-anchor">#</a>
-  - `name` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-frame-option-name"/><a href="#page-frame-option-name" class="list-anchor">#</a>
+  - `name` [string] *(optional)*
     
     Frame name specified in the `iframe`'s `name` attribute. Optional.
-  - `url` [string] | [RegExp] | [function]\([URL]\):[boolean] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-frame-option-url"/><a href="#page-frame-option-url" class="list-anchor">#</a>
+  - `url` [string] | [RegExp] | [function]\([URL]\):[boolean] *(optional)*
     
     A glob pattern, regex pattern or predicate receiving frame's `url` as a [URL] object. Optional.
   
@@ -1394,16 +1394,16 @@ The `format` options are:
     
     Paper orientation. Defaults to `false`.
   - `margin` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-margin"/><a href="#page-pdf-option-margin" class="list-anchor">#</a>
-    - `top` [string] | [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-top"/><a href="#page-pdf-option-top" class="list-anchor">#</a>
+    - `top` [string] | [number] *(optional)*
       
       Top margin, accepts values labeled with units. Defaults to `0`.
-    - `right` [string] | [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-right"/><a href="#page-pdf-option-right" class="list-anchor">#</a>
+    - `right` [string] | [number] *(optional)*
       
       Right margin, accepts values labeled with units. Defaults to `0`.
-    - `bottom` [string] | [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-bottom"/><a href="#page-pdf-option-bottom" class="list-anchor">#</a>
+    - `bottom` [string] | [number] *(optional)*
       
       Bottom margin, accepts values labeled with units. Defaults to `0`.
-    - `left` [string] | [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-left"/><a href="#page-pdf-option-left" class="list-anchor">#</a>
+    - `left` [string] | [number] *(optional)*
       
       Left margin, accepts values labeled with units. Defaults to `0`.
     
@@ -1664,16 +1664,16 @@ await page.screenshot(options);
     
     When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be changed.  Defaults to `"hide"`.
   - `clip` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-clip"/><a href="#page-screenshot-option-clip" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-x"/><a href="#page-screenshot-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       x-coordinate of top-left corner of clip area
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-y"/><a href="#page-screenshot-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       y-coordinate of top-left corner of clip area
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-width"/><a href="#page-screenshot-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       width of clipping area
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-height"/><a href="#page-screenshot-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       height of clipping area
     
@@ -1850,10 +1850,10 @@ await page.goto('https://example.com');
 
 **Arguments**
 - `viewportSize` [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-viewport-size-option-viewport-size"/><a href="#page-set-viewport-size-option-viewport-size" class="list-anchor">#</a>
-  - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-viewport-size-option-width"/><a href="#page-set-viewport-size-option-width" class="list-anchor">#</a>
+  - `width` [number]
     
     page width in pixels.
-  - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-viewport-size-option-height"/><a href="#page-set-viewport-size-option-height" class="list-anchor">#</a>
+  - `height` [number]
     
     page height in pixels.
 
@@ -2005,10 +2005,10 @@ const download = await downloadPromise;
   
   Event name, same one typically passed into `*.on(event)`.
 - `optionsOrPredicate` [function] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-wait-for-event-option-options-or-predicate"/><a href="#page-wait-for-event-option-options-or-predicate" class="list-anchor">#</a>
-  - `predicate` [function]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-wait-for-event-option-predicate"/><a href="#page-wait-for-event-option-predicate" class="list-anchor">#</a>
+  - `predicate` [function]
     
     Receives the event data and resolves to truthy value when the waiting should resolve.
-  - `timeout` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-wait-for-event-option-timeout"/><a href="#page-wait-for-event-option-timeout" class="list-anchor">#</a>
+  - `timeout` [number] *(optional)*
     
     Maximum time to wait for in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout` option in the config, or by using the [browserContext.setDefaultTimeout()](/api/class-browsercontext.mdx#browser-context-set-default-timeout) or [page.setDefaultTimeout()](/api/class-page.mdx#page-set-default-timeout) methods.
   
@@ -2951,10 +2951,10 @@ await page.check(selector, options);
     
     This option has no effect.
   - `position` [Object] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-position"/><a href="#page-check-option-position" class="list-anchor">#</a>
-    - `x` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-x"/><a href="#page-check-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-y"/><a href="#page-check-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3029,10 +3029,10 @@ await page.click(selector, options);
     
     Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-position"/><a href="#page-click-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-x"/><a href="#page-click-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-y"/><a href="#page-click-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3107,10 +3107,10 @@ await page.dblclick(selector, options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-position"/><a href="#page-dblclick-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-x"/><a href="#page-dblclick-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-y"/><a href="#page-dblclick-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3371,10 +3371,10 @@ await page.hover(selector, options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-position"/><a href="#page-hover-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-x"/><a href="#page-hover-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-y"/><a href="#page-hover-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3842,13 +3842,13 @@ page.selectOption('select#colors', ['red', 'green', 'blue']);
   
   A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
 - `values` [null] | [string] | [ElementHandle] | [Array]&lt;[string]&gt; | [Object] | [Array]&lt;[ElementHandle]&gt; | [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-values"/><a href="#page-select-option-option-values" class="list-anchor">#</a>
-  - `value` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-value"/><a href="#page-select-option-option-value" class="list-anchor">#</a>
+  - `value` [string] *(optional)*
     
     Matches by `option.value`. Optional.
-  - `label` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-label"/><a href="#page-select-option-option-label" class="list-anchor">#</a>
+  - `label` [string] *(optional)*
     
     Matches by `option.label`. Optional.
-  - `index` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-select-option-option-index"/><a href="#page-select-option-option-index" class="list-anchor">#</a>
+  - `index` [number] *(optional)*
     
     Matches by the index. Optional.
   
@@ -3926,10 +3926,10 @@ await page.setChecked(selector, checked, options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-position"/><a href="#page-set-checked-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-x"/><a href="#page-set-checked-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-y"/><a href="#page-set-checked-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3975,13 +3975,13 @@ await page.setInputFiles(selector, files, options);
   
   A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
 - `files` [string] | [Array]&lt;[string]&gt; | [Object] | [Array]&lt;[Object]&gt;<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-files"/><a href="#page-set-input-files-option-files" class="list-anchor">#</a>
-  - `name` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-name"/><a href="#page-set-input-files-option-name" class="list-anchor">#</a>
+  - `name` [string]
     
     File name
-  - `mimeType` [string]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-mime-type"/><a href="#page-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [string]
     
     File type
-  - `buffer` [Buffer]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-buffer"/><a href="#page-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `buffer` [Buffer]
     
     File content
 - `options` [Object] *(optional)*
@@ -4055,10 +4055,10 @@ await page.tap(selector, options);
     
     This option has no effect.
   - `position` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-position"/><a href="#page-tap-option-position" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-x"/><a href="#page-tap-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-y"/><a href="#page-tap-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -4207,10 +4207,10 @@ await page.uncheck(selector, options);
     
     This option has no effect.
   - `position` [Object] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-position"/><a href="#page-uncheck-option-position" class="list-anchor">#</a>
-    - `x` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-x"/><a href="#page-uncheck-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       
-    - `y` [number] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-y"/><a href="#page-uncheck-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       
     A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/nodejs/docs/api/class-pageassertions.mdx
+++ b/nodejs/docs/api/class-pageassertions.mdx
@@ -54,16 +54,16 @@ Note that screenshot assertions only work with Playwright test runner.
     
     When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be changed.  Defaults to `"hide"`.
   - `clip` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-assertions-to-have-screenshot-1-option-clip"/><a href="#page-assertions-to-have-screenshot-1-option-clip" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-assertions-to-have-screenshot-1-option-x"/><a href="#page-assertions-to-have-screenshot-1-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       x-coordinate of top-left corner of clip area
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-assertions-to-have-screenshot-1-option-y"/><a href="#page-assertions-to-have-screenshot-1-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       y-coordinate of top-left corner of clip area
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-assertions-to-have-screenshot-1-option-width"/><a href="#page-assertions-to-have-screenshot-1-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       width of clipping area
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-assertions-to-have-screenshot-1-option-height"/><a href="#page-assertions-to-have-screenshot-1-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       height of clipping area
     
@@ -133,16 +133,16 @@ Note that screenshot assertions only work with Playwright test runner.
     
     When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be changed.  Defaults to `"hide"`.
   - `clip` [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-assertions-to-have-screenshot-2-option-clip"/><a href="#page-assertions-to-have-screenshot-2-option-clip" class="list-anchor">#</a>
-    - `x` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-assertions-to-have-screenshot-2-option-x"/><a href="#page-assertions-to-have-screenshot-2-option-x" class="list-anchor">#</a>
+    - `x` [number]
       
       x-coordinate of top-left corner of clip area
-    - `y` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-assertions-to-have-screenshot-2-option-y"/><a href="#page-assertions-to-have-screenshot-2-option-y" class="list-anchor">#</a>
+    - `y` [number]
       
       y-coordinate of top-left corner of clip area
-    - `width` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-assertions-to-have-screenshot-2-option-width"/><a href="#page-assertions-to-have-screenshot-2-option-width" class="list-anchor">#</a>
+    - `width` [number]
       
       width of clipping area
-    - `height` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-assertions-to-have-screenshot-2-option-height"/><a href="#page-assertions-to-have-screenshot-2-option-height" class="list-anchor">#</a>
+    - `height` [number]
       
       height of clipping area
     

--- a/nodejs/docs/api/class-reporter.mdx
+++ b/nodejs/docs/api/class-reporter.mdx
@@ -153,13 +153,13 @@ await reporter.onEnd(result);
 
 **Arguments**
 - `result` [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="reporter-on-end-option-result"/><a href="#reporter-on-end-option-result" class="list-anchor">#</a>
-  - `status` "passed" | "failed" | "timedout" | "interrupted"<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="reporter-on-end-option-status"/><a href="#reporter-on-end-option-status" class="list-anchor">#</a>
+  - `status` "passed" | "failed" | "timedout" | "interrupted"
     
     Test run status.
-  - `startTime` [Date]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="reporter-on-end-option-start-time"/><a href="#reporter-on-end-option-start-time" class="list-anchor">#</a>
+  - `startTime` [Date]
     
     Test run start wall time.
-  - `duration` [number]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="reporter-on-end-option-duration"/><a href="#reporter-on-end-option-duration" class="list-anchor">#</a>
+  - `duration` [number]
     
     Test run duration in milliseconds.
   

--- a/nodejs/docs/api/class-selectors.mdx
+++ b/nodejs/docs/api/class-selectors.mdx
@@ -64,10 +64,10 @@ const { selectors, firefox } = require('@playwright/test');  // Or 'chromium' or
   
   Name that is used in selectors as a prefix, e.g. `{name: 'foo'}` enables `foo=myselectorbody` selectors. May only contain `[a-zA-Z0-9_]` characters.
 - `script` [function] | [string] | [Object]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="selectors-register-option-script"/><a href="#selectors-register-option-script" class="list-anchor">#</a>
-  - `path` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="selectors-register-option-path"/><a href="#selectors-register-option-path" class="list-anchor">#</a>
+  - `path` [string] *(optional)*
     
     Path to the JavaScript file. If `path` is a relative path, then it is resolved relative to the current working directory. Optional.
-  - `content` [string] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="selectors-register-option-content"/><a href="#selectors-register-option-content" class="list-anchor">#</a>
+  - `content` [string] *(optional)*
     
     Raw script content. Optional.
   

--- a/nodejs/docs/api/class-test.mdx
+++ b/nodejs/docs/api/class-test.mdx
@@ -100,14 +100,14 @@ Learn more about [test annotations](../test-annotations.mdx).
   
   Test title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-call-option-details"/><a href="#test-call-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-call-option-tag"/><a href="#test-call-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-call-option-annotation"/><a href="#test-call-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-call-option-type"/><a href="#test-call-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       Annotation type, for example `'issue'`.
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-call-option-description"/><a href="#test-call-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       Optional annotation description, for example an issue url.
     
@@ -424,14 +424,14 @@ Learn more about [test annotations](../test-annotations.mdx).
   
   Group title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-option-details"/><a href="#test-describe-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-option-tag"/><a href="#test-describe-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-option-annotation"/><a href="#test-describe-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-option-type"/><a href="#test-describe-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-option-description"/><a href="#test-describe-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     
@@ -546,14 +546,14 @@ test.describe.fixme(() => {
   
   Group title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-fixme-option-details"/><a href="#test-describe-fixme-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-fixme-option-tag"/><a href="#test-describe-fixme-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-fixme-option-annotation"/><a href="#test-describe-fixme-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-fixme-option-type"/><a href="#test-describe-fixme-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-fixme-option-description"/><a href="#test-describe-fixme-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     
@@ -599,14 +599,14 @@ test.describe.only(() => {
   
   Group title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-only-option-details"/><a href="#test-describe-only-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-only-option-tag"/><a href="#test-describe-only-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-only-option-annotation"/><a href="#test-describe-only-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-only-option-type"/><a href="#test-describe-only-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-only-option-description"/><a href="#test-describe-only-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     
@@ -649,14 +649,14 @@ test.describe.skip(() => {
   
   Group title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-skip-option-details"/><a href="#test-describe-skip-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-skip-option-tag"/><a href="#test-describe-skip-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-skip-option-annotation"/><a href="#test-describe-skip-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-skip-option-type"/><a href="#test-describe-skip-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-skip-option-description"/><a href="#test-describe-skip-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     
@@ -884,14 +884,14 @@ test('less readable', async ({ page }) => {
   
   Test title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-fail-option-details"/><a href="#test-fail-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-fail-option-tag"/><a href="#test-fail-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-fail-option-annotation"/><a href="#test-fail-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-fail-option-type"/><a href="#test-fail-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-fail-option-description"/><a href="#test-fail-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     
@@ -980,14 +980,14 @@ test('less readable', async ({ page }) => {
   
   Test title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-fixme-option-details"/><a href="#test-fixme-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-fixme-option-tag"/><a href="#test-fixme-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-fixme-option-annotation"/><a href="#test-fixme-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-fixme-option-type"/><a href="#test-fixme-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-fixme-option-description"/><a href="#test-fixme-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     
@@ -1051,14 +1051,14 @@ test.only('focus this test', async ({ page }) => {
   
   Test title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-only-option-details"/><a href="#test-only-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-only-option-tag"/><a href="#test-only-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-only-option-annotation"/><a href="#test-only-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-only-option-type"/><a href="#test-only-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-only-option-description"/><a href="#test-only-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     
@@ -1196,14 +1196,14 @@ test('less readable', async ({ page }) => {
   
   Test title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-skip-option-details"/><a href="#test-skip-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-skip-option-tag"/><a href="#test-skip-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-skip-option-annotation"/><a href="#test-skip-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-skip-option-type"/><a href="#test-skip-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-skip-option-description"/><a href="#test-skip-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     
@@ -1566,14 +1566,14 @@ test.describe.parallel(() => {
   
   Group title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-parallel-option-details"/><a href="#test-describe-parallel-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-parallel-option-tag"/><a href="#test-describe-parallel-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-parallel-option-annotation"/><a href="#test-describe-parallel-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-parallel-option-type"/><a href="#test-describe-parallel-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-parallel-option-description"/><a href="#test-describe-parallel-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     
@@ -1622,14 +1622,14 @@ test.describe.parallel.only(() => {
   
   Group title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-parallel-only-option-details"/><a href="#test-describe-parallel-only-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-parallel-only-option-tag"/><a href="#test-describe-parallel-only-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-parallel-only-option-annotation"/><a href="#test-describe-parallel-only-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-parallel-only-option-type"/><a href="#test-describe-parallel-only-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-parallel-only-option-description"/><a href="#test-describe-parallel-only-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     
@@ -1683,14 +1683,14 @@ test.describe.serial(() => {
   
   Group title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-serial-option-details"/><a href="#test-describe-serial-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-serial-option-tag"/><a href="#test-describe-serial-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-serial-option-annotation"/><a href="#test-describe-serial-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-serial-option-type"/><a href="#test-describe-serial-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-serial-option-description"/><a href="#test-describe-serial-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     
@@ -1746,14 +1746,14 @@ test.describe.serial.only(() => {
   
   Group title.
 - `details` [Object] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-serial-only-option-details"/><a href="#test-describe-serial-only-option-details" class="list-anchor">#</a>
-  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-serial-only-option-tag"/><a href="#test-describe-serial-only-option-tag" class="list-anchor">#</a>
+  - `tag` [string] | [Array]&lt;[string]&gt; *(optional)*
     
     
-  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-serial-only-option-annotation"/><a href="#test-describe-serial-only-option-annotation" class="list-anchor">#</a>
-    - `type` [string] <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-serial-only-option-type"/><a href="#test-describe-serial-only-option-type" class="list-anchor">#</a>
+  - `annotation` [Object] | [Array]&lt;[Object]&gt; *(optional)*
+    - `type` [string]
       
       
-    - `description` [string] *(optional)* <font size="2">Added in: v1.42</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="test-describe-serial-only-option-description"/><a href="#test-describe-serial-only-option-description" class="list-anchor">#</a>
+    - `description` [string] *(optional)*
       
       
     

--- a/nodejs/docs/api/class-websocket.mdx
+++ b/nodejs/docs/api/class-websocket.mdx
@@ -66,10 +66,10 @@ await webSocket.waitForEvent(event, optionsOrPredicate, options);
   
   Event name, same one would pass into `webSocket.on(event)`.
 - `optionsOrPredicate` [function] | [Object] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="web-socket-wait-for-event-option-options-or-predicate"/><a href="#web-socket-wait-for-event-option-options-or-predicate" class="list-anchor">#</a>
-  - `predicate` [function]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="web-socket-wait-for-event-option-predicate"/><a href="#web-socket-wait-for-event-option-predicate" class="list-anchor">#</a>
+  - `predicate` [function]
     
     Receives the event data and resolves to truthy value when the waiting should resolve.
-  - `timeout` [number] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="web-socket-wait-for-event-option-timeout"/><a href="#web-socket-wait-for-event-option-timeout" class="list-anchor">#</a>
+  - `timeout` [number] *(optional)*
     
     Maximum time to wait for in milliseconds. Defaults to `0` - no timeout. The default value can be changed via `actionTimeout` option in the config, or by using the [browserContext.setDefaultTimeout()](/api/class-browsercontext.mdx#browser-context-set-default-timeout) or [page.setDefaultTimeout()](/api/class-page.mdx#page-set-default-timeout) methods.
   

--- a/python/docs/api/class-apirequest.mdx
+++ b/python/docs/api/class-apirequest.mdx
@@ -35,19 +35,19 @@ api_request.new_context(**kwargs)
   * baseURL: `http://localhost:3000/foo/` and sending request to `./bar.html` results in `http://localhost:3000/foo/bar.html`
   * baseURL: `http://localhost:3000/foo` (without trailing slash) and navigating to `./bar.html` results in `http://localhost:3000/bar.html`
 - `client_certificates` [List]\[[Dict]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-client-certificates"/><a href="#api-request-new-context-option-client-certificates" class="list-anchor">#</a>
-  - `origin` [str] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origin"/><a href="#api-request-new-context-option-origin" class="list-anchor">#</a>
+  - `origin` [str]
     
     Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-  - `certPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-cert-path"/><a href="#api-request-new-context-option-cert-path" class="list-anchor">#</a>
+  - `certPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the file with the certificate in PEM format.
-  - `keyPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-key-path"/><a href="#api-request-new-context-option-key-path" class="list-anchor">#</a>
+  - `keyPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the file with the private key in PEM format.
-  - `pfxPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-pfx-path"/><a href="#api-request-new-context-option-pfx-path" class="list-anchor">#</a>
+  - `pfxPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the PFX or PKCS12 encoded private key and certificate chain.
-  - `passphrase` [str] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-passphrase"/><a href="#api-request-new-context-option-passphrase" class="list-anchor">#</a>
+  - `passphrase` [str] *(optional)*
     
     Passphrase for the private key (PEM or PFX).
   
@@ -69,16 +69,16 @@ api_request.new_context(**kwargs)
   
   An object containing additional HTTP headers to be sent with every request. Defaults to none.
 - `http_credentials` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-http-credentials"/><a href="#api-request-new-context-option-http-credentials" class="list-anchor">#</a>
-  - `username` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-username"/><a href="#api-request-new-context-option-username" class="list-anchor">#</a>
+  - `username` [str]
     
     
-  - `password` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-password"/><a href="#api-request-new-context-option-password" class="list-anchor">#</a>
+  - `password` [str]
     
     
-  - `origin` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origin"/><a href="#api-request-new-context-option-origin" class="list-anchor">#</a>
+  - `origin` [str] *(optional)*
     
     Restrain sending http credentials on specific origin (scheme://host:port).
-  - `send` "unauthorized" | "always" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-send"/><a href="#api-request-new-context-option-send" class="list-anchor">#</a>
+  - `send` "unauthorized" | "always" *(optional)*
     
     This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
   
@@ -87,56 +87,56 @@ api_request.new_context(**kwargs)
   
   Whether to ignore HTTPS errors when sending network requests. Defaults to `false`.
 - `proxy` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-proxy"/><a href="#api-request-new-context-option-proxy" class="list-anchor">#</a>
-  - `server` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-server"/><a href="#api-request-new-context-option-server" class="list-anchor">#</a>
+  - `server` [str]
     
     Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-  - `bypass` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-bypass"/><a href="#api-request-new-context-option-bypass" class="list-anchor">#</a>
+  - `bypass` [str] *(optional)*
     
     Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-  - `username` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-username"/><a href="#api-request-new-context-option-username" class="list-anchor">#</a>
+  - `username` [str] *(optional)*
     
     Optional username to use if HTTP proxy requires authentication.
-  - `password` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-password"/><a href="#api-request-new-context-option-password" class="list-anchor">#</a>
+  - `password` [str] *(optional)*
     
     Optional password to use if HTTP proxy requires authentication.
   
   Network proxy settings.
 - `storage_state` [Union]\[[str], [pathlib.Path]\] | [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-storage-state"/><a href="#api-request-new-context-option-storage-state" class="list-anchor">#</a>
-  - `cookies` [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-cookies"/><a href="#api-request-new-context-option-cookies" class="list-anchor">#</a>
-    - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-name"/><a href="#api-request-new-context-option-name" class="list-anchor">#</a>
+  - `cookies` [List]\[[Dict]\]
+    - `name` [str]
       
       
-    - `value` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-value"/><a href="#api-request-new-context-option-value" class="list-anchor">#</a>
+    - `value` [str]
       
       
-    - `domain` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-domain"/><a href="#api-request-new-context-option-domain" class="list-anchor">#</a>
+    - `domain` [str]
       
       
-    - `path` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-path"/><a href="#api-request-new-context-option-path" class="list-anchor">#</a>
+    - `path` [str]
       
       
-    - `expires` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-expires"/><a href="#api-request-new-context-option-expires" class="list-anchor">#</a>
+    - `expires` [float]
       
       Unix time in seconds.
-    - `httpOnly` [bool]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-http-only"/><a href="#api-request-new-context-option-http-only" class="list-anchor">#</a>
+    - `httpOnly` [bool]
       
       
-    - `secure` [bool]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-secure"/><a href="#api-request-new-context-option-secure" class="list-anchor">#</a>
+    - `secure` [bool]
       
       
-    - `sameSite` "Strict" | "Lax" | "None"<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-same-site"/><a href="#api-request-new-context-option-same-site" class="list-anchor">#</a>
+    - `sameSite` "Strict" | "Lax" | "None"
       
       
     
-  - `origins` [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origins"/><a href="#api-request-new-context-option-origins" class="list-anchor">#</a>
-    - `origin` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-origin"/><a href="#api-request-new-context-option-origin" class="list-anchor">#</a>
+  - `origins` [List]\[[Dict]\]
+    - `origin` [str]
       
       
-    - `localStorage` [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-local-storage"/><a href="#api-request-new-context-option-local-storage" class="list-anchor">#</a>
-      - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-name"/><a href="#api-request-new-context-option-name" class="list-anchor">#</a>
+    - `localStorage` [List]\[[Dict]\]
+      - `name` [str]
         
         
-      - `value` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-new-context-option-value"/><a href="#api-request-new-context-option-value" class="list-anchor">#</a>
+      - `value` [str]
         
         
       

--- a/python/docs/api/class-apirequestcontext.mdx
+++ b/python/docs/api/class-apirequestcontext.mdx
@@ -177,13 +177,13 @@ api_request_context.delete(url, **kwargs)
   
   Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
 - `multipart` [Dict]\[[str], [str] | [float] | [bool] | [ReadStream] | [Dict]\] *(optional)* <font size="2">Added in: v1.17</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-delete-option-multipart"/><a href="#api-request-context-delete-option-multipart" class="list-anchor">#</a>
-  - `name` [str] <font size="2">Added in: v1.17</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-delete-option-name"/><a href="#api-request-context-delete-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str] <font size="2">Added in: v1.17</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-delete-option-mime-type"/><a href="#api-request-context-delete-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes] <font size="2">Added in: v1.17</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-delete-option-buffer"/><a href="#api-request-context-delete-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
   
@@ -284,13 +284,13 @@ api_request_context.fetch(
   
   If set changes the fetch method (e.g. [PUT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT) or [POST](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST)). If not specified, GET method is used.
 - `multipart` [Dict]\[[str], [str] | [float] | [bool] | [ReadStream] | [Dict]\] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-fetch-option-multipart"/><a href="#api-request-context-fetch-option-multipart" class="list-anchor">#</a>
-  - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-fetch-option-name"/><a href="#api-request-context-fetch-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-fetch-option-mime-type"/><a href="#api-request-context-fetch-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-fetch-option-buffer"/><a href="#api-request-context-fetch-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
   
@@ -351,13 +351,13 @@ api_request_context.get("https://example.com/api/getText", params=query_params)
   
   Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
 - `multipart` [Dict]\[[str], [str] | [float] | [bool] | [ReadStream] | [Dict]\] *(optional)* <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-get-option-multipart"/><a href="#api-request-context-get-option-multipart" class="list-anchor">#</a>
-  - `name` [str] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-get-option-name"/><a href="#api-request-context-get-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-get-option-mime-type"/><a href="#api-request-context-get-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-get-option-buffer"/><a href="#api-request-context-get-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
   
@@ -413,13 +413,13 @@ api_request_context.head(url, **kwargs)
   
   Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
 - `multipart` [Dict]\[[str], [str] | [float] | [bool] | [ReadStream] | [Dict]\] *(optional)* <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-head-option-multipart"/><a href="#api-request-context-head-option-multipart" class="list-anchor">#</a>
-  - `name` [str] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-head-option-name"/><a href="#api-request-context-head-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-head-option-mime-type"/><a href="#api-request-context-head-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes] <font size="2">Added in: v1.26</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-head-option-buffer"/><a href="#api-request-context-head-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
   
@@ -475,13 +475,13 @@ api_request_context.patch(url, **kwargs)
   
   Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
 - `multipart` [Dict]\[[str], [str] | [float] | [bool] | [ReadStream] | [Dict]\] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-patch-option-multipart"/><a href="#api-request-context-patch-option-multipart" class="list-anchor">#</a>
-  - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-patch-option-name"/><a href="#api-request-context-patch-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-patch-option-mime-type"/><a href="#api-request-context-patch-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-patch-option-buffer"/><a href="#api-request-context-patch-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
   
@@ -566,13 +566,13 @@ api_request_context.post(
   
   Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
 - `multipart` [Dict]\[[str], [str] | [float] | [bool] | [ReadStream] | [Dict]\] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-post-option-multipart"/><a href="#api-request-context-post-option-multipart" class="list-anchor">#</a>
-  - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-post-option-name"/><a href="#api-request-context-post-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-post-option-mime-type"/><a href="#api-request-context-post-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-post-option-buffer"/><a href="#api-request-context-post-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
   
@@ -628,13 +628,13 @@ api_request_context.put(url, **kwargs)
   
   Maximum number of times network errors should be retried. Currently only `ECONNRESET` error is retried. Does not retry based on HTTP response codes. An error will be thrown if the limit is exceeded. Defaults to `0` - no retries.
 - `multipart` [Dict]\[[str], [str] | [float] | [bool] | [ReadStream] | [Dict]\] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-put-option-multipart"/><a href="#api-request-context-put-option-multipart" class="list-anchor">#</a>
-  - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-put-option-name"/><a href="#api-request-context-put-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-put-option-mime-type"/><a href="#api-request-context-put-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="api-request-context-put-option-buffer"/><a href="#api-request-context-put-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
   

--- a/python/docs/api/class-browser.mdx
+++ b/python/docs/api/class-browser.mdx
@@ -181,19 +181,19 @@ await browser.close()
   
   Toggles bypassing page's Content-Security-Policy. Defaults to `false`.
 - `client_certificates` [List]\[[Dict]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-client-certificates"/><a href="#browser-new-context-option-client-certificates" class="list-anchor">#</a>
-  - `origin` [str] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origin"/><a href="#browser-new-context-option-origin" class="list-anchor">#</a>
+  - `origin` [str]
     
     Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-  - `certPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-cert-path"/><a href="#browser-new-context-option-cert-path" class="list-anchor">#</a>
+  - `certPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the file with the certificate in PEM format.
-  - `keyPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-key-path"/><a href="#browser-new-context-option-key-path" class="list-anchor">#</a>
+  - `keyPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the file with the private key in PEM format.
-  - `pfxPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-pfx-path"/><a href="#browser-new-context-option-pfx-path" class="list-anchor">#</a>
+  - `pfxPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the PFX or PKCS12 encoded private key and certificate chain.
-  - `passphrase` [str] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-passphrase"/><a href="#browser-new-context-option-passphrase" class="list-anchor">#</a>
+  - `passphrase` [str] *(optional)*
     
     Passphrase for the private key (PEM or PFX).
   
@@ -224,29 +224,29 @@ await browser.close()
   
   Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [page.emulate_media()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'none'`.
 - `geolocation` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-geolocation"/><a href="#browser-new-context-option-geolocation" class="list-anchor">#</a>
-  - `latitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-latitude"/><a href="#browser-new-context-option-latitude" class="list-anchor">#</a>
+  - `latitude` [float]
     
     Latitude between -90 and 90.
-  - `longitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-longitude"/><a href="#browser-new-context-option-longitude" class="list-anchor">#</a>
+  - `longitude` [float]
     
     Longitude between -180 and 180.
-  - `accuracy` [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-accuracy"/><a href="#browser-new-context-option-accuracy" class="list-anchor">#</a>
+  - `accuracy` [float] *(optional)*
     
     Non-negative accuracy value. Defaults to `0`.
 - `has_touch` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-has-touch"/><a href="#browser-new-context-option-has-touch" class="list-anchor">#</a>
   
   Specifies if viewport supports touch events. Defaults to false. Learn more about [mobile emulation](../emulation.mdx#devices).
 - `http_credentials` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-http-credentials"/><a href="#browser-new-context-option-http-credentials" class="list-anchor">#</a>
-  - `username` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-username"/><a href="#browser-new-context-option-username" class="list-anchor">#</a>
+  - `username` [str]
     
     
-  - `password` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-password"/><a href="#browser-new-context-option-password" class="list-anchor">#</a>
+  - `password` [str]
     
     
-  - `origin` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origin"/><a href="#browser-new-context-option-origin" class="list-anchor">#</a>
+  - `origin` [str] *(optional)*
     
     Restrain sending http credentials on specific origin (scheme://host:port).
-  - `send` "unauthorized" | "always" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-send"/><a href="#browser-new-context-option-send" class="list-anchor">#</a>
+  - `send` "unauthorized" | "always" *(optional)*
     
     This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
   
@@ -273,16 +273,16 @@ await browser.close()
   
   A list of permissions to grant to all pages in this context. See [browser_context.grant_permissions()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
 - `proxy` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-proxy"/><a href="#browser-new-context-option-proxy" class="list-anchor">#</a>
-  - `server` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-server"/><a href="#browser-new-context-option-server" class="list-anchor">#</a>
+  - `server` [str]
     
     Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-  - `bypass` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-bypass"/><a href="#browser-new-context-option-bypass" class="list-anchor">#</a>
+  - `bypass` [str] *(optional)*
     
     Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-  - `username` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-username"/><a href="#browser-new-context-option-username" class="list-anchor">#</a>
+  - `username` [str] *(optional)*
     
     Optional username to use if HTTP proxy requires authentication.
-  - `password` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-password"/><a href="#browser-new-context-option-password" class="list-anchor">#</a>
+  - `password` [str] *(optional)*
     
     Optional password to use if HTTP proxy requires authentication.
   
@@ -309,10 +309,10 @@ await browser.close()
   
   Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure to call [browser_context.close()](/api/class-browsercontext.mdx#browser-context-close) for videos to be saved.
 - `record_video_size` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-record-video-size"/><a href="#browser-new-context-option-record-video-size" class="list-anchor">#</a>
-  - `width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+  - `width` [int]
     
     Video frame width.
-  - `height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+  - `height` [int]
     
     Video frame height.
   
@@ -321,10 +321,10 @@ await browser.close()
   
   Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [page.emulate_media()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'no-preference'`.
 - `screen` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-screen"/><a href="#browser-new-context-option-screen" class="list-anchor">#</a>
-  - `width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+  - `width` [int]
     
     page width in pixels.
-  - `height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+  - `height` [int]
     
     page height in pixels.
   
@@ -335,42 +335,42 @@ await browser.close()
   * `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
   * `'block'`: Playwright will block all registration of Service Workers.
 - `storage_state` [Union]\[[str], [pathlib.Path]\] | [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-storage-state"/><a href="#browser-new-context-option-storage-state" class="list-anchor">#</a>
-  - `cookies` [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-cookies"/><a href="#browser-new-context-option-cookies" class="list-anchor">#</a>
-    - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-name"/><a href="#browser-new-context-option-name" class="list-anchor">#</a>
+  - `cookies` [List]\[[Dict]\]
+    - `name` [str]
       
       
-    - `value` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-value"/><a href="#browser-new-context-option-value" class="list-anchor">#</a>
+    - `value` [str]
       
       
-    - `domain` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-domain"/><a href="#browser-new-context-option-domain" class="list-anchor">#</a>
+    - `domain` [str]
       
       Domain and path are required. For the cookie to apply to all subdomains as well, prefix domain with a dot, like this: ".example.com"
-    - `path` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-path"/><a href="#browser-new-context-option-path" class="list-anchor">#</a>
+    - `path` [str]
       
       Domain and path are required
-    - `expires` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-expires"/><a href="#browser-new-context-option-expires" class="list-anchor">#</a>
+    - `expires` [float]
       
       Unix time in seconds.
-    - `httpOnly` [bool]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-http-only"/><a href="#browser-new-context-option-http-only" class="list-anchor">#</a>
+    - `httpOnly` [bool]
       
       
-    - `secure` [bool]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-secure"/><a href="#browser-new-context-option-secure" class="list-anchor">#</a>
+    - `secure` [bool]
       
       
-    - `sameSite` "Strict" | "Lax" | "None"<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-same-site"/><a href="#browser-new-context-option-same-site" class="list-anchor">#</a>
+    - `sameSite` "Strict" | "Lax" | "None"
       
       sameSite flag
     
     Cookies to set for context
-  - `origins` [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origins"/><a href="#browser-new-context-option-origins" class="list-anchor">#</a>
-    - `origin` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-origin"/><a href="#browser-new-context-option-origin" class="list-anchor">#</a>
+  - `origins` [List]\[[Dict]\]
+    - `origin` [str]
       
       
-    - `localStorage` [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-local-storage"/><a href="#browser-new-context-option-local-storage" class="list-anchor">#</a>
-      - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-name"/><a href="#browser-new-context-option-name" class="list-anchor">#</a>
+    - `localStorage` [List]\[[Dict]\]
+      - `name` [str]
         
         
-      - `value` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-value"/><a href="#browser-new-context-option-value" class="list-anchor">#</a>
+      - `value` [str]
         
         
       
@@ -389,10 +389,10 @@ await browser.close()
   
   Specific user agent to use in this context.
 - `viewport` [NoneType] | [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-viewport"/><a href="#browser-new-context-option-viewport" class="list-anchor">#</a>
-  - `width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-width"/><a href="#browser-new-context-option-width" class="list-anchor">#</a>
+  - `width` [int]
     
     page width in pixels.
-  - `height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-context-option-height"/><a href="#browser-new-context-option-height" class="list-anchor">#</a>
+  - `height` [int]
     
     page height in pixels.
   
@@ -432,19 +432,19 @@ browser.new_page(**kwargs)
   
   Toggles bypassing page's Content-Security-Policy. Defaults to `false`.
 - `client_certificates` [List]\[[Dict]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-client-certificates"/><a href="#browser-new-page-option-client-certificates" class="list-anchor">#</a>
-  - `origin` [str] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origin"/><a href="#browser-new-page-option-origin" class="list-anchor">#</a>
+  - `origin` [str]
     
     Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-  - `certPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-cert-path"/><a href="#browser-new-page-option-cert-path" class="list-anchor">#</a>
+  - `certPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the file with the certificate in PEM format.
-  - `keyPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-key-path"/><a href="#browser-new-page-option-key-path" class="list-anchor">#</a>
+  - `keyPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the file with the private key in PEM format.
-  - `pfxPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-pfx-path"/><a href="#browser-new-page-option-pfx-path" class="list-anchor">#</a>
+  - `pfxPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the PFX or PKCS12 encoded private key and certificate chain.
-  - `passphrase` [str] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-passphrase"/><a href="#browser-new-page-option-passphrase" class="list-anchor">#</a>
+  - `passphrase` [str] *(optional)*
     
     Passphrase for the private key (PEM or PFX).
   
@@ -475,29 +475,29 @@ browser.new_page(**kwargs)
   
   Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [page.emulate_media()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'none'`.
 - `geolocation` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-geolocation"/><a href="#browser-new-page-option-geolocation" class="list-anchor">#</a>
-  - `latitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-latitude"/><a href="#browser-new-page-option-latitude" class="list-anchor">#</a>
+  - `latitude` [float]
     
     Latitude between -90 and 90.
-  - `longitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-longitude"/><a href="#browser-new-page-option-longitude" class="list-anchor">#</a>
+  - `longitude` [float]
     
     Longitude between -180 and 180.
-  - `accuracy` [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-accuracy"/><a href="#browser-new-page-option-accuracy" class="list-anchor">#</a>
+  - `accuracy` [float] *(optional)*
     
     Non-negative accuracy value. Defaults to `0`.
 - `has_touch` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-has-touch"/><a href="#browser-new-page-option-has-touch" class="list-anchor">#</a>
   
   Specifies if viewport supports touch events. Defaults to false. Learn more about [mobile emulation](../emulation.mdx#devices).
 - `http_credentials` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-http-credentials"/><a href="#browser-new-page-option-http-credentials" class="list-anchor">#</a>
-  - `username` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-username"/><a href="#browser-new-page-option-username" class="list-anchor">#</a>
+  - `username` [str]
     
     
-  - `password` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-password"/><a href="#browser-new-page-option-password" class="list-anchor">#</a>
+  - `password` [str]
     
     
-  - `origin` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origin"/><a href="#browser-new-page-option-origin" class="list-anchor">#</a>
+  - `origin` [str] *(optional)*
     
     Restrain sending http credentials on specific origin (scheme://host:port).
-  - `send` "unauthorized" | "always" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-send"/><a href="#browser-new-page-option-send" class="list-anchor">#</a>
+  - `send` "unauthorized" | "always" *(optional)*
     
     This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
   
@@ -524,16 +524,16 @@ browser.new_page(**kwargs)
   
   A list of permissions to grant to all pages in this context. See [browser_context.grant_permissions()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
 - `proxy` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-proxy"/><a href="#browser-new-page-option-proxy" class="list-anchor">#</a>
-  - `server` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-server"/><a href="#browser-new-page-option-server" class="list-anchor">#</a>
+  - `server` [str]
     
     Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-  - `bypass` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-bypass"/><a href="#browser-new-page-option-bypass" class="list-anchor">#</a>
+  - `bypass` [str] *(optional)*
     
     Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-  - `username` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-username"/><a href="#browser-new-page-option-username" class="list-anchor">#</a>
+  - `username` [str] *(optional)*
     
     Optional username to use if HTTP proxy requires authentication.
-  - `password` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-password"/><a href="#browser-new-page-option-password" class="list-anchor">#</a>
+  - `password` [str] *(optional)*
     
     Optional password to use if HTTP proxy requires authentication.
   
@@ -560,10 +560,10 @@ browser.new_page(**kwargs)
   
   Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure to call [browser_context.close()](/api/class-browsercontext.mdx#browser-context-close) for videos to be saved.
 - `record_video_size` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-record-video-size"/><a href="#browser-new-page-option-record-video-size" class="list-anchor">#</a>
-  - `width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+  - `width` [int]
     
     Video frame width.
-  - `height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+  - `height` [int]
     
     Video frame height.
   
@@ -572,10 +572,10 @@ browser.new_page(**kwargs)
   
   Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [page.emulate_media()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'no-preference'`.
 - `screen` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-screen"/><a href="#browser-new-page-option-screen" class="list-anchor">#</a>
-  - `width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+  - `width` [int]
     
     page width in pixels.
-  - `height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+  - `height` [int]
     
     page height in pixels.
   
@@ -586,42 +586,42 @@ browser.new_page(**kwargs)
   * `'allow'`: [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) can be registered.
   * `'block'`: Playwright will block all registration of Service Workers.
 - `storage_state` [Union]\[[str], [pathlib.Path]\] | [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-storage-state"/><a href="#browser-new-page-option-storage-state" class="list-anchor">#</a>
-  - `cookies` [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-cookies"/><a href="#browser-new-page-option-cookies" class="list-anchor">#</a>
-    - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-name"/><a href="#browser-new-page-option-name" class="list-anchor">#</a>
+  - `cookies` [List]\[[Dict]\]
+    - `name` [str]
       
       
-    - `value` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-value"/><a href="#browser-new-page-option-value" class="list-anchor">#</a>
+    - `value` [str]
       
       
-    - `domain` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-domain"/><a href="#browser-new-page-option-domain" class="list-anchor">#</a>
+    - `domain` [str]
       
       Domain and path are required. For the cookie to apply to all subdomains as well, prefix domain with a dot, like this: ".example.com"
-    - `path` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-path"/><a href="#browser-new-page-option-path" class="list-anchor">#</a>
+    - `path` [str]
       
       Domain and path are required
-    - `expires` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-expires"/><a href="#browser-new-page-option-expires" class="list-anchor">#</a>
+    - `expires` [float]
       
       Unix time in seconds.
-    - `httpOnly` [bool]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-http-only"/><a href="#browser-new-page-option-http-only" class="list-anchor">#</a>
+    - `httpOnly` [bool]
       
       
-    - `secure` [bool]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-secure"/><a href="#browser-new-page-option-secure" class="list-anchor">#</a>
+    - `secure` [bool]
       
       
-    - `sameSite` "Strict" | "Lax" | "None"<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-same-site"/><a href="#browser-new-page-option-same-site" class="list-anchor">#</a>
+    - `sameSite` "Strict" | "Lax" | "None"
       
       sameSite flag
     
     Cookies to set for context
-  - `origins` [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origins"/><a href="#browser-new-page-option-origins" class="list-anchor">#</a>
-    - `origin` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-origin"/><a href="#browser-new-page-option-origin" class="list-anchor">#</a>
+  - `origins` [List]\[[Dict]\]
+    - `origin` [str]
       
       
-    - `localStorage` [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-local-storage"/><a href="#browser-new-page-option-local-storage" class="list-anchor">#</a>
-      - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-name"/><a href="#browser-new-page-option-name" class="list-anchor">#</a>
+    - `localStorage` [List]\[[Dict]\]
+      - `name` [str]
         
         
-      - `value` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-value"/><a href="#browser-new-page-option-value" class="list-anchor">#</a>
+      - `value` [str]
         
         
       
@@ -640,10 +640,10 @@ browser.new_page(**kwargs)
   
   Specific user agent to use in this context.
 - `viewport` [NoneType] | [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-viewport"/><a href="#browser-new-page-option-viewport" class="list-anchor">#</a>
-  - `width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-width"/><a href="#browser-new-page-option-width" class="list-anchor">#</a>
+  - `width` [int]
     
     page width in pixels.
-  - `height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-new-page-option-height"/><a href="#browser-new-page-option-height" class="list-anchor">#</a>
+  - `height` [int]
     
     page height in pixels.
   

--- a/python/docs/api/class-browsercontext.mdx
+++ b/python/docs/api/class-browsercontext.mdx
@@ -88,31 +88,31 @@ await browser_context.add_cookies([cookie_object1, cookie_object2])
 
 **Arguments**
 - `cookies` [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-cookies"/><a href="#browser-context-add-cookies-option-cookies" class="list-anchor">#</a>
-  - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-name"/><a href="#browser-context-add-cookies-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     
-  - `value` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-value"/><a href="#browser-context-add-cookies-option-value" class="list-anchor">#</a>
+  - `value` [str]
     
     
-  - `url` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-url"/><a href="#browser-context-add-cookies-option-url" class="list-anchor">#</a>
+  - `url` [str] *(optional)*
     
     Either url or domain / path are required. Optional.
-  - `domain` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-domain"/><a href="#browser-context-add-cookies-option-domain" class="list-anchor">#</a>
+  - `domain` [str] *(optional)*
     
     For the cookie to apply to all subdomains as well, prefix domain with a dot, like this: ".example.com". Either url or domain / path are required. Optional.
-  - `path` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-path"/><a href="#browser-context-add-cookies-option-path" class="list-anchor">#</a>
+  - `path` [str] *(optional)*
     
     Either url or domain / path are required Optional.
-  - `expires` [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-expires"/><a href="#browser-context-add-cookies-option-expires" class="list-anchor">#</a>
+  - `expires` [float] *(optional)*
     
     Unix time in seconds. Optional.
-  - `httpOnly` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-http-only"/><a href="#browser-context-add-cookies-option-http-only" class="list-anchor">#</a>
+  - `httpOnly` [bool] *(optional)*
     
     Optional.
-  - `secure` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-secure"/><a href="#browser-context-add-cookies-option-secure" class="list-anchor">#</a>
+  - `secure` [bool] *(optional)*
     
     Optional.
-  - `sameSite` "Strict" | "Lax" | "None" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-add-cookies-option-same-site"/><a href="#browser-context-add-cookies-option-same-site" class="list-anchor">#</a>
+  - `sameSite` "Strict" | "Lax" | "None" *(optional)*
     
     Optional.
 
@@ -1076,13 +1076,13 @@ Consider using [browser_context.grant_permissions()](/api/class-browsercontext.m
 
 **Arguments**
 - `geolocation` [NoneType] | [Dict]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-geolocation"/><a href="#browser-context-set-geolocation-option-geolocation" class="list-anchor">#</a>
-  - `latitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-latitude"/><a href="#browser-context-set-geolocation-option-latitude" class="list-anchor">#</a>
+  - `latitude` [float]
     
     Latitude between -90 and 90.
-  - `longitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-longitude"/><a href="#browser-context-set-geolocation-option-longitude" class="list-anchor">#</a>
+  - `longitude` [float]
     
     Longitude between -180 and 180.
-  - `accuracy` [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-context-set-geolocation-option-accuracy"/><a href="#browser-context-set-geolocation-option-accuracy" class="list-anchor">#</a>
+  - `accuracy` [float] *(optional)*
     
     Non-negative accuracy value. Defaults to `0`.
 

--- a/python/docs/api/class-browsertype.mdx
+++ b/python/docs/api/class-browsertype.mdx
@@ -263,16 +263,16 @@ browser = await playwright.chromium.launch( # or "firefox" or "webkit".
   
   If `true`, Playwright does not pass its own configurations args and only uses the ones from `args`. If an array is given, then filters out the given default arguments. Dangerous option; use with care. Defaults to `false`.
 - `proxy` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-proxy"/><a href="#browser-type-launch-option-proxy" class="list-anchor">#</a>
-  - `server` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-server"/><a href="#browser-type-launch-option-server" class="list-anchor">#</a>
+  - `server` [str]
     
     Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-  - `bypass` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-bypass"/><a href="#browser-type-launch-option-bypass" class="list-anchor">#</a>
+  - `bypass` [str] *(optional)*
     
     Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-  - `username` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-username"/><a href="#browser-type-launch-option-username" class="list-anchor">#</a>
+  - `username` [str] *(optional)*
     
     Optional username to use if HTTP proxy requires authentication.
-  - `password` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-option-password"/><a href="#browser-type-launch-option-password" class="list-anchor">#</a>
+  - `password` [str] *(optional)*
     
     Optional password to use if HTTP proxy requires authentication.
   
@@ -337,19 +337,19 @@ browser_type.launch_persistent_context(user_data_dir, **kwargs)
   
   Enable Chromium sandboxing. Defaults to `false`.
 - `client_certificates` [List]\[[Dict]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-client-certificates"/><a href="#browser-type-launch-persistent-context-option-client-certificates" class="list-anchor">#</a>
-  - `origin` [str] <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-origin"/><a href="#browser-type-launch-persistent-context-option-origin" class="list-anchor">#</a>
+  - `origin` [str]
     
     Exact origin that the certificate is valid for. Origin includes `https` protocol, a hostname and optionally a port.
-  - `certPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-cert-path"/><a href="#browser-type-launch-persistent-context-option-cert-path" class="list-anchor">#</a>
+  - `certPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the file with the certificate in PEM format.
-  - `keyPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-key-path"/><a href="#browser-type-launch-persistent-context-option-key-path" class="list-anchor">#</a>
+  - `keyPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the file with the private key in PEM format.
-  - `pfxPath` [Union]\[[str], [pathlib.Path]\] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-pfx-path"/><a href="#browser-type-launch-persistent-context-option-pfx-path" class="list-anchor">#</a>
+  - `pfxPath` [Union]\[[str], [pathlib.Path]\] *(optional)*
     
     Path to the PFX or PKCS12 encoded private key and certificate chain.
-  - `passphrase` [str] *(optional)* <font size="2">Added in: 1.46</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-passphrase"/><a href="#browser-type-launch-persistent-context-option-passphrase" class="list-anchor">#</a>
+  - `passphrase` [str] *(optional)*
     
     Passphrase for the private key (PEM or PFX).
   
@@ -400,13 +400,13 @@ browser_type.launch_persistent_context(user_data_dir, **kwargs)
   
   Emulates `'forced-colors'` media feature, supported values are `'active'`, `'none'`. See [page.emulate_media()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'none'`.
 - `geolocation` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-geolocation"/><a href="#browser-type-launch-persistent-context-option-geolocation" class="list-anchor">#</a>
-  - `latitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-latitude"/><a href="#browser-type-launch-persistent-context-option-latitude" class="list-anchor">#</a>
+  - `latitude` [float]
     
     Latitude between -90 and 90.
-  - `longitude` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-longitude"/><a href="#browser-type-launch-persistent-context-option-longitude" class="list-anchor">#</a>
+  - `longitude` [float]
     
     Longitude between -180 and 180.
-  - `accuracy` [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-accuracy"/><a href="#browser-type-launch-persistent-context-option-accuracy" class="list-anchor">#</a>
+  - `accuracy` [float] *(optional)*
     
     Non-negative accuracy value. Defaults to `0`.
 - `handle_sighup` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-handle-sighup"/><a href="#browser-type-launch-persistent-context-option-handle-sighup" class="list-anchor">#</a>
@@ -425,16 +425,16 @@ browser_type.launch_persistent_context(user_data_dir, **kwargs)
   
   Whether to run browser in headless mode. More details for [Chromium](https://developers.google.com/web/updates/2017/04/headless-chrome) and [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Headless_mode). Defaults to `true` unless the `devtools` option is `true`.
 - `http_credentials` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-http-credentials"/><a href="#browser-type-launch-persistent-context-option-http-credentials" class="list-anchor">#</a>
-  - `username` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-username"/><a href="#browser-type-launch-persistent-context-option-username" class="list-anchor">#</a>
+  - `username` [str]
     
     
-  - `password` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-password"/><a href="#browser-type-launch-persistent-context-option-password" class="list-anchor">#</a>
+  - `password` [str]
     
     
-  - `origin` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-origin"/><a href="#browser-type-launch-persistent-context-option-origin" class="list-anchor">#</a>
+  - `origin` [str] *(optional)*
     
     Restrain sending http credentials on specific origin (scheme://host:port).
-  - `send` "unauthorized" | "always" *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-send"/><a href="#browser-type-launch-persistent-context-option-send" class="list-anchor">#</a>
+  - `send` "unauthorized" | "always" *(optional)*
     
     This option only applies to the requests sent from corresponding [APIRequestContext] and does not affect requests sent from the browser. `'always'` - `Authorization` header with basic authentication credentials will be sent with the each API request. `'unauthorized` - the credentials are only sent when 401 (Unauthorized) response with `WWW-Authenticate` header is received. Defaults to `'unauthorized'`.
   
@@ -464,16 +464,16 @@ browser_type.launch_persistent_context(user_data_dir, **kwargs)
   
   A list of permissions to grant to all pages in this context. See [browser_context.grant_permissions()](/api/class-browsercontext.mdx#browser-context-grant-permissions) for more details. Defaults to none.
 - `proxy` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-proxy"/><a href="#browser-type-launch-persistent-context-option-proxy" class="list-anchor">#</a>
-  - `server` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-server"/><a href="#browser-type-launch-persistent-context-option-server" class="list-anchor">#</a>
+  - `server` [str]
     
     Proxy to be used for all requests. HTTP and SOCKS proxies are supported, for example `http://myproxy.com:3128` or `socks5://myproxy.com:3128`. Short form `myproxy.com:3128` is considered an HTTP proxy.
-  - `bypass` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-bypass"/><a href="#browser-type-launch-persistent-context-option-bypass" class="list-anchor">#</a>
+  - `bypass` [str] *(optional)*
     
     Optional comma-separated domains to bypass proxy, for example `".com, chromium.org, .domain.com"`.
-  - `username` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-username"/><a href="#browser-type-launch-persistent-context-option-username" class="list-anchor">#</a>
+  - `username` [str] *(optional)*
     
     Optional username to use if HTTP proxy requires authentication.
-  - `password` [str] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-password"/><a href="#browser-type-launch-persistent-context-option-password" class="list-anchor">#</a>
+  - `password` [str] *(optional)*
     
     Optional password to use if HTTP proxy requires authentication.
   
@@ -495,10 +495,10 @@ browser_type.launch_persistent_context(user_data_dir, **kwargs)
   
   Enables video recording for all pages into the specified directory. If not specified videos are not recorded. Make sure to call [browser_context.close()](/api/class-browsercontext.mdx#browser-context-close) for videos to be saved.
 - `record_video_size` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-record-video-size"/><a href="#browser-type-launch-persistent-context-option-record-video-size" class="list-anchor">#</a>
-  - `width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+  - `width` [int]
     
     Video frame width.
-  - `height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+  - `height` [int]
     
     Video frame height.
   
@@ -507,10 +507,10 @@ browser_type.launch_persistent_context(user_data_dir, **kwargs)
   
   Emulates `'prefers-reduced-motion'` media feature, supported values are `'reduce'`, `'no-preference'`. See [page.emulate_media()](/api/class-page.mdx#page-emulate-media) for more details. Passing `'null'` resets emulation to system defaults. Defaults to `'no-preference'`.
 - `screen` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-screen"/><a href="#browser-type-launch-persistent-context-option-screen" class="list-anchor">#</a>
-  - `width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+  - `width` [int]
     
     page width in pixels.
-  - `height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+  - `height` [int]
     
     page height in pixels.
   
@@ -539,10 +539,10 @@ browser_type.launch_persistent_context(user_data_dir, **kwargs)
   
   Specific user agent to use in this context.
 - `viewport` [NoneType] | [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-viewport"/><a href="#browser-type-launch-persistent-context-option-viewport" class="list-anchor">#</a>
-  - `width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-width"/><a href="#browser-type-launch-persistent-context-option-width" class="list-anchor">#</a>
+  - `width` [int]
     
     page width in pixels.
-  - `height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="browser-type-launch-persistent-context-option-height"/><a href="#browser-type-launch-persistent-context-option-height" class="list-anchor">#</a>
+  - `height` [int]
     
     page height in pixels.
   

--- a/python/docs/api/class-elementhandle.mdx
+++ b/python/docs/api/class-elementhandle.mdx
@@ -282,10 +282,10 @@ element_handle.check(**kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-position"/><a href="#element-handle-check-option-position" class="list-anchor">#</a>
-  - `x` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-x"/><a href="#element-handle-check-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-check-option-y"/><a href="#element-handle-check-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -354,10 +354,10 @@ element_handle.click(**kwargs)
   
   Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-position"/><a href="#element-handle-click-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-x"/><a href="#element-handle-click-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-click-option-y"/><a href="#element-handle-click-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -426,10 +426,10 @@ element_handle.dblclick(**kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-position"/><a href="#element-handle-dblclick-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-x"/><a href="#element-handle-dblclick-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-dblclick-option-y"/><a href="#element-handle-dblclick-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -816,10 +816,10 @@ element_handle.hover(**kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-position"/><a href="#element-handle-hover-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-x"/><a href="#element-handle-hover-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-hover-option-y"/><a href="#element-handle-hover-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1444,10 +1444,10 @@ element_handle.set_checked(checked, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-position"/><a href="#element-handle-set-checked-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-x"/><a href="#element-handle-set-checked-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-checked-option-y"/><a href="#element-handle-set-checked-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1487,13 +1487,13 @@ element_handle.set_input_files(files, **kwargs)
 
 **Arguments**
 - `files` [Union]\[[str], [pathlib.Path]\] | [List]\[[Union]\[[str], [pathlib.Path]\]\] | [Dict] | [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-files"/><a href="#element-handle-set-input-files-option-files" class="list-anchor">#</a>
-  - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-name"/><a href="#element-handle-set-input-files-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-mime-type"/><a href="#element-handle-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-buffer"/><a href="#element-handle-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
 - `no_wait_after` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-set-input-files-option-no-wait-after"/><a href="#element-handle-set-input-files-option-no-wait-after" class="list-anchor">#</a>
@@ -1560,10 +1560,10 @@ element_handle.tap(**kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-position"/><a href="#element-handle-tap-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-x"/><a href="#element-handle-tap-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-tap-option-y"/><a href="#element-handle-tap-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1686,10 +1686,10 @@ element_handle.uncheck(**kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-position"/><a href="#element-handle-uncheck-option-position" class="list-anchor">#</a>
-  - `x` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-x"/><a href="#element-handle-uncheck-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="element-handle-uncheck-option-y"/><a href="#element-handle-uncheck-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/python/docs/api/class-filechooser.mdx
+++ b/python/docs/api/class-filechooser.mdx
@@ -59,13 +59,13 @@ file_chooser.set_files(files, **kwargs)
 
 **Arguments**
 - `files` [Union]\[[str], [pathlib.Path]\] | [List]\[[Union]\[[str], [pathlib.Path]\]\] | [Dict] | [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-files"/><a href="#file-chooser-set-files-option-files" class="list-anchor">#</a>
-  - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-name"/><a href="#file-chooser-set-files-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-mime-type"/><a href="#file-chooser-set-files-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-buffer"/><a href="#file-chooser-set-files-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
 - `no_wait_after` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="file-chooser-set-files-option-no-wait-after"/><a href="#file-chooser-set-files-option-no-wait-after" class="list-anchor">#</a>

--- a/python/docs/api/class-frame.mdx
+++ b/python/docs/api/class-frame.mdx
@@ -192,10 +192,10 @@ frame.drag_and_drop(source, target, **kwargs)
   
   This option has no effect.
 - `source_position` [Dict] *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-source-position"/><a href="#frame-drag-and-drop-option-source-position" class="list-anchor">#</a>
-  - `x` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-x"/><a href="#frame-drag-and-drop-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-y"/><a href="#frame-drag-and-drop-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -203,10 +203,10 @@ frame.drag_and_drop(source, target, **kwargs)
   
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `target_position` [Dict] *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-target-position"/><a href="#frame-drag-and-drop-option-target-position" class="list-anchor">#</a>
-  - `x` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-x"/><a href="#frame-drag-and-drop-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-drag-and-drop-option-y"/><a href="#frame-drag-and-drop-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -1549,10 +1549,10 @@ frame.check(selector, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-position"/><a href="#frame-check-option-position" class="list-anchor">#</a>
-  - `x` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-x"/><a href="#frame-check-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-check-option-y"/><a href="#frame-check-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1626,10 +1626,10 @@ frame.click(selector, **kwargs)
   
   Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-position"/><a href="#frame-click-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-x"/><a href="#frame-click-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-click-option-y"/><a href="#frame-click-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -1703,10 +1703,10 @@ frame.dblclick(selector, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-position"/><a href="#frame-dblclick-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-x"/><a href="#frame-dblclick-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-dblclick-option-y"/><a href="#frame-dblclick-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2198,10 +2198,10 @@ frame.hover(selector, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-position"/><a href="#frame-hover-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-x"/><a href="#frame-hover-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-hover-option-y"/><a href="#frame-hover-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2792,10 +2792,10 @@ frame.set_checked(selector, checked, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-position"/><a href="#frame-set-checked-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-x"/><a href="#frame-set-checked-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-checked-option-y"/><a href="#frame-set-checked-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2841,13 +2841,13 @@ frame.set_input_files(selector, files, **kwargs)
   
   A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
 - `files` [Union]\[[str], [pathlib.Path]\] | [List]\[[Union]\[[str], [pathlib.Path]\]\] | [Dict] | [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-files"/><a href="#frame-set-input-files-option-files" class="list-anchor">#</a>
-  - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-name"/><a href="#frame-set-input-files-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-mime-type"/><a href="#frame-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-buffer"/><a href="#frame-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
 - `no_wait_after` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-set-input-files-option-no-wait-after"/><a href="#frame-set-input-files-option-no-wait-after" class="list-anchor">#</a>
@@ -2919,10 +2919,10 @@ frame.tap(selector, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-position"/><a href="#frame-tap-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-x"/><a href="#frame-tap-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-tap-option-y"/><a href="#frame-tap-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3068,10 +3068,10 @@ frame.uncheck(selector, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-position"/><a href="#frame-uncheck-option-position" class="list-anchor">#</a>
-  - `x` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-x"/><a href="#frame-uncheck-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="frame-uncheck-option-y"/><a href="#frame-uncheck-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/python/docs/api/class-locator.mdx
+++ b/python/docs/api/class-locator.mdx
@@ -317,10 +317,10 @@ await page.get_by_role("checkbox").check()
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-position"/><a href="#locator-check-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-x"/><a href="#locator-check-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-check-option-y"/><a href="#locator-check-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -497,10 +497,10 @@ await page.locator("canvas").click(
   
   Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-position"/><a href="#locator-click-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-x"/><a href="#locator-click-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-click-option-y"/><a href="#locator-click-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -604,10 +604,10 @@ locator.dblclick(**kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-position"/><a href="#locator-dblclick-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-x"/><a href="#locator-dblclick-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-dblclick-option-y"/><a href="#locator-dblclick-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -800,18 +800,18 @@ await source.drag_to(
   
   This option has no effect.
 - `source_position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-source-position"/><a href="#locator-drag-to-option-source-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-x"/><a href="#locator-drag-to-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-y"/><a href="#locator-drag-to-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
 - `target_position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-target-position"/><a href="#locator-drag-to-option-target-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-x"/><a href="#locator-drag-to-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-drag-to-option-y"/><a href="#locator-drag-to-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -1746,10 +1746,10 @@ await page.get_by_role("link").hover()
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-position"/><a href="#locator-hover-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-x"/><a href="#locator-hover-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-hover-option-y"/><a href="#locator-hover-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2767,10 +2767,10 @@ await page.get_by_role("checkbox").set_checked(True)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-position"/><a href="#locator-set-checked-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-x"/><a href="#locator-set-checked-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-checked-option-y"/><a href="#locator-set-checked-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -2866,13 +2866,13 @@ await page.get_by_label("Upload file").set_input_files(
 
 **Arguments**
 - `files` [Union]\[[str], [pathlib.Path]\] | [List]\[[Union]\[[str], [pathlib.Path]\]\] | [Dict] | [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-files"/><a href="#locator-set-input-files-option-files" class="list-anchor">#</a>
-  - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-name"/><a href="#locator-set-input-files-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-mime-type"/><a href="#locator-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-buffer"/><a href="#locator-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
 - `no_wait_after` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-set-input-files-option-no-wait-after"/><a href="#locator-set-input-files-option-no-wait-after" class="list-anchor">#</a>
@@ -2927,10 +2927,10 @@ locator.tap(**kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-position"/><a href="#locator-tap-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-x"/><a href="#locator-tap-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-tap-option-y"/><a href="#locator-tap-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -3033,10 +3033,10 @@ await page.get_by_role("checkbox").uncheck()
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-position"/><a href="#locator-uncheck-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-x"/><a href="#locator-uncheck-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="locator-uncheck-option-y"/><a href="#locator-uncheck-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/python/docs/api/class-page.mdx
+++ b/python/docs/api/class-page.mdx
@@ -529,10 +529,10 @@ await page.drag_and_drop(
   
   This option has no effect.
 - `source_position` [Dict] *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-source-position"/><a href="#page-drag-and-drop-option-source-position" class="list-anchor">#</a>
-  - `x` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-x"/><a href="#page-drag-and-drop-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-y"/><a href="#page-drag-and-drop-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   Clicks on the source element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -540,10 +540,10 @@ await page.drag_and_drop(
   
   When true, the call requires selector to resolve to a single element. If given selector resolves to more than one element, the call throws an exception.
 - `target_position` [Dict] *(optional)* <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-target-position"/><a href="#page-drag-and-drop-option-target-position" class="list-anchor">#</a>
-  - `x` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-x"/><a href="#page-drag-and-drop-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float] <font size="2">Added in: v1.14</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-drag-and-drop-option-y"/><a href="#page-drag-and-drop-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   Drops on the target element at this point relative to the top-left corner of the element's padding box. If not specified, some visible point of the element is used.
@@ -2312,16 +2312,16 @@ The `format` options are:
   
   Paper orientation. Defaults to `false`.
 - `margin` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-margin"/><a href="#page-pdf-option-margin" class="list-anchor">#</a>
-  - `top` [str] | [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-top"/><a href="#page-pdf-option-top" class="list-anchor">#</a>
+  - `top` [str] | [float] *(optional)*
     
     Top margin, accepts values labeled with units. Defaults to `0`.
-  - `right` [str] | [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-right"/><a href="#page-pdf-option-right" class="list-anchor">#</a>
+  - `right` [str] | [float] *(optional)*
     
     Right margin, accepts values labeled with units. Defaults to `0`.
-  - `bottom` [str] | [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-bottom"/><a href="#page-pdf-option-bottom" class="list-anchor">#</a>
+  - `bottom` [str] | [float] *(optional)*
     
     Bottom margin, accepts values labeled with units. Defaults to `0`.
-  - `left` [str] | [float] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-pdf-option-left"/><a href="#page-pdf-option-left" class="list-anchor">#</a>
+  - `left` [str] | [float] *(optional)*
     
     Left margin, accepts values labeled with units. Defaults to `0`.
   
@@ -2642,16 +2642,16 @@ page.screenshot(**kwargs)
   
   When set to `"hide"`, screenshot will hide text caret. When set to `"initial"`, text caret behavior will not be changed.  Defaults to `"hide"`.
 - `clip` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-clip"/><a href="#page-screenshot-option-clip" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-x"/><a href="#page-screenshot-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     x-coordinate of top-left corner of clip area
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-y"/><a href="#page-screenshot-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     y-coordinate of top-left corner of clip area
-  - `width` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-width"/><a href="#page-screenshot-option-width" class="list-anchor">#</a>
+  - `width` [float]
     
     width of clipping area
-  - `height` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-screenshot-option-height"/><a href="#page-screenshot-option-height" class="list-anchor">#</a>
+  - `height` [float]
     
     height of clipping area
   
@@ -2846,10 +2846,10 @@ await page.goto("https://example.com")
 
 **Arguments**
 - `viewport_size` [Dict]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-viewport-size-option-viewport-size"/><a href="#page-set-viewport-size-option-viewport-size" class="list-anchor">#</a>
-  - `width` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-viewport-size-option-width"/><a href="#page-set-viewport-size-option-width" class="list-anchor">#</a>
+  - `width` [int]
     
     page width in pixels.
-  - `height` [int]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-viewport-size-option-height"/><a href="#page-set-viewport-size-option-height" class="list-anchor">#</a>
+  - `height` [int]
     
     page height in pixels.
 
@@ -3984,10 +3984,10 @@ page.check(selector, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-position"/><a href="#page-check-option-position" class="list-anchor">#</a>
-  - `x` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-x"/><a href="#page-check-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-check-option-y"/><a href="#page-check-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -4061,10 +4061,10 @@ page.click(selector, **kwargs)
   
   Actions that initiate navigations are waiting for these navigations to happen and for pages to start loading. You can opt out of waiting via setting this flag. You would only need this option in the exceptional cases such as navigating to inaccessible pages. Defaults to `false`.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-position"/><a href="#page-click-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-x"/><a href="#page-click-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-click-option-y"/><a href="#page-click-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -4138,10 +4138,10 @@ page.dblclick(selector, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-position"/><a href="#page-dblclick-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-x"/><a href="#page-dblclick-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-dblclick-option-y"/><a href="#page-dblclick-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -4631,10 +4631,10 @@ page.hover(selector, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-position"/><a href="#page-hover-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-x"/><a href="#page-hover-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-hover-option-y"/><a href="#page-hover-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -5286,10 +5286,10 @@ page.set_checked(selector, checked, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-position"/><a href="#page-set-checked-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-x"/><a href="#page-set-checked-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-checked-option-y"/><a href="#page-set-checked-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -5335,13 +5335,13 @@ page.set_input_files(selector, files, **kwargs)
   
   A selector to search for an element. If there are multiple elements satisfying the selector, the first will be used.
 - `files` [Union]\[[str], [pathlib.Path]\] | [List]\[[Union]\[[str], [pathlib.Path]\]\] | [Dict] | [List]\[[Dict]\]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-files"/><a href="#page-set-input-files-option-files" class="list-anchor">#</a>
-  - `name` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-name"/><a href="#page-set-input-files-option-name" class="list-anchor">#</a>
+  - `name` [str]
     
     File name
-  - `mimeType` [str]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-mime-type"/><a href="#page-set-input-files-option-mime-type" class="list-anchor">#</a>
+  - `mimeType` [str]
     
     File type
-  - `buffer` [bytes]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-buffer"/><a href="#page-set-input-files-option-buffer" class="list-anchor">#</a>
+  - `buffer` [bytes]
     
     File content
 - `no_wait_after` [bool] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-set-input-files-option-no-wait-after"/><a href="#page-set-input-files-option-no-wait-after" class="list-anchor">#</a>
@@ -5413,10 +5413,10 @@ page.tap(selector, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)*<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-position"/><a href="#page-tap-option-position" class="list-anchor">#</a>
-  - `x` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-x"/><a href="#page-tap-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-tap-option-y"/><a href="#page-tap-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.
@@ -5562,10 +5562,10 @@ page.uncheck(selector, **kwargs)
   
   This option has no effect.
 - `position` [Dict] *(optional)* <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-position"/><a href="#page-uncheck-option-position" class="list-anchor">#</a>
-  - `x` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-x"/><a href="#page-uncheck-option-x" class="list-anchor">#</a>
+  - `x` [float]
     
     
-  - `y` [float] <font size="2">Added in: v1.11</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-uncheck-option-y"/><a href="#page-uncheck-option-y" class="list-anchor">#</a>
+  - `y` [float]
     
     
   A point to use relative to the top-left corner of element padding box. If not specified, uses some visible point of the element.

--- a/src/documentation.js
+++ b/src/documentation.js
@@ -353,6 +353,8 @@ class Member {
     this.clazz = null;
     /** @type {Member=} */
     this.enclosingMethod = undefined;
+    /** @type {Member=} */
+    this.parent = undefined;
     this.async = false;
     this.alias = name;
     this.overloadIndex = 0;
@@ -372,10 +374,11 @@ class Member {
     this.args = new Map();
     if (this.kind === 'method')
       this.enclosingMethod = this;
-    const indexType = type => {
-      type.deepProperties().forEach(p => {
+    const indexArg = (/** @type {Member} */ arg) => {
+      arg.type.deepProperties().forEach(p => {
         p.enclosingMethod = this;
-        indexType(p.type);
+        p.parent = arg;
+        indexArg(p);
       });
     }
     for (const arg of this.argsArray) {
@@ -385,7 +388,7 @@ class Member {
         // @ts-ignore
         arg.type.properties.sort((p1, p2) => p1.name.localeCompare(p2.name));
       }
-      indexType(arg.type);
+      indexArg(arg);
     }
   }
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -568,7 +568,7 @@ ${this.documentation.renderLinksInText(member.discouraged)}
     let linkAnchor = '';
     let sinceVersion = '';
 
-    if (member.enclosingMethod && member.name !== 'options') {
+    if (member.enclosingMethod && member.name !== 'options' && (!member.parent || member.parent.name === 'options')) {
       const hash = calculatePropertyHash(member, direction);
       linkTag = `<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="${hash}"/>`;
       if (member.enclosingMethod.since !== member.since)


### PR DESCRIPTION
Motivation: This fixes an issue with non-unique links where e.g. param.sourcePosition.x and param.targetPosition.x were just yielding into param.x twice.

This requires also updating the files upstream once this landed.

Fixes https://github.com/microsoft/playwright/issues/32098