### PR TITLE
improve the documentation for the typing example with the pytest plugin

### DIFF
--- a/python/docs/test-runners.mdx
+++ b/python/docs/test-runners.mdx
@@ -97,7 +97,7 @@ See [Running Tests](./running-tests.mdx) for general information on `pytest` opt
 
 ## Examples
 
-### Configure Mypy typings for auto-completion
+### Configure typings for auto-completion
 
 ```py title="test_my_application.py"
 from playwright.sync_api import Page
@@ -106,6 +106,8 @@ def test_visit_admin_dashboard(page: Page):
     page.goto("/admin")
     # ...
 ```
+
+If you're using VSCode with Pylance, these types can be inferred by enabling the `python.testing.pytestEnabled` setting so you don't need the type annotation.
 
 ### Configure slow mo
 

--- a/python/versioned_docs/version-stable/test-runners.mdx
+++ b/python/versioned_docs/version-stable/test-runners.mdx
@@ -97,7 +97,7 @@ See [Running Tests](./running-tests.mdx) for general information on `pytest` opt
 
 ## Examples
 
-### Configure Mypy typings for auto-completion
+### Configure typings for auto-completion
 
 ```py title="test_my_application.py"
 from playwright.sync_api import Page
@@ -106,6 +106,8 @@ def test_visit_admin_dashboard(page: Page):
     page.goto("/admin")
     # ...
 ```
+
+If you're using VSCode with Pylance, these types can be inferred by enabling the `python.testing.pytestEnabled` setting so you don't need the type annotation.
 
 ### Configure slow mo
 


### PR DESCRIPTION
- remove "Mypy" from the typing example because mypy does not have a language server and therefore does not have auto-completion
- add note about using pylance