### PR TITLE
docs(community): highlight active link in video nav (aria-current)

### DIFF
--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -16,17 +16,41 @@
 
 import React, { type ReactNode } from 'react';
 import Link from '@docusaurus/Link';
+import { useLocation } from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './styles.module.css';
 
-function Navigation({ links }) {
+interface NavLink {
+  label: string;
+  href: string;
+}
+
+interface NavigationProps {
+  links: NavLink[];
+}
+
+function Navigation({ links }: NavigationProps) {
+  const location = useLocation();
+  
   return (
     <nav className="container">
       <ul className={styles.nav}>
-        {links.map((link, i) => (
-          <li key={i} className={styles.links}>
-            <Link href={link.href}>{link.label}</Link>
-          </li>
-        ))}
+        {links.map((link, i) => {
+          const baseHref = useBaseUrl(link.href);
+          const isActive = location.pathname === baseHref || 
+                          location.pathname.startsWith(baseHref + '/');
+          
+          return (
+            <li key={i} className={`${styles.links} ${isActive ? styles.active : ''}`}>
+              <Link 
+                href={link.href}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {link.label}
+              </Link>
+            </li>
+          );
+        })}
       </ul>
     </nav>
   );

--- a/src/components/Navigation/styles.module.css
+++ b/src/components/Navigation/styles.module.css
@@ -4,3 +4,8 @@
   gap: 2rem;
   justify-content: center;
 }
+
+.active a {
+  font-weight: 700;
+  text-decoration: underline;
+}


### PR DESCRIPTION
- make `Community video` navigation show the `active section` (bold + underline) and set `aria-current="page"` based on the current path (prefix-aware)
- applies to `Conference/Release/Live/Feature/Learn/MCP` pages
- no dependency changes.

<img width="1447" height="882" alt="Screenshot 2025-09-08 at 17 12 05" src="https://github.com/user-attachments/assets/59ccfe22-54b1-4465-9fad-5d4933b77ac5" />

<img width="1449" height="882" alt="Screenshot 2025-09-08 at 17 11 35" src="https://github.com/user-attachments/assets/7bd09849-1981-4c19-9b8e-1beed033888d" />

