### PR TITLE
Add await to response.json() for async ApiResponse class

### DIFF
--- a/python/docs/api/class-apiresponse.mdx
+++ b/python/docs/api/class-apiresponse.mdx
@@ -45,7 +45,8 @@ async def run(playwright: Playwright):
     assert response.ok
     assert response.status == 200
     assert response.headers["content-type"] == "application/json; charset=utf-8"
-    assert await response.json()["name"] == "foobar"
+    json_data = await response.json()
+    assert json_data["name"] == "foobar"
     assert await response.body() == '{"status": "ok"}'
 
 

--- a/python/docs/api/class-apiresponse.mdx
+++ b/python/docs/api/class-apiresponse.mdx
@@ -45,7 +45,7 @@ async def run(playwright: Playwright):
     assert response.ok
     assert response.status == 200
     assert response.headers["content-type"] == "application/json; charset=utf-8"
-    assert response.json()["name"] == "foobar"
+    assert await response.json()["name"] == "foobar"
     assert await response.body() == '{"status": "ok"}'
 
 

--- a/python/versioned_docs/version-stable/api/class-apiresponse.mdx
+++ b/python/versioned_docs/version-stable/api/class-apiresponse.mdx
@@ -45,7 +45,8 @@ async def run(playwright: Playwright):
     assert response.ok
     assert response.status == 200
     assert response.headers["content-type"] == "application/json; charset=utf-8"
-    assert await response.json()["name"] == "foobar"
+    json_data = await response.json()
+    assert json_data["name"] == "foobar"
     assert await response.body() == '{"status": "ok"}'
 
 

--- a/python/versioned_docs/version-stable/api/class-apiresponse.mdx
+++ b/python/versioned_docs/version-stable/api/class-apiresponse.mdx
@@ -45,7 +45,7 @@ async def run(playwright: Playwright):
     assert response.ok
     assert response.status == 200
     assert response.headers["content-type"] == "application/json; charset=utf-8"
-    assert response.json()["name"] == "foobar"
+    assert await response.json()["name"] == "foobar"
     assert await response.body() == '{"status": "ok"}'
 
 


### PR DESCRIPTION
The current async [APIResponse class documentation in API Reference](https://playwright.dev/python/docs/api/class-apiresponse) has an incorrect line in the example - 

`assert response.json()["name"] == "foobar"`

As the async APIResponse `response.json()` returns a coroutine, this line will raise a `TypeError: 'coroutine' object is not subscriptable` exception.

Replacing it with 
```
json_data = await response.json()
assert json_data["name"] == "foobar"
```
will solve this and show the correct way to use `response.json()`
