### PR TITLE
docs: Add comment explaining how Docusaurus starts up in current release mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ node src/versions.js --delete 1.16
 npm run start-nodejs
 ```
 
+> [!IMPORTANT]  
+> The docs will start up in "current release" mode by default. To see the latest version of the docs (and likely your changes), visit `/next` or press shift 5 times.
+
 See `package.json` for other languages (java, python, .NET).
 
 ### Run prod build and serve


### PR DESCRIPTION
Multiple times I have forgotten that my change can only be found in `/next` mode, and it's likely other contributors have the same issue. Document this common issue.