### PR TITLE
devops: fix stable docs roll workflow

### DIFF
--- a/.github/workflows/azure-static-web-apps-delightful-forest-0a29f6210.yml
+++ b/.github/workflows/azure-static-web-apps-delightful-forest-0a29f6210.yml
@@ -75,10 +75,10 @@ jobs:
     name: Auto Merge
     runs-on: ubuntu-latest
     needs: [build_and_deploy_job, test]
-    if: github.repository == 'microsoft/playwright.dev' && startsWith(github.head_ref, 'roll/')
+    if: github.repository == 'microsoft/playwright.dev' && startsWith(github.head_ref, 'roll/next-')
     steps:
       - name: Merge pull request
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
           script: |

--- a/.github/workflows/roll-next.yml
+++ b/.github/workflows/roll-next.yml
@@ -50,7 +50,7 @@ jobs:
           git commit -m "feat(roll): roll to ToT Playwright ($(date +"%d-%m-%y"))"
           git push origin $BRANCH_NAME --force
       - name: Create Pull Request
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ steps.prepare-branch.outputs.HAS_CHANGES == '1' }}
         with:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/roll-stable.yml
+++ b/.github/workflows/roll-stable.yml
@@ -16,11 +16,11 @@ jobs:
         id: determine-version
         with:
           script: |
-            const allBranches = await github.rest.repos.listBranches({
+            const allBranches = await github.paginate("GET /repos/{owner}/{repo}/branches", {
               owner: 'microsoft',
               repo: 'playwright',
             });
-            const relevantBranches = allBranches.data.filter(branch => branch.name.startsWith('release-'));
+            const relevantBranches = allBranches.filter(branch => branch.name.startsWith('release-'));
             relevantBranches.sort((a, b) => {
               const aVersion = parseFloat(a.name.split('-')[1]);
               const bVersion = parseFloat(b.name.split('-')[1]);
@@ -50,7 +50,7 @@ jobs:
       - name: Prepare branch
         id: prepare-branch
         run: |
-          BRANCH_NAME="roll-release/$(date +"%d-%m-%y")"
+          BRANCH_NAME="roll/stable-$(date +"%d-%m-%y")"
           set +e
           git diff -s --exit-code
           HAS_CHANGES="$?"
@@ -72,7 +72,7 @@ jobs:
           git commit -m "feat(roll): roll to ${{ steps.determine-version.outputs.result }} Playwright"
           git push origin $BRANCH_NAME --force
       - name: Create Pull Request
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ steps.prepare-branch.outputs.HAS_CHANGES == '1' }}
         with:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}


### PR DESCRIPTION
drive-by: actions/github-script@v6 -> actions/github-script@v7 in order to fix a outdated Node.js warning.