### PR TITLE
fix: make roll runnable by default on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,26 +39,6 @@ npm run serve
 
 ### Running this on Windows
 
-If you don't already, you might need to set the default shell to `bash`.
-
-```powershell
-npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"
-```
-
-You can revert it later, if you have issues, by doing:
-
-```powershell
-npm config delete script-shell
-```
-
-In some cases, the `postinstall` script doesn't auto-run after `npm install`, in which case, you can run that manually:
-
-```sh
-npm run postinstall
-```
-
-That should bring your environment to a state ready for testing.
-
 To roll the docs in PowerShell, make sure you set the env variable correctly, i.e.:
 
 ```powershell

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "concurrently": "^9.0.1",
     "http-server": "^14.1.1",
     "lodash": "^4.17.21",
-    "rimraf -g": "^6.0.1",
+    "rimraf": "^6.0.1",
     "swc-loader": "^0.2.6",
     "typescript": "^5.6.2"
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "swizzle": "docusaurus swizzle",
     "clear": "docusaurus clear",
     "sync-upstream-scripts": "node src/sync_upstream_scripts.js",
-    "roll": "rm -rf nodejs/docs/* && rm -rf python/docs/* && rm -rf java/docs/* && rm -rf dotnet/docs/* && npm run sync-upstream-scripts && node src/generate.js",
+    "roll": "rimraf -g nodejs/docs/* && rimraf -g python/docs/* && rimraf -g java/docs/* && rimraf -g dotnet/docs/* && npm run sync-upstream-scripts && node src/generate.js",
     "start-dotnet": "concurrently \"node src/generate.js --watch csharp\" \"npm run start\"",
     "start-java": "concurrently \"node src/generate.js --watch java\" \"npm run start\"",
     "start-nodejs": "concurrently \"node src/generate.js --watch js\" \"npm run start\"",
@@ -24,12 +24,12 @@
     "build-python": "npm run cleanup && cp -r python/* . && node --max-old-space-size=4096 node_modules/.bin/docusaurus build --out-dir=build/python",
     "build-java": "npm run cleanup && cp -r java/* . && node --max-old-space-size=4096 node_modules/.bin/docusaurus build --out-dir=build/java",
     "build-dotnet": "npm run cleanup && cp -r dotnet/* . && node --max-old-space-size=4096 node_modules/.bin/docusaurus build --out-dir=build/dotnet",
-    "build": "tsc && rm -rf build && npm run build-nodejs && npm run build-python && npm run build-java && npm run build-dotnet",
+    "build": "tsc && rimraf -g build && npm run build-nodejs && npm run build-python && npm run build-java && npm run build-dotnet",
     "version-dotnet": "npm run prepare-dotnet && docusaurus docs:version stable && cp -r docs/* dotnet/docs/ && cp -r versioned_docs/* dotnet/versioned_docs/ && cp -r versioned_sidebars/* dotnet/versioned_sidebars/ && cp versions.json dotnet/",
     "version-java": "npm run prepare-java && docusaurus docs:version stable && cp -r docs/* java/docs/ && cp -r versioned_docs/* java/versioned_docs/ && cp -r versioned_sidebars/* java/versioned_sidebars/ && cp versions.json java/",
     "version-node": "npm run prepare-nodejs && docusaurus docs:version stable && cp -r docs/* nodejs/docs/ && cp -r versioned_docs/* nodejs/versioned_docs/ && cp -r versioned_sidebars/* nodejs/versioned_sidebars/ && cp versions.json nodejs/",
     "version-python": "npm run prepare-python && docusaurus docs:version stable && cp -r docs/* python/docs/ && cp -r versioned_docs/* python/versioned_docs/ && cp -r versioned_sidebars/* python/versioned_sidebars/ && cp versions.json python/",
-    "cleanup": "rm -rf docs versioned_docs versioned_sidebars docusaurus.config.ts versions.json sidebars.js",
+    "cleanup": "rimraf -g docs versioned_docs versioned_sidebars docusaurus.config.ts versions.json sidebars.js",
     "version-all": "npm run version-python && npm run version-node && npm run version-java && npm run version-dotnet",
     "serve": "docusaurus serve"
   },
@@ -69,7 +69,7 @@
     "concurrently": "^9.0.1",
     "http-server": "^14.1.1",
     "lodash": "^4.17.21",
-    "rimraf": "^6.0.1",
+    "rimraf -g": "^6.0.1",
     "swc-loader": "^0.2.6",
     "typescript": "^5.6.2"
   }


### PR DESCRIPTION
Makes `roll` runnable on Windows by default. This removes the need for Bash on Windows mentions in the README.