### PR TITLE
Remove TODOs

### DIFF
--- a/dotnet/versioned_docs/version-stable/ci-intro.mdx
+++ b/dotnet/versioned_docs/version-stable/ci-intro.mdx
@@ -53,14 +53,14 @@ Looking at the list of steps in `jobs.test.steps`, you can see that the workflow
 
 Once you have your [GitHub actions workflow](#setting-up-github-actions) setup then all you need to do is [Create a repo on GitHub](https://docs.github.com/en/get-started/quickstart/create-a-repo) or push your code to an existing repository. Follow the instructions on GitHub and don't forget to [initialize a git repository](https://github.com/git-guides/git-init) using the `git init` command so you can [add](https://github.com/git-guides/git-add), [commit](https://github.com/git-guides/git-commit) and [push](https://github.com/git-guides/git-push) your code.
 
-###### 
+######
 ![dotnet repo on github](https://github.com/microsoft/playwright/assets/13063165/4f1b4cc3-b850-4d60-a99e-24057eaf91ad)
 
 ## Opening the Workflows
 
 Click on the **Actions** tab to see the workflows. Here you will see if your tests have passed or failed.
 
-###### 
+######
 ![opening the workflow](https://github.com/microsoft/playwright/assets/13063165/71793c09-0815-4faa-866b-85684a1f87e5)
 
 On Pull Requests you can also click on the **Details** link in the [PR status check](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks).
@@ -71,14 +71,14 @@ On Pull Requests you can also click on the **Details** link in the [PR status ch
 
 Clicking on the workflow run will show you the all the actions that GitHub performed and clicking on **Run Playwright tests** will show the error messages, what was expected and what was received as well as the call log.
 
-###### 
+######
 ![viewing the test logs](https://github.com/microsoft/playwright/assets/13063165/ba2d8d7b-ffce-42de-95e0-bcb35c421975)
 
 ## Viewing the Trace
 
 You can upload Traces which get created on your CI like GitHub Actions as artifacts. This requires [starting and stopping the trace](./trace-viewer-intro#recording-a-trace). We recommend only recording traces for failing tests. Once your traces have been uploaded to CI, they can then be downloaded and opened using [trace.playwright.dev](https://trace.playwright.dev), which is a statically hosted variant of the Trace Viewer. You can upload trace files using drag and drop.
 
-###### 
+######
 ![playwright trace viewer](https://github.com/microsoft/playwright/assets/13063165/84150084-5019-470a-8449-b61d206bfbb0)
 
 ## What's Next
@@ -87,7 +87,7 @@ You can upload Traces which get created on your CI like GitHub Actions as artifa
 - [Learn how to write Assertions](./test-assertions.mdx)
 - [Learn more about the Trace Viewer](/trace-viewer.mdx)
 - [Learn more ways of running tests on GitHub Actions](/ci.mdx)
-- [Learn more about running tests on other CI providers](/ci.mdx#github-actions) // TODO: is this link correct?
+- [Learn more about running tests on other CI providers](/ci.mdx#github-actions)
 
 
 [Accessibility]: /api/class-accessibility.mdx "Accessibility"

--- a/java/versioned_docs/version-stable/ci-intro.mdx
+++ b/java/versioned_docs/version-stable/ci-intro.mdx
@@ -53,21 +53,21 @@ Looking at the list of steps in `jobs.test.steps`, you can see that the workflow
 
 Once you have your [GitHub actions workflow](#setting-up-github-actions) setup then all you need to do is [Create a repo on GitHub](https://docs.github.com/en/get-started/quickstart/create-a-repo) or push your code to an existing repository. Follow the instructions on GitHub and don't forget to [initialize a git repository](https://github.com/git-guides/git-init) using the `git init` command so you can [add](https://github.com/git-guides/git-add), [commit](https://github.com/git-guides/git-commit) and [push](https://github.com/git-guides/git-push) your code.
 
-###### 
+######
 <img width="861" alt="Create a Repo and Push to GitHub" src="https://user-images.githubusercontent.com/13063165/183423254-d2735278-a2ab-4d63-bb99-48d8e5e447bc.png"/>
 
 ## Opening the Workflows
 
 Click on the **Actions** tab to see the workflows. Here you will see if your tests have passed or failed.
 
-###### 
+######
 ![opening the workflow](https://user-images.githubusercontent.com/13063165/183423783-58bf2008-514e-4f96-9c12-c9a55703960c.png)
 
 ## Viewing Test Logs
 
 Clicking on the workflow run will show you the all the actions that GitHub performed and clicking on **Run Playwright tests** will show the error messages, what was expected and what was received as well as the call log.
 
-###### 
+######
 ![Viewing Test Logs](https://user-images.githubusercontent.com/13063165/183423783-58bf2008-514e-4f96-9c12-c9a55703960c.png)
 
 ## Viewing the Trace
@@ -82,7 +82,7 @@ Clicking on the workflow run will show you the all the actions that GitHub perfo
 - [Learn how to write Assertions](./test-assertions.mdx)
 - [Learn more about the Trace Viewer](/trace-viewer.mdx)
 - [Learn more ways of running tests on GitHub Actions](/ci.mdx)
-- [Learn more about running tests on other CI providers](/ci.mdx#github-actions) // TODO: is this link correct?
+- [Learn more about running tests on other CI providers](/ci.mdx#github-actions)
 
 
 [APIRequest]: /api/class-apirequest.mdx "APIRequest"

--- a/nodejs/versioned_docs/version-stable/ci-intro.mdx
+++ b/nodejs/versioned_docs/version-stable/ci-intro.mdx
@@ -60,21 +60,21 @@ To learn more about this, see ["Understanding GitHub Actions"](https://docs.gith
 
 Once you have your [GitHub actions workflow](#setting-up-github-actions) setup then all you need to do is [Create a repo on GitHub](https://docs.github.com/en/get-started/quickstart/create-a-repo) or push your code to an existing repository. Follow the instructions on GitHub and don't forget to [initialize a git repository](https://github.com/git-guides/git-init) using the `git init` command so you can [add](https://github.com/git-guides/git-add), [commit](https://github.com/git-guides/git-commit) and [push](https://github.com/git-guides/git-push) your code.
 
-###### 
+######
 <img width="861" alt="Create a Repo and Push to GitHub" src="https://user-images.githubusercontent.com/13063165/183423254-d2735278-a2ab-4d63-bb99-48d8e5e447bc.png"/>
 
 ## Opening the Workflows
 
 Click on the **Actions** tab to see the workflows. Here you will see if your tests have passed or failed.
 
-###### 
+######
 ![opening the workflow](https://user-images.githubusercontent.com/13063165/183423783-58bf2008-514e-4f96-9c12-c9a55703960c.png)
 
 ## Viewing Test Logs
 
 Clicking on the workflow run will show you the all the actions that GitHub performed and clicking on **Run Playwright tests** will show the error messages, what was expected and what was received as well as the call log.
 
-###### 
+######
 ![Viewing Test Logs](https://user-images.githubusercontent.com/13063165/183423783-58bf2008-514e-4f96-9c12-c9a55703960c.png)
 
 ## HTML Report
@@ -111,19 +111,19 @@ Downloading the HTML report as a zip file is not very convenient. However, we ca
 1. Create an [Azure Storage account](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-create).
 1. Enable [Static website hosting](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website-how-to#enable-static-website-hosting) for the storage account.
 1. Create a Service Principal in Azure and grant it access to Azure Blob storage. Upon successful execution, the command will display the credentials which will be used in the next step.
-   
+
    ```bash
    az ad sp create-for-rbac --name "github-actions" --role "Storage Blob Data Contributor" --scopes /subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP_NAME>/providers/Microsoft.Storage/storageAccounts/<STORAGE_ACCOUNT_NAME>
    ```
-   
+
 1. Use the credentials from the previous step to set up encrypted secrets in your GitHub repository. Go to your repository's settings, under [GitHub Actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository), and add the following secrets:
    - `AZCOPY_SPA_APPLICATION_ID`
    - `AZCOPY_SPA_CLIENT_SECRET`
    - `AZCOPY_TENANT_ID`
-   
+
    For a detailed guide on how to authorize a service principal using a client secret, refer to [this Microsoft documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-authorize-azure-active-directory#authorize-a-service-principal-by-using-a-client-secret-1).
 1. Add a step that uploads the HTML report to Azure Storage.
-   
+
    ```yaml title=".github/workflows/playwright.yml"
    ...
        - name: Upload HTML report to Azure
@@ -138,7 +138,7 @@ Downloading the HTML report as a zip file is not very convenient. However, we ca
            AZCOPY_SPA_CLIENT_SECRET: '${{ secrets.AZCOPY_SPA_CLIENT_SECRET }}'
            AZCOPY_TENANT_ID: '${{ secrets.AZCOPY_TENANT_ID }}'
    ```
-   
+
 The contents of the `$web` storage container can be accessed from a browser by using the [public URL](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website-how-to?tabs=azure-portal#portal-find-url) of the website.
 
 :::note
@@ -151,7 +151,7 @@ This step will not work for pull requests created from a forked repository becau
 - [Learn how to write Assertions](./test-assertions.mdx)
 - [Learn more about the Trace Viewer](/trace-viewer.mdx)
 - [Learn more ways of running tests on GitHub Actions](/ci.mdx)
-- [Learn more about running tests on other CI providers](/ci.mdx#github-actions) // TODO: is this link correct?
+- [Learn more about running tests on other CI providers](/ci.mdx#github-actions)
 
 
 [Accessibility]: /api/class-accessibility.mdx "Accessibility"

--- a/python/versioned_docs/version-stable/ci-intro.mdx
+++ b/python/versioned_docs/version-stable/ci-intro.mdx
@@ -60,21 +60,21 @@ Looking at the list of steps in `jobs.test.steps`, you can see that the workflow
 
 Once you have your [GitHub actions workflow](#setting-up-github-actions) setup then all you need to do is [Create a repo on GitHub](https://docs.github.com/en/get-started/quickstart/create-a-repo) or push your code to an existing repository. Follow the instructions on GitHub and don't forget to [initialize a git repository](https://github.com/git-guides/git-init) using the `git init` command so you can [add](https://github.com/git-guides/git-add), [commit](https://github.com/git-guides/git-commit) and [push](https://github.com/git-guides/git-push) your code.
 
-###### 
+######
 <img width="861" alt="Create a Repo and Push to GitHub" src="https://user-images.githubusercontent.com/13063165/183423254-d2735278-a2ab-4d63-bb99-48d8e5e447bc.png"/>
 
 ## Opening the Workflows
 
 Click on the **Actions** tab to see the workflows. Here you will see if your tests have passed or failed.
 
-###### 
+######
 ![opening the workflow](https://user-images.githubusercontent.com/13063165/183423783-58bf2008-514e-4f96-9c12-c9a55703960c.png)
 
 ## Viewing Test Logs
 
 Clicking on the workflow run will show you the all the actions that GitHub performed and clicking on **Run Playwright tests** will show the error messages, what was expected and what was received as well as the call log.
 
-###### 
+######
 ![Viewing Test Logs](https://user-images.githubusercontent.com/13063165/183423783-58bf2008-514e-4f96-9c12-c9a55703960c.png)
 
 ## Viewing the Trace
@@ -89,7 +89,7 @@ Clicking on the workflow run will show you the all the actions that GitHub perfo
 - [Learn how to write Assertions](./test-assertions.mdx)
 - [Learn more about the Trace Viewer](/trace-viewer.mdx)
 - [Learn more ways of running tests on GitHub Actions](/ci.mdx)
-- [Learn more about running tests on other CI providers](/ci.mdx#github-actions) // TODO: is this link correct?
+- [Learn more about running tests on other CI providers](/ci.mdx#github-actions)
 
 
 [Accessibility]: /api/class-accessibility.mdx "Accessibility"


### PR DESCRIPTION
The links do point to the correct documentation, so there is no need for these TODOs anymore.

Weirdly enough I don't see this TODO in the source docs in the main playwright repo

https://github.com/microsoft/playwright/blob/main/docs/src/ci-intro.md

<!-- 
  Hey, thank you for your contribution!
  The actual source of the file which you are probably editing lives in this repository
  https://github.com/microsoft/playwright/blob/main/docs
  Thank you for doing the Pull Request there!
-->
