### PR TITLE
Update test-runners.mdx

### DIFF
--- a/python/docs/test-runners.mdx
+++ b/python/docs/test-runners.mdx
@@ -257,7 +257,7 @@ See the [guides for CI providers](./ci.mdx) to deploy your tests to CI/CD.
 
 ## Async Fixtures
 
-To use async fixtures, install [`pytest-playwright-asyncio`](https://pypi.org/project/pytest-playwright-asyncio/).
+To use async fixtures, install [`pytest-playwright-asyncio`](https://pypi.org/project/pytest-playwright-asyncio/). (Do not install `pytest-playwright-asyncio` together with `pytest-playwright`)
 
 Ensure you are using `pytest-asyncio>=0.26.0` and set [`asyncio_default_test_loop_scope = session`](https://pytest-asyncio.readthedocs.io/en/v0.26.0/how-to-guides/change_default_test_loop.html) in your configuration (`pytest.ini/pyproject.toml/setup.cfg`).
 


### PR DESCRIPTION
Documents the need to not install packages together to prevent error "option names {'--browser'} already added"

When I installed both packages together I got the error message:

```
argparsing.py", line 403, in addoption
    raise ValueError(f"option names {conflict} already added")
ValueError: option names {'--browser'} already added
```

<!-- 
  Hey, thank you for your contribution!
  The actual source of the file which you are probably editing lives in this repository
  https://github.com/microsoft/playwright/blob/main/docs
  Thank you for doing the Pull Request there!
-->
