### PR TITLE
docs(Page.route): clarify handler argument signature

### DIFF
--- a/python/docs/api/class-page.mdx
+++ b/python/docs/api/class-page.mdx
@@ -2606,8 +2606,8 @@ Enabling routing disables http cache.
 - `url` [str] | [Pattern] | [Callable]\[[URL]\]:[bool]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-route-option-url"/><a href="#page-route-option-url" class="list-anchor">#</a>
   
   A glob pattern, regex pattern, or predicate that receives a [URL] to match during routing. If [base_url](/api/class-browser.mdx#browser-new-context-option-base-url) is set in the context options and the provided URL is a string that does not start with `*`, it is resolved using the [`new URL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) constructor.
-- `handler` [Callable]\[[Route], [Request]\]:[Promise]\[[Any]\] | [Any]<a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-route-option-handler"/><a href="#page-route-option-handler" class="list-anchor">#</a>
-  
+- `handler` [Callable]\[[Route]\] | [Callable]\[[Route], [Request]\]:[Promise]\[[Any]\] | [Any] <a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-route-option-handler"></a><a href="#page-route-option-handler" class="list-anchor">#</a>
+
   handler function to route the request.
 - `times` [int] *(optional)* <font size="2">Added in: v1.15</font><a aria-hidden="true" tabIndex="-1" class="list-anchor-link" id="page-route-option-times"/><a href="#page-route-option-times" class="list-anchor">#</a>
   


### PR DESCRIPTION
Update the documentation to reflect that the handler function can accept either a single argument (Route) or two arguments (Route, Request), improving accuracy and clarity.

https://github.com/microsoft/playwright-python/issues/2853

<!-- 
  Hey, thank you for your contribution!
  The actual source of the file which you are probably editing lives in this repository
  https://github.com/microsoft/playwright/blob/main/docs
  Thank you for doing the Pull Request there!
-->
