### PR TITLE
devops: determine release update branch automatically

### DIFF
--- a/.github/workflows/roll-next.yml
+++ b/.github/workflows/roll-next.yml
@@ -1,50 +1,36 @@
-name: Create/Update release
+name: Roll Next
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        type: string
-        description: Version number, e.g. 1.19 (not scary, will just open a PR)
-        required: true
+  schedule:
+    # Every day at 10:05 UTC
+    - cron: "5 10 * * *"
 
 permissions:
-  contents: write
+  contents: write 
 
 jobs:
-  build:
-    name: Build
+  roll-docs:
+    name: Roll Playwright to ToT
     runs-on: ubuntu-22.04
     steps:
-      - name: Validate input version number
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
-            echo "Version is not a two digit semver version"
-            exit 1
-          fi 
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4
         with:
           repository: 'microsoft/playwright'
           path: playwright
-          ref: 'release-${{ github.event.inputs.version }}'
       - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Install dependencies
         run: npm ci
-      - name: Delete previous Stable
-        run: node src/versions.js --delete stable
       - name: Roll
         run: npm run roll
         env:
           SRC_DIR: ./playwright
-      - name: Create new version
-        run: npm run version-all
       - name: Prepare branch
         id: prepare-branch
         run: |
-          BRANCH_NAME="roll-release/$(date +"%d-%m-%y")"
+          BRANCH_NAME="roll/next-$(date +"%d-%m-%y")"
           set +e
           git diff -s --exit-code
           HAS_CHANGES="$?"
@@ -60,10 +46,8 @@ jobs:
           git config --global user.name github-actions
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
           git checkout -b "$BRANCH_NAME"
-          # We only want to upgrade the version itself, not the next release
-          git add "*versioned*"
-          git add "**/versions.json"
-          git commit -m "feat(roll): roll to ${{ github.event.inputs.version }} Playwright"
+          git add .
+          git commit -m "feat(roll): roll to ToT Playwright ($(date +"%d-%m-%y"))"
           git push origin $BRANCH_NAME --force
       - name: Create Pull Request
         uses: actions/github-script@v6
@@ -76,6 +60,6 @@ jobs:
               repo: 'playwright.dev',
               head: 'microsoft:${{ steps.prepare-branch.outputs.BRANCH_NAME }}',
               base: 'main',
-              title: 'feat(roll): roll to ${{ github.event.inputs.version }} Playwright',
+              title: 'feat(roll): roll to ToT Playwright (${{ steps.prepare-branch.outputs.BRANCH_NAME }})',
               body: 'Upstream commit: https://github.com/microsoft/playwright/commit/${{ steps.prepare-branch.outputs.GIT_COMMIT }}',
             });

--- a/.github/workflows/roll-stable.yml
+++ b/.github/workflows/roll-stable.yml
@@ -1,35 +1,56 @@
-name: Roll
+name: Roll Stable
 on:
   workflow_dispatch:
   schedule:
+    # Every day at 10:00 UTC
     - cron: "0 10 * * *"
-
 permissions:
-  contents: write 
+  contents: write
 
 jobs:
-  roll-docs:
-    name: Roll Playwright to ToT
+  build:
+    name: Build
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/github-script@v7
+        id: determine-version
+        with:
+          script: |
+            const allBranches = await github.rest.repos.listBranches({
+              owner: 'microsoft',
+              repo: 'playwright',
+            });
+            const relevantBranches = allBranches.data.filter(branch => branch.name.startsWith('release-'));
+            relevantBranches.sort((a, b) => {
+              const aVersion = parseFloat(a.name.split('-')[1]);
+              const bVersion = parseFloat(b.name.split('-')[1]);
+              return aVersion - bVersion;
+            });
+            return relevantBranches.pop().name.replace(/^release-/, '');
+          result-encoding: string
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4
         with:
           repository: 'microsoft/playwright'
           path: playwright
+          ref: 'release-${{ steps.determine-version.outputs.result }}'
       - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Install dependencies
         run: npm ci
+      - name: Delete previous Stable
+        run: node src/versions.js --delete stable
       - name: Roll
         run: npm run roll
         env:
           SRC_DIR: ./playwright
+      - name: Create new version
+        run: npm run version-all
       - name: Prepare branch
         id: prepare-branch
         run: |
-          BRANCH_NAME="roll/$(date +"%d-%m-%y")"
+          BRANCH_NAME="roll-release/$(date +"%d-%m-%y")"
           set +e
           git diff -s --exit-code
           HAS_CHANGES="$?"
@@ -45,8 +66,10 @@ jobs:
           git config --global user.name github-actions
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
           git checkout -b "$BRANCH_NAME"
-          git add .
-          git commit -m "feat(roll): roll to ToT Playwright ($(date +"%d-%m-%y"))"
+          # We only want to upgrade the version itself, not the next release
+          git add "*versioned*"
+          git add "**/versions.json"
+          git commit -m "feat(roll): roll to ${{ steps.determine-version.outputs.result }} Playwright"
           git push origin $BRANCH_NAME --force
       - name: Create Pull Request
         uses: actions/github-script@v6
@@ -59,6 +82,6 @@ jobs:
               repo: 'playwright.dev',
               head: 'microsoft:${{ steps.prepare-branch.outputs.BRANCH_NAME }}',
               base: 'main',
-              title: 'feat(roll): roll to ToT Playwright (${{ steps.prepare-branch.outputs.BRANCH_NAME }})',
+              title: 'feat(roll): roll to ${{ steps.determine-version.outputs.result }} Playwright',
               body: 'Upstream commit: https://github.com/microsoft/playwright/commit/${{ steps.prepare-branch.outputs.GIT_COMMIT }}',
             });

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # playwright.dev
 
-This website is built using [Docusaurus v2](https://v2.docusaurus.io/). Content is pulled from the microsoft/playwright repo.
+This website is built using [Docusaurus](https://docusaurus.io/). Content is pulled from the microsoft/playwright repo.
 
 ## Development
 
@@ -95,6 +95,6 @@ You can set the `BASE_URL=https://playwright.dev` env var, otherwise `http://loc
 
 #### Stable docs rolling
 
-1. Go to the [Release GitHub Actions workflow](https://github.com/microsoft/playwright.dev/actions/workflows/create_release.yml)
-1. Execute it with the version number e.g. `1.25` and wait for the PR [getting created](https://github.com/microsoft/playwright.dev/pulls). The PR will copy changes from the release branch in playwright repo.
+1. Go to the [Release GitHub Actions workflow](https://github.com/microsoft/playwright.dev/actions/workflows/roll-stable.yml)
+1. Execute it and wait for the PR [getting created](https://github.com/microsoft/playwright.dev/pulls). The PR will copy changes from the release branch in playwright repo.
 2. Review the PR and merge it.


### PR DESCRIPTION
We are always interested in only the last release-* branch to update with our stable playwright.dev docs, hence we can automate the process of finding the correct version. This also allows us to run it scheduled, which makes it easier to keep cherry-picked docs changes in sync with the actual deployed version.