### PR TITLE
use of the correct type

### DIFF
--- a/java/docs/mock.mdx
+++ b/java/docs/mock.mdx
@@ -82,7 +82,7 @@ Setting `update` option to true will create or update the HAR file with the actu
 
 ```java
 // Get the response from the HAR file
-page.routeFromHAR("./hars/fruit.har", new RouteFromHAROptions()
+page.routeFromHAR(Path.of("./hars/fruit.har"), new RouteFromHAROptions()
   .setUrl("*/**/api/v1/fruits")
   .setUpdate(true)
 );
@@ -116,7 +116,7 @@ Now that you have the HAR file recorded and modified the mock data, it can be us
 // Replay API requests from HAR.
 // Either use a matching response from the HAR,
 // or abort the request if nothing matches.
-page.routeFromHAR("./hars/fruit.har", new RouteFromHAROptions()
+page.routeFromHAR(Path.of("./hars/fruit.har"), new RouteFromHAROptions()
   .setUrl("*/**/api/v1/fruits")
   .setUpdate(false)
 );


### PR DESCRIPTION
In the documentation (JAVA), the wrong argument was passed in the “routeFromHAR()” method