### PR TITLE
fix: make /intro/ work

### DIFF
--- a/dotnet/docusaurus.config.ts
+++ b/dotnet/docusaurus.config.ts
@@ -216,7 +216,7 @@ export default {
   customFields: {
     repositoryName: "playwright-dotnet",
   },
-  trailingSlash: false,
+  trailingSlash: true,
   webpack: {
     jsLoader: (isServer) => ({
       loader: require.resolve('swc-loader'),

--- a/java/docusaurus.config.ts
+++ b/java/docusaurus.config.ts
@@ -216,7 +216,7 @@ module.exports = {
   customFields: {
     repositoryName: "playwright-java",
   },
-  trailingSlash: false,
+  trailingSlash: true,
   webpack: {
     jsLoader: (isServer) => ({
       loader: require.resolve('swc-loader'),

--- a/nodejs/docusaurus.config.ts
+++ b/nodejs/docusaurus.config.ts
@@ -216,7 +216,7 @@ export default {
   customFields: {
     repositoryName: "playwright",
   },
-  trailingSlash: false,
+  trailingSlash: true,
   webpack: {
     jsLoader: (isServer) => ({
       loader: require.resolve('swc-loader'),

--- a/python/docusaurus.config.ts
+++ b/python/docusaurus.config.ts
@@ -217,7 +217,7 @@ export default {
   customFields: {
     repositoryName: "playwright-python",
   },
-  trailingSlash: false,
+  trailingSlash: true,
   webpack: {
     jsLoader: (isServer) => ({
       loader: require.resolve('swc-loader'),


### PR DESCRIPTION
Following https://github.com/slorber/trailing-slash-guide and https://docusaurus.io/docs/api/docusaurus-config#trailingSlash, setting `trailingSlash: true` will make Docusaurus emit `intro.md` as `/intro/index.html` instead of `/intro.html`. This will make GH Pages serve the file for both `/intro` and `/intro/`, as opposed to just for `/intro`.

Closes https://github.com/microsoft/playwright.dev/issues/1560 