### PR TITLE
chore: revert ProgressiveImage implementation in newly generated docs

### DIFF
--- a/dotnet/docs/actionability.mdx
+++ b/dotnet/docs/actionability.mdx
@@ -5,7 +5,6 @@ title: "Auto-waiting"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/api-testing.mdx
+++ b/dotnet/docs/api-testing.mdx
@@ -5,7 +5,6 @@ title: "API testing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/api/class-accessibility.mdx
+++ b/dotnet/docs/api/class-accessibility.mdx
@@ -5,7 +5,6 @@ title: "Accessibility"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 :::warning[Deprecated]

--- a/dotnet/docs/api/class-apirequest.mdx
+++ b/dotnet/docs/api/class-apirequest.mdx
@@ -5,7 +5,6 @@ title: "APIRequest"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Exposes API that can be used for the Web API testing. This class is used for creating [APIRequestContext] instance which in turn can be used for sending web requests. An instance of this class can be obtained via [Playwright.APIRequest](/api/class-playwright.mdx#playwright-request). For more information see [APIRequestContext].

--- a/dotnet/docs/api/class-apirequestcontext.mdx
+++ b/dotnet/docs/api/class-apirequestcontext.mdx
@@ -5,7 +5,6 @@ title: "APIRequestContext"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 This API is used for the Web API testing. You can use it to trigger API endpoints, configure micro-services, prepare environment or the service to your e2e test.

--- a/dotnet/docs/api/class-apiresponse.mdx
+++ b/dotnet/docs/api/class-apiresponse.mdx
@@ -5,7 +5,6 @@ title: "APIResponse"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [APIResponse] class represents responses returned by [ApiRequestContext.GetAsync()](/api/class-apirequestcontext.mdx#api-request-context-get) and similar methods.

--- a/dotnet/docs/api/class-apiresponseassertions.mdx
+++ b/dotnet/docs/api/class-apiresponseassertions.mdx
@@ -5,7 +5,6 @@ title: "APIResponseAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [APIResponseAssertions] class provides assertion methods that can be used to make assertions about the [APIResponse] in the tests.

--- a/dotnet/docs/api/class-browser.mdx
+++ b/dotnet/docs/api/class-browser.mdx
@@ -5,7 +5,6 @@ title: "Browser"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 A Browser is created via [BrowserType.LaunchAsync()](/api/class-browsertype.mdx#browser-type-launch). An example of using a [Browser] to create a [Page]:

--- a/dotnet/docs/api/class-browsercontext.mdx
+++ b/dotnet/docs/api/class-browsercontext.mdx
@@ -5,7 +5,6 @@ title: "BrowserContext"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 BrowserContexts provide a way to operate multiple independent browser sessions.

--- a/dotnet/docs/api/class-browsertype.mdx
+++ b/dotnet/docs/api/class-browsertype.mdx
@@ -5,7 +5,6 @@ title: "BrowserType"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 BrowserType provides methods to launch a specific browser instance or connect to an existing one. The following is a typical example of using Playwright to drive automation:

--- a/dotnet/docs/api/class-cdpsession.mdx
+++ b/dotnet/docs/api/class-cdpsession.mdx
@@ -5,7 +5,6 @@ title: "CDPSession"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The `CDPSession` instances are used to talk raw Chrome Devtools Protocol:

--- a/dotnet/docs/api/class-cdpsessionevent.mdx
+++ b/dotnet/docs/api/class-cdpsessionevent.mdx
@@ -5,7 +5,6 @@ title: "CDPSessionEvent"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [CDPSessionEvent] objects are returned by page via the [CdpSession.Event()](/api/class-cdpsession.mdx#cdp-session-event) method.

--- a/dotnet/docs/api/class-clock.mdx
+++ b/dotnet/docs/api/class-clock.mdx
@@ -5,7 +5,6 @@ title: "Clock"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Accurately simulating time-dependent behavior is essential for verifying the correctness of applications. Learn more about [clock emulation](../clock.mdx).

--- a/dotnet/docs/api/class-consolemessage.mdx
+++ b/dotnet/docs/api/class-consolemessage.mdx
@@ -5,7 +5,6 @@ title: "ConsoleMessage"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [ConsoleMessage] objects are dispatched by page via the [Page.Console](/api/class-page.mdx#page-event-console) event. For each console message logged in the page there will be corresponding event in the Playwright context.

--- a/dotnet/docs/api/class-dialog.mdx
+++ b/dotnet/docs/api/class-dialog.mdx
@@ -5,7 +5,6 @@ title: "Dialog"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Dialog] objects are dispatched by page via the [Page.Dialog](/api/class-page.mdx#page-event-dialog) event.

--- a/dotnet/docs/api/class-download.mdx
+++ b/dotnet/docs/api/class-download.mdx
@@ -5,7 +5,6 @@ title: "Download"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Download] objects are dispatched by page via the [Page.Download](/api/class-page.mdx#page-event-download) event.

--- a/dotnet/docs/api/class-elementhandle.mdx
+++ b/dotnet/docs/api/class-elementhandle.mdx
@@ -5,7 +5,6 @@ title: "ElementHandle"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 * extends: [JSHandle]
 

--- a/dotnet/docs/api/class-filechooser.mdx
+++ b/dotnet/docs/api/class-filechooser.mdx
@@ -5,7 +5,6 @@ title: "FileChooser"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [FileChooser] objects are dispatched by the page in the [Page.FileChooser](/api/class-page.mdx#page-event-file-chooser) event.

--- a/dotnet/docs/api/class-formdata.mdx
+++ b/dotnet/docs/api/class-formdata.mdx
@@ -5,7 +5,6 @@ title: "FormData"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [FormData] is used create form data that is sent via [APIRequestContext].

--- a/dotnet/docs/api/class-frame.mdx
+++ b/dotnet/docs/api/class-frame.mdx
@@ -5,7 +5,6 @@ title: "Frame"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 At every point of time, page exposes its current frame tree via the [Page.MainFrame](/api/class-page.mdx#page-main-frame) and [Frame.ChildFrames](/api/class-frame.mdx#frame-child-frames) methods.

--- a/dotnet/docs/api/class-framelocator.mdx
+++ b/dotnet/docs/api/class-framelocator.mdx
@@ -5,7 +5,6 @@ title: "FrameLocator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 FrameLocator represents a view to the `iframe` on the page. It captures the logic sufficient to retrieve the `iframe` and locate elements in that iframe. FrameLocator can be created with either [Locator.ContentFrame](/api/class-locator.mdx#locator-content-frame), [Page.FrameLocator()](/api/class-page.mdx#page-frame-locator) or [Locator.FrameLocator()](/api/class-locator.mdx#locator-frame-locator) method.

--- a/dotnet/docs/api/class-jshandle.mdx
+++ b/dotnet/docs/api/class-jshandle.mdx
@@ -5,7 +5,6 @@ title: "JSHandle"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 JSHandle represents an in-page JavaScript object. JSHandles can be created with the [Page.EvaluateHandleAsync()](/api/class-page.mdx#page-evaluate-handle) method.

--- a/dotnet/docs/api/class-keyboard.mdx
+++ b/dotnet/docs/api/class-keyboard.mdx
@@ -5,7 +5,6 @@ title: "Keyboard"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Keyboard provides an api for managing a virtual keyboard. The high level api is [Keyboard.TypeAsync()](/api/class-keyboard.mdx#keyboard-type), which takes raw characters and generates proper `keydown`, `keypress`/`input`, and `keyup` events on your page.

--- a/dotnet/docs/api/class-locator.mdx
+++ b/dotnet/docs/api/class-locator.mdx
@@ -5,7 +5,6 @@ title: "Locator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Locators are the central piece of Playwright's auto-waiting and retry-ability. In a nutshell, locators represent a way to find element(s) on the page at any moment. A locator can be created with the [Page.Locator()](/api/class-page.mdx#page-locator) method.

--- a/dotnet/docs/api/class-locatorassertions.mdx
+++ b/dotnet/docs/api/class-locatorassertions.mdx
@@ -5,7 +5,6 @@ title: "LocatorAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [LocatorAssertions] class provides assertion methods that can be used to make assertions about the [Locator] state in the tests.

--- a/dotnet/docs/api/class-mouse.mdx
+++ b/dotnet/docs/api/class-mouse.mdx
@@ -5,7 +5,6 @@ title: "Mouse"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.

--- a/dotnet/docs/api/class-page.mdx
+++ b/dotnet/docs/api/class-page.mdx
@@ -5,7 +5,6 @@ title: "Page"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Page provides methods to interact with a single tab in a [Browser], or an [extension background page](https://developer.chrome.com/extensions/background_pages) in Chromium. One [Browser] instance might have multiple [Page] instances.

--- a/dotnet/docs/api/class-pageassertions.mdx
+++ b/dotnet/docs/api/class-pageassertions.mdx
@@ -5,7 +5,6 @@ title: "PageAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [PageAssertions] class provides assertion methods that can be used to make assertions about the [Page] state in the tests.

--- a/dotnet/docs/api/class-playwright.mdx
+++ b/dotnet/docs/api/class-playwright.mdx
@@ -5,7 +5,6 @@ title: "Playwright"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright module provides a method to launch a browser instance. The following is a typical example of using Playwright to drive automation:

--- a/dotnet/docs/api/class-playwrightassertions.mdx
+++ b/dotnet/docs/api/class-playwrightassertions.mdx
@@ -5,7 +5,6 @@ title: "PlaywrightAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright gives you Web-First Assertions with convenience methods for creating assertions that will wait and retry until the expected condition is met.

--- a/dotnet/docs/api/class-request.mdx
+++ b/dotnet/docs/api/class-request.mdx
@@ -5,7 +5,6 @@ title: "Request"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever the page sends a request for a network resource the following sequence of events are emitted by [Page]:

--- a/dotnet/docs/api/class-response.mdx
+++ b/dotnet/docs/api/class-response.mdx
@@ -5,7 +5,6 @@ title: "Response"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Response] class represents responses which are received by page.

--- a/dotnet/docs/api/class-route.mdx
+++ b/dotnet/docs/api/class-route.mdx
@@ -5,7 +5,6 @@ title: "Route"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever a network route is set up with [Page.RouteAsync()](/api/class-page.mdx#page-route) or [BrowserContext.RouteAsync()](/api/class-browsercontext.mdx#browser-context-route), the `Route` object allows to handle the route.

--- a/dotnet/docs/api/class-selectors.mdx
+++ b/dotnet/docs/api/class-selectors.mdx
@@ -5,7 +5,6 @@ title: "Selectors"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Selectors can be used to install custom selector engines. See [extensibility](../extensibility.mdx) for more information.

--- a/dotnet/docs/api/class-timeouterror.mdx
+++ b/dotnet/docs/api/class-timeouterror.mdx
@@ -5,7 +5,6 @@ title: "TimeoutError"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 * extends: [Error]
 

--- a/dotnet/docs/api/class-touchscreen.mdx
+++ b/dotnet/docs/api/class-touchscreen.mdx
@@ -5,7 +5,6 @@ title: "Touchscreen"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Touchscreen class operates in main-frame CSS pixels relative to the top-left corner of the viewport. Methods on the touchscreen can only be used in browser contexts that have been initialized with `hasTouch` set to true.

--- a/dotnet/docs/api/class-tracing.mdx
+++ b/dotnet/docs/api/class-tracing.mdx
@@ -5,7 +5,6 @@ title: "Tracing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 API for collecting and saving Playwright traces. Playwright traces can be opened in [Trace Viewer](../trace-viewer.mdx) after Playwright script runs.

--- a/dotnet/docs/api/class-video.mdx
+++ b/dotnet/docs/api/class-video.mdx
@@ -5,7 +5,6 @@ title: "Video"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 When browser context is created with the `recordVideo` option, each page has a video object associated with it.

--- a/dotnet/docs/api/class-weberror.mdx
+++ b/dotnet/docs/api/class-weberror.mdx
@@ -5,7 +5,6 @@ title: "WebError"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [WebError] class represents an unhandled exception thrown in the page. It is dispatched via the [BrowserContext.WebError](/api/class-browsercontext.mdx#browser-context-event-web-error) event.

--- a/dotnet/docs/api/class-websocket.mdx
+++ b/dotnet/docs/api/class-websocket.mdx
@@ -5,7 +5,6 @@ title: "WebSocket"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [WebSocket] class represents WebSocket connections within a page. It provides the ability to inspect and manipulate the data being transmitted and received.

--- a/dotnet/docs/api/class-websocketframe.mdx
+++ b/dotnet/docs/api/class-websocketframe.mdx
@@ -5,7 +5,6 @@ title: "WebSocketFrame"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [WebSocketFrame] class represents frames sent over [WebSocket] connections in the page. Frame payload is returned by either [WebSocketFrame.Text](/api/class-websocketframe.mdx#web-socket-frame-text) or [WebSocketFrame.Binary](/api/class-websocketframe.mdx#web-socket-frame-binary) method depending on the its type.

--- a/dotnet/docs/api/class-websocketroute.mdx
+++ b/dotnet/docs/api/class-websocketroute.mdx
@@ -5,7 +5,6 @@ title: "WebSocketRoute"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever a [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) route is set up with [Page.RouteWebSocketAsync()](/api/class-page.mdx#page-route-web-socket) or [BrowserContext.RouteWebSocketAsync()](/api/class-browsercontext.mdx#browser-context-route-web-socket), the `WebSocketRoute` object allows to handle the WebSocket, like an actual server would do.

--- a/dotnet/docs/api/class-worker.mdx
+++ b/dotnet/docs/api/class-worker.mdx
@@ -5,7 +5,6 @@ title: "Worker"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Worker class represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). `worker` event is emitted on the page object to signal a worker creation. `close` event is emitted on the worker object when the worker is gone.

--- a/dotnet/docs/aria-snapshots.mdx
+++ b/dotnet/docs/aria-snapshots.mdx
@@ -5,7 +5,6 @@ title: "Snapshot testing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/dotnet/docs/auth.mdx
+++ b/dotnet/docs/auth.mdx
@@ -5,7 +5,6 @@ title: "Authentication"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/browser-contexts.mdx
+++ b/dotnet/docs/browser-contexts.mdx
@@ -5,7 +5,6 @@ title: "Isolation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/browsers.mdx
+++ b/dotnet/docs/browsers.mdx
@@ -5,7 +5,6 @@ title: "Browsers"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/ci-intro.mdx
+++ b/dotnet/docs/ci-intro.mdx
@@ -5,7 +5,6 @@ title: "Setting up CI"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 
@@ -84,7 +83,7 @@ Clicking on the workflow run shows you all the actions that GitHub performed and
 You can upload Traces which get created on your CI like GitHub Actions as artifacts. This requires [starting and stopping the trace](./trace-viewer-intro#recording-a-trace). We recommend only recording traces for failing tests. Once your traces have been uploaded to CI, they can then be downloaded and opened using [trace.playwright.dev](https://trace.playwright.dev), which is a statically hosted variant of the Trace Viewer. You can upload trace files using drag and drop.
 
 ###### 
-<ProgressiveImage image={require("../images/getting-started/trace-viewer-failed-test.png")} alt="playwright trace viewer" />
+![playwright trace viewer](../images/getting-started/trace-viewer-failed-test.png)
 
 ## Properly handling Secrets
 

--- a/dotnet/docs/ci.mdx
+++ b/dotnet/docs/ci.mdx
@@ -5,7 +5,6 @@ title: "Continuous Integration"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/clock.mdx
+++ b/dotnet/docs/clock.mdx
@@ -5,7 +5,6 @@ title: "Clock"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/dotnet/docs/codegen-intro.mdx
+++ b/dotnet/docs/codegen-intro.mdx
@@ -5,7 +5,6 @@ title: "Generating tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 
@@ -35,7 +34,7 @@ With the test generator you can record:
   * `'assert value'` to assert that an element has a specific value
 
 ###### 
-<ProgressiveImage image={require("../images/getting-started/record-test-csharp.png")} alt="recording a test" />
+![recording a test](../images/getting-started/record-test-csharp.png)
 
 ###### 
 When you finish interacting with the page, press the `'record'` button to stop recording and use the `'copy'` button to copy the generated code to your editor.
@@ -54,7 +53,7 @@ You can generate [locators](/locators.mdx) with the test generator.
 * Use the copy button to copy the locator and paste it into your code
 
 ###### 
-<ProgressiveImage image={require("../images/getting-started/pick-locator-csharp.png")} alt="picking a locator" />
+![picking a locator](../images/getting-started/pick-locator-csharp.png)
 
 ### Emulation
 

--- a/dotnet/docs/codegen.mdx
+++ b/dotnet/docs/codegen.mdx
@@ -5,7 +5,6 @@ title: "Test generator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/dotnet/docs/debug.mdx
+++ b/dotnet/docs/debug.mdx
@@ -5,7 +5,6 @@ title: "Debugging Tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Playwright Inspector
 

--- a/dotnet/docs/dialogs.mdx
+++ b/dotnet/docs/dialogs.mdx
@@ -5,7 +5,6 @@ title: "Dialogs"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/docker.mdx
+++ b/dotnet/docs/docker.mdx
@@ -5,7 +5,6 @@ title: "Docker"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/downloads.mdx
+++ b/dotnet/docs/downloads.mdx
@@ -5,7 +5,6 @@ title: "Downloads"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/emulation.mdx
+++ b/dotnet/docs/emulation.mdx
@@ -5,7 +5,6 @@ title: "Emulation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/evaluating.mdx
+++ b/dotnet/docs/evaluating.mdx
@@ -5,7 +5,6 @@ title: "Evaluating JavaScript"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/events.mdx
+++ b/dotnet/docs/events.mdx
@@ -5,7 +5,6 @@ title: "Events"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/extensibility.mdx
+++ b/dotnet/docs/extensibility.mdx
@@ -5,7 +5,6 @@ title: "Extensibility"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Custom selector engines
 

--- a/dotnet/docs/frames.mdx
+++ b/dotnet/docs/frames.mdx
@@ -5,7 +5,6 @@ title: "Frames"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/handles.mdx
+++ b/dotnet/docs/handles.mdx
@@ -5,7 +5,6 @@ title: "Handles"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/input.mdx
+++ b/dotnet/docs/input.mdx
@@ -5,7 +5,6 @@ title: "Actions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/intro.mdx
+++ b/dotnet/docs/intro.mdx
@@ -5,7 +5,6 @@ title: "Installation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/languages.mdx
+++ b/dotnet/docs/languages.mdx
@@ -5,7 +5,6 @@ title: "Supported languages"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/library.mdx
+++ b/dotnet/docs/library.mdx
@@ -5,7 +5,6 @@ title: "Getting started - Library"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/locators.mdx
+++ b/dotnet/docs/locators.mdx
@@ -5,7 +5,6 @@ title: "Locators"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/mock.mdx
+++ b/dotnet/docs/mock.mdx
@@ -5,7 +5,6 @@ title: "Mock APIs"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/navigations.mdx
+++ b/dotnet/docs/navigations.mdx
@@ -5,7 +5,6 @@ title: "Navigations"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/network.mdx
+++ b/dotnet/docs/network.mdx
@@ -5,7 +5,6 @@ title: "Network"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/other-locators.mdx
+++ b/dotnet/docs/other-locators.mdx
@@ -5,7 +5,6 @@ title: "Other locators"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/pages.mdx
+++ b/dotnet/docs/pages.mdx
@@ -5,7 +5,6 @@ title: "Pages"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Pages
 

--- a/dotnet/docs/pom.mdx
+++ b/dotnet/docs/pom.mdx
@@ -5,7 +5,6 @@ title: "Page object models"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/release-notes.mdx
+++ b/dotnet/docs/release-notes.mdx
@@ -6,7 +6,6 @@ toc_max_heading_level: 2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Version 1.55
 

--- a/dotnet/docs/running-tests.mdx
+++ b/dotnet/docs/running-tests.mdx
@@ -5,7 +5,6 @@ title: "Running and debugging tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/screenshots.mdx
+++ b/dotnet/docs/screenshots.mdx
@@ -5,7 +5,6 @@ title: "Screenshots"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/selenium-grid.mdx
+++ b/dotnet/docs/selenium-grid.mdx
@@ -5,7 +5,6 @@ title: "Selenium Grid (experimental)"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/test-assertions.mdx
+++ b/dotnet/docs/test-assertions.mdx
@@ -5,7 +5,6 @@ title: "Assertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## List of assertions
 

--- a/dotnet/docs/test-runners.mdx
+++ b/dotnet/docs/test-runners.mdx
@@ -5,7 +5,6 @@ title: "Test Runners"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/touch-events.mdx
+++ b/dotnet/docs/touch-events.mdx
@@ -5,7 +5,6 @@ title: "Touch events (legacy)"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/trace-viewer-intro.mdx
+++ b/dotnet/docs/trace-viewer-intro.mdx
@@ -5,7 +5,6 @@ title: "Trace viewer"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/trace-viewer.mdx
+++ b/dotnet/docs/trace-viewer.mdx
@@ -5,7 +5,6 @@ title: "Trace viewer"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/dotnet/docs/videos.mdx
+++ b/dotnet/docs/videos.mdx
@@ -5,7 +5,6 @@ title: "Videos"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/webview2.mdx
+++ b/dotnet/docs/webview2.mdx
@@ -5,7 +5,6 @@ title: "WebView2"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/dotnet/docs/writing-tests.mdx
+++ b/dotnet/docs/writing-tests.mdx
@@ -5,7 +5,6 @@ title: "Writing tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/accessibility-testing.mdx
+++ b/java/docs/accessibility-testing.mdx
@@ -5,7 +5,6 @@ title: "Accessibility testing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/actionability.mdx
+++ b/java/docs/actionability.mdx
@@ -5,7 +5,6 @@ title: "Auto-waiting"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/api-testing.mdx
+++ b/java/docs/api-testing.mdx
@@ -5,7 +5,6 @@ title: "API testing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/api/class-apirequest.mdx
+++ b/java/docs/api/class-apirequest.mdx
@@ -5,7 +5,6 @@ title: "APIRequest"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Exposes API that can be used for the Web API testing. This class is used for creating [APIRequestContext] instance which in turn can be used for sending web requests. An instance of this class can be obtained via [Playwright.request()](/api/class-playwright.mdx#playwright-request). For more information see [APIRequestContext].

--- a/java/docs/api/class-apirequestcontext.mdx
+++ b/java/docs/api/class-apirequestcontext.mdx
@@ -5,7 +5,6 @@ title: "APIRequestContext"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 This API is used for the Web API testing. You can use it to trigger API endpoints, configure micro-services, prepare environment or the service to your e2e test.

--- a/java/docs/api/class-apiresponse.mdx
+++ b/java/docs/api/class-apiresponse.mdx
@@ -5,7 +5,6 @@ title: "APIResponse"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [APIResponse] class represents responses returned by [APIRequestContext.get()](/api/class-apirequestcontext.mdx#api-request-context-get) and similar methods.

--- a/java/docs/api/class-apiresponseassertions.mdx
+++ b/java/docs/api/class-apiresponseassertions.mdx
@@ -5,7 +5,6 @@ title: "APIResponseAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [APIResponseAssertions] class provides assertion methods that can be used to make assertions about the [APIResponse] in the tests.

--- a/java/docs/api/class-browser.mdx
+++ b/java/docs/api/class-browser.mdx
@@ -5,7 +5,6 @@ title: "Browser"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 A Browser is created via [BrowserType.launch()](/api/class-browsertype.mdx#browser-type-launch). An example of using a [Browser] to create a [Page]:

--- a/java/docs/api/class-browsercontext.mdx
+++ b/java/docs/api/class-browsercontext.mdx
@@ -5,7 +5,6 @@ title: "BrowserContext"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 BrowserContexts provide a way to operate multiple independent browser sessions.

--- a/java/docs/api/class-browsertype.mdx
+++ b/java/docs/api/class-browsertype.mdx
@@ -5,7 +5,6 @@ title: "BrowserType"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 BrowserType provides methods to launch a specific browser instance or connect to an existing one. The following is a typical example of using Playwright to drive automation:

--- a/java/docs/api/class-cdpsession.mdx
+++ b/java/docs/api/class-cdpsession.mdx
@@ -5,7 +5,6 @@ title: "CDPSession"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The `CDPSession` instances are used to talk raw Chrome Devtools Protocol:

--- a/java/docs/api/class-clock.mdx
+++ b/java/docs/api/class-clock.mdx
@@ -5,7 +5,6 @@ title: "Clock"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Accurately simulating time-dependent behavior is essential for verifying the correctness of applications. Learn more about [clock emulation](../clock.mdx).

--- a/java/docs/api/class-consolemessage.mdx
+++ b/java/docs/api/class-consolemessage.mdx
@@ -5,7 +5,6 @@ title: "ConsoleMessage"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [ConsoleMessage] objects are dispatched by page via the [Page.onConsoleMessage(handler)](/api/class-page.mdx#page-event-console) event. For each console message logged in the page there will be corresponding event in the Playwright context.

--- a/java/docs/api/class-dialog.mdx
+++ b/java/docs/api/class-dialog.mdx
@@ -5,7 +5,6 @@ title: "Dialog"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Dialog] objects are dispatched by page via the [Page.onDialog(handler)](/api/class-page.mdx#page-event-dialog) event.

--- a/java/docs/api/class-download.mdx
+++ b/java/docs/api/class-download.mdx
@@ -5,7 +5,6 @@ title: "Download"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Download] objects are dispatched by page via the [Page.onDownload(handler)](/api/class-page.mdx#page-event-download) event.

--- a/java/docs/api/class-elementhandle.mdx
+++ b/java/docs/api/class-elementhandle.mdx
@@ -5,7 +5,6 @@ title: "ElementHandle"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 * extends: [JSHandle]
 

--- a/java/docs/api/class-filechooser.mdx
+++ b/java/docs/api/class-filechooser.mdx
@@ -5,7 +5,6 @@ title: "FileChooser"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [FileChooser] objects are dispatched by the page in the [Page.onFileChooser(handler)](/api/class-page.mdx#page-event-file-chooser) event.

--- a/java/docs/api/class-formdata.mdx
+++ b/java/docs/api/class-formdata.mdx
@@ -5,7 +5,6 @@ title: "FormData"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [FormData] is used create form data that is sent via [APIRequestContext].

--- a/java/docs/api/class-frame.mdx
+++ b/java/docs/api/class-frame.mdx
@@ -5,7 +5,6 @@ title: "Frame"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 At every point of time, page exposes its current frame tree via the [Page.mainFrame()](/api/class-page.mdx#page-main-frame) and [Frame.childFrames()](/api/class-frame.mdx#frame-child-frames) methods.

--- a/java/docs/api/class-framelocator.mdx
+++ b/java/docs/api/class-framelocator.mdx
@@ -5,7 +5,6 @@ title: "FrameLocator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 FrameLocator represents a view to the `iframe` on the page. It captures the logic sufficient to retrieve the `iframe` and locate elements in that iframe. FrameLocator can be created with either [Locator.contentFrame()](/api/class-locator.mdx#locator-content-frame), [Page.frameLocator()](/api/class-page.mdx#page-frame-locator) or [Locator.frameLocator()](/api/class-locator.mdx#locator-frame-locator) method.

--- a/java/docs/api/class-jshandle.mdx
+++ b/java/docs/api/class-jshandle.mdx
@@ -5,7 +5,6 @@ title: "JSHandle"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 JSHandle represents an in-page JavaScript object. JSHandles can be created with the [Page.evaluateHandle()](/api/class-page.mdx#page-evaluate-handle) method.

--- a/java/docs/api/class-keyboard.mdx
+++ b/java/docs/api/class-keyboard.mdx
@@ -5,7 +5,6 @@ title: "Keyboard"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Keyboard provides an api for managing a virtual keyboard. The high level api is [Keyboard.type()](/api/class-keyboard.mdx#keyboard-type), which takes raw characters and generates proper `keydown`, `keypress`/`input`, and `keyup` events on your page.

--- a/java/docs/api/class-locator.mdx
+++ b/java/docs/api/class-locator.mdx
@@ -5,7 +5,6 @@ title: "Locator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Locators are the central piece of Playwright's auto-waiting and retry-ability. In a nutshell, locators represent a way to find element(s) on the page at any moment. A locator can be created with the [Page.locator()](/api/class-page.mdx#page-locator) method.

--- a/java/docs/api/class-locatorassertions.mdx
+++ b/java/docs/api/class-locatorassertions.mdx
@@ -5,7 +5,6 @@ title: "LocatorAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [LocatorAssertions] class provides assertion methods that can be used to make assertions about the [Locator] state in the tests.

--- a/java/docs/api/class-mouse.mdx
+++ b/java/docs/api/class-mouse.mdx
@@ -5,7 +5,6 @@ title: "Mouse"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.

--- a/java/docs/api/class-page.mdx
+++ b/java/docs/api/class-page.mdx
@@ -5,7 +5,6 @@ title: "Page"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Page provides methods to interact with a single tab in a [Browser], or an [extension background page](https://developer.chrome.com/extensions/background_pages) in Chromium. One [Browser] instance might have multiple [Page] instances.

--- a/java/docs/api/class-pageassertions.mdx
+++ b/java/docs/api/class-pageassertions.mdx
@@ -5,7 +5,6 @@ title: "PageAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [PageAssertions] class provides assertion methods that can be used to make assertions about the [Page] state in the tests.

--- a/java/docs/api/class-playwright.mdx
+++ b/java/docs/api/class-playwright.mdx
@@ -5,7 +5,6 @@ title: "Playwright"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright module provides a method to launch a browser instance. The following is a typical example of using Playwright to drive automation:

--- a/java/docs/api/class-playwrightassertions.mdx
+++ b/java/docs/api/class-playwrightassertions.mdx
@@ -5,7 +5,6 @@ title: "PlaywrightAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright gives you Web-First Assertions with convenience methods for creating assertions that will wait and retry until the expected condition is met.

--- a/java/docs/api/class-playwrightexception.mdx
+++ b/java/docs/api/class-playwrightexception.mdx
@@ -5,7 +5,6 @@ title: "PlaywrightException"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 * extends: [RuntimeException]
 

--- a/java/docs/api/class-request.mdx
+++ b/java/docs/api/class-request.mdx
@@ -5,7 +5,6 @@ title: "Request"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever the page sends a request for a network resource the following sequence of events are emitted by [Page]:

--- a/java/docs/api/class-requestoptions.mdx
+++ b/java/docs/api/class-requestoptions.mdx
@@ -5,7 +5,6 @@ title: "RequestOptions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [RequestOptions] allows to create form data to be sent via [APIRequestContext]. Playwright will automatically determine content type of the request.

--- a/java/docs/api/class-response.mdx
+++ b/java/docs/api/class-response.mdx
@@ -5,7 +5,6 @@ title: "Response"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Response] class represents responses which are received by page.

--- a/java/docs/api/class-route.mdx
+++ b/java/docs/api/class-route.mdx
@@ -5,7 +5,6 @@ title: "Route"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever a network route is set up with [Page.route()](/api/class-page.mdx#page-route) or [BrowserContext.route()](/api/class-browsercontext.mdx#browser-context-route), the `Route` object allows to handle the route.

--- a/java/docs/api/class-selectors.mdx
+++ b/java/docs/api/class-selectors.mdx
@@ -5,7 +5,6 @@ title: "Selectors"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Selectors can be used to install custom selector engines. See [extensibility](../extensibility.mdx) for more information.

--- a/java/docs/api/class-timeouterror.mdx
+++ b/java/docs/api/class-timeouterror.mdx
@@ -5,7 +5,6 @@ title: "TimeoutError"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 * extends: [PlaywrightException]
 

--- a/java/docs/api/class-touchscreen.mdx
+++ b/java/docs/api/class-touchscreen.mdx
@@ -5,7 +5,6 @@ title: "Touchscreen"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Touchscreen class operates in main-frame CSS pixels relative to the top-left corner of the viewport. Methods on the touchscreen can only be used in browser contexts that have been initialized with `hasTouch` set to true.

--- a/java/docs/api/class-tracing.mdx
+++ b/java/docs/api/class-tracing.mdx
@@ -5,7 +5,6 @@ title: "Tracing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 API for collecting and saving Playwright traces. Playwright traces can be opened in [Trace Viewer](../trace-viewer.mdx) after Playwright script runs.

--- a/java/docs/api/class-video.mdx
+++ b/java/docs/api/class-video.mdx
@@ -5,7 +5,6 @@ title: "Video"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 When browser context is created with the `recordVideo` option, each page has a video object associated with it.

--- a/java/docs/api/class-weberror.mdx
+++ b/java/docs/api/class-weberror.mdx
@@ -5,7 +5,6 @@ title: "WebError"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [WebError] class represents an unhandled exception thrown in the page. It is dispatched via the [BrowserContext.onWebError(handler)](/api/class-browsercontext.mdx#browser-context-event-web-error) event.

--- a/java/docs/api/class-websocket.mdx
+++ b/java/docs/api/class-websocket.mdx
@@ -5,7 +5,6 @@ title: "WebSocket"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [WebSocket] class represents WebSocket connections within a page. It provides the ability to inspect and manipulate the data being transmitted and received.

--- a/java/docs/api/class-websocketframe.mdx
+++ b/java/docs/api/class-websocketframe.mdx
@@ -5,7 +5,6 @@ title: "WebSocketFrame"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [WebSocketFrame] class represents frames sent over [WebSocket] connections in the page. Frame payload is returned by either [WebSocketFrame.text()](/api/class-websocketframe.mdx#web-socket-frame-text) or [WebSocketFrame.binary()](/api/class-websocketframe.mdx#web-socket-frame-binary) method depending on the its type.

--- a/java/docs/api/class-websocketroute.mdx
+++ b/java/docs/api/class-websocketroute.mdx
@@ -5,7 +5,6 @@ title: "WebSocketRoute"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever a [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) route is set up with [Page.routeWebSocket()](/api/class-page.mdx#page-route-web-socket) or [BrowserContext.routeWebSocket()](/api/class-browsercontext.mdx#browser-context-route-web-socket), the `WebSocketRoute` object allows to handle the WebSocket, like an actual server would do.

--- a/java/docs/api/class-worker.mdx
+++ b/java/docs/api/class-worker.mdx
@@ -5,7 +5,6 @@ title: "Worker"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Worker class represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). `worker` event is emitted on the page object to signal a worker creation. `close` event is emitted on the worker object when the worker is gone.

--- a/java/docs/aria-snapshots.mdx
+++ b/java/docs/aria-snapshots.mdx
@@ -5,7 +5,6 @@ title: "Snapshot testing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/java/docs/auth.mdx
+++ b/java/docs/auth.mdx
@@ -5,7 +5,6 @@ title: "Authentication"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/browser-contexts.mdx
+++ b/java/docs/browser-contexts.mdx
@@ -5,7 +5,6 @@ title: "Isolation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/browsers.mdx
+++ b/java/docs/browsers.mdx
@@ -5,7 +5,6 @@ title: "Browsers"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/ci-intro.mdx
+++ b/java/docs/ci-intro.mdx
@@ -5,7 +5,6 @@ title: "Setting up CI"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 
@@ -79,7 +78,7 @@ Clicking on the workflow run shows you all the actions that GitHub performed and
 
 [trace.playwright.dev](https://trace.playwright.dev) is a statically hosted variant of the Trace Viewer. You can upload trace files using drag and drop.
 
-<ProgressiveImage image={require("../images/getting-started/trace-viewer-failed-test.png")} alt="playwright trace viewer" />
+![playwright trace viewer](../images/getting-started/trace-viewer-failed-test.png)
 
 ## Properly handling Secrets
 

--- a/java/docs/ci.mdx
+++ b/java/docs/ci.mdx
@@ -5,7 +5,6 @@ title: "Continuous Integration"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/clock.mdx
+++ b/java/docs/clock.mdx
@@ -5,7 +5,6 @@ title: "Clock"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/java/docs/codegen-intro.mdx
+++ b/java/docs/codegen-intro.mdx
@@ -5,7 +5,6 @@ title: "Generating tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 
@@ -35,7 +34,7 @@ With the test generator you can record:
   * `'assert value'` to assert that an element has a specific value
 
 ###### 
-<ProgressiveImage image={require("../images/getting-started/record-test-java.png")} alt="recording a test" />
+![recording a test](../images/getting-started/record-test-java.png)
 
 ###### 
 When you finish interacting with the page, press the `'record'` button to stop recording and use the `'copy'` button to copy the generated code to your editor.
@@ -54,7 +53,7 @@ You can generate [locators](/locators.mdx) with the test generator.
 * Use the copy button to copy the locator and paste it into your code
 
 ###### 
-<ProgressiveImage image={require("../images/getting-started/pick-locator-java.png")} alt="picking a locator" />
+![picking a locator](../images/getting-started/pick-locator-java.png)
 
 ### Emulation
 

--- a/java/docs/codegen.mdx
+++ b/java/docs/codegen.mdx
@@ -5,7 +5,6 @@ title: "Test generator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/java/docs/debug.mdx
+++ b/java/docs/debug.mdx
@@ -5,7 +5,6 @@ title: "Debugging Tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Playwright Inspector
 

--- a/java/docs/dialogs.mdx
+++ b/java/docs/dialogs.mdx
@@ -5,7 +5,6 @@ title: "Dialogs"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/docker.mdx
+++ b/java/docs/docker.mdx
@@ -5,7 +5,6 @@ title: "Docker"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/downloads.mdx
+++ b/java/docs/downloads.mdx
@@ -5,7 +5,6 @@ title: "Downloads"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/emulation.mdx
+++ b/java/docs/emulation.mdx
@@ -5,7 +5,6 @@ title: "Emulation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/evaluating.mdx
+++ b/java/docs/evaluating.mdx
@@ -5,7 +5,6 @@ title: "Evaluating JavaScript"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/events.mdx
+++ b/java/docs/events.mdx
@@ -5,7 +5,6 @@ title: "Events"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/extensibility.mdx
+++ b/java/docs/extensibility.mdx
@@ -5,7 +5,6 @@ title: "Extensibility"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Custom selector engines
 

--- a/java/docs/frames.mdx
+++ b/java/docs/frames.mdx
@@ -5,7 +5,6 @@ title: "Frames"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/handles.mdx
+++ b/java/docs/handles.mdx
@@ -5,7 +5,6 @@ title: "Handles"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/input.mdx
+++ b/java/docs/input.mdx
@@ -5,7 +5,6 @@ title: "Actions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/intro.mdx
+++ b/java/docs/intro.mdx
@@ -5,7 +5,6 @@ title: "Installation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/junit.mdx
+++ b/java/docs/junit.mdx
@@ -5,7 +5,6 @@ title: "JUnit (experimental)"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/languages.mdx
+++ b/java/docs/languages.mdx
@@ -5,7 +5,6 @@ title: "Supported languages"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/locators.mdx
+++ b/java/docs/locators.mdx
@@ -5,7 +5,6 @@ title: "Locators"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/mock.mdx
+++ b/java/docs/mock.mdx
@@ -5,7 +5,6 @@ title: "Mock APIs"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/navigations.mdx
+++ b/java/docs/navigations.mdx
@@ -5,7 +5,6 @@ title: "Navigations"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/network.mdx
+++ b/java/docs/network.mdx
@@ -5,7 +5,6 @@ title: "Network"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/other-locators.mdx
+++ b/java/docs/other-locators.mdx
@@ -5,7 +5,6 @@ title: "Other locators"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/pages.mdx
+++ b/java/docs/pages.mdx
@@ -5,7 +5,6 @@ title: "Pages"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Pages
 

--- a/java/docs/pom.mdx
+++ b/java/docs/pom.mdx
@@ -5,7 +5,6 @@ title: "Page object models"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/release-notes.mdx
+++ b/java/docs/release-notes.mdx
@@ -6,7 +6,6 @@ toc_max_heading_level: 2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Version 1.55
 

--- a/java/docs/running-tests.mdx
+++ b/java/docs/running-tests.mdx
@@ -5,7 +5,6 @@ title: "Running and debugging tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/screenshots.mdx
+++ b/java/docs/screenshots.mdx
@@ -5,7 +5,6 @@ title: "Screenshots"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/selenium-grid.mdx
+++ b/java/docs/selenium-grid.mdx
@@ -5,7 +5,6 @@ title: "Selenium Grid (experimental)"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/test-assertions.mdx
+++ b/java/docs/test-assertions.mdx
@@ -5,7 +5,6 @@ title: "Assertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## List of assertions
 

--- a/java/docs/test-runners.mdx
+++ b/java/docs/test-runners.mdx
@@ -5,7 +5,6 @@ title: "Test Runners"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/threading.mdx
+++ b/java/docs/threading.mdx
@@ -5,7 +5,6 @@ title: "Multithreading"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/touch-events.mdx
+++ b/java/docs/touch-events.mdx
@@ -5,7 +5,6 @@ title: "Touch events (legacy)"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/trace-viewer-intro.mdx
+++ b/java/docs/trace-viewer-intro.mdx
@@ -5,7 +5,6 @@ title: "Trace viewer"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/trace-viewer.mdx
+++ b/java/docs/trace-viewer.mdx
@@ -5,7 +5,6 @@ title: "Trace viewer"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/java/docs/videos.mdx
+++ b/java/docs/videos.mdx
@@ -5,7 +5,6 @@ title: "Videos"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/webview2.mdx
+++ b/java/docs/webview2.mdx
@@ -5,7 +5,6 @@ title: "WebView2"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/java/docs/writing-tests.mdx
+++ b/java/docs/writing-tests.mdx
@@ -5,7 +5,6 @@ title: "Writing tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/accessibility-testing.mdx
+++ b/nodejs/docs/accessibility-testing.mdx
@@ -5,7 +5,6 @@ title: "Accessibility testing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/actionability.mdx
+++ b/nodejs/docs/actionability.mdx
@@ -5,7 +5,6 @@ title: "Auto-waiting"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/api-testing.mdx
+++ b/nodejs/docs/api-testing.mdx
@@ -5,7 +5,6 @@ title: "API testing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/api/class-accessibility.mdx
+++ b/nodejs/docs/api/class-accessibility.mdx
@@ -5,7 +5,6 @@ title: "Accessibility"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 :::warning[Deprecated]

--- a/nodejs/docs/api/class-android.mdx
+++ b/nodejs/docs/api/class-android.mdx
@@ -5,7 +5,6 @@ title: "Android"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright has **experimental** support for Android automation. This includes Chrome for Android and Android WebView.

--- a/nodejs/docs/api/class-androiddevice.mdx
+++ b/nodejs/docs/api/class-androiddevice.mdx
@@ -5,7 +5,6 @@ title: "AndroidDevice"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [AndroidDevice] represents a connected device, either real hardware or emulated. Devices can be obtained using [android.devices()](/api/class-android.mdx#android-devices).

--- a/nodejs/docs/api/class-androidinput.mdx
+++ b/nodejs/docs/api/class-androidinput.mdx
@@ -5,7 +5,6 @@ title: "AndroidInput"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 

--- a/nodejs/docs/api/class-androidsocket.mdx
+++ b/nodejs/docs/api/class-androidsocket.mdx
@@ -5,7 +5,6 @@ title: "AndroidSocket"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [AndroidSocket] is a way to communicate with a process launched on the [AndroidDevice]. Use [androidDevice.open()](/api/class-androiddevice.mdx#android-device-open) to open a socket.

--- a/nodejs/docs/api/class-androidwebview.mdx
+++ b/nodejs/docs/api/class-androidwebview.mdx
@@ -5,7 +5,6 @@ title: "AndroidWebView"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [AndroidWebView] represents a WebView open on the [AndroidDevice]. WebView is usually obtained using [androidDevice.webView()](/api/class-androiddevice.mdx#android-device-web-view).

--- a/nodejs/docs/api/class-apirequest.mdx
+++ b/nodejs/docs/api/class-apirequest.mdx
@@ -5,7 +5,6 @@ title: "APIRequest"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Exposes API that can be used for the Web API testing. This class is used for creating [APIRequestContext] instance which in turn can be used for sending web requests. An instance of this class can be obtained via [playwright.request](/api/class-playwright.mdx#playwright-request). For more information see [APIRequestContext].

--- a/nodejs/docs/api/class-apirequestcontext.mdx
+++ b/nodejs/docs/api/class-apirequestcontext.mdx
@@ -5,7 +5,6 @@ title: "APIRequestContext"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 This API is used for the Web API testing. You can use it to trigger API endpoints, configure micro-services, prepare environment or the service to your e2e test.

--- a/nodejs/docs/api/class-apiresponse.mdx
+++ b/nodejs/docs/api/class-apiresponse.mdx
@@ -5,7 +5,6 @@ title: "APIResponse"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [APIResponse] class represents responses returned by [apiRequestContext.get()](/api/class-apirequestcontext.mdx#api-request-context-get) and similar methods.

--- a/nodejs/docs/api/class-apiresponseassertions.mdx
+++ b/nodejs/docs/api/class-apiresponseassertions.mdx
@@ -5,7 +5,6 @@ title: "APIResponseAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [APIResponseAssertions] class provides assertion methods that can be used to make assertions about the [APIResponse] in the tests.

--- a/nodejs/docs/api/class-browser.mdx
+++ b/nodejs/docs/api/class-browser.mdx
@@ -5,7 +5,6 @@ title: "Browser"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 A Browser is created via [browserType.launch()](/api/class-browsertype.mdx#browser-type-launch). An example of using a [Browser] to create a [Page]:

--- a/nodejs/docs/api/class-browsercontext.mdx
+++ b/nodejs/docs/api/class-browsercontext.mdx
@@ -5,7 +5,6 @@ title: "BrowserContext"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 BrowserContexts provide a way to operate multiple independent browser sessions.

--- a/nodejs/docs/api/class-browserserver.mdx
+++ b/nodejs/docs/api/class-browserserver.mdx
@@ -5,7 +5,6 @@ title: "BrowserServer"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 

--- a/nodejs/docs/api/class-browsertype.mdx
+++ b/nodejs/docs/api/class-browsertype.mdx
@@ -5,7 +5,6 @@ title: "BrowserType"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 BrowserType provides methods to launch a specific browser instance or connect to an existing one. The following is a typical example of using Playwright to drive automation:

--- a/nodejs/docs/api/class-cdpsession.mdx
+++ b/nodejs/docs/api/class-cdpsession.mdx
@@ -5,7 +5,6 @@ title: "CDPSession"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The `CDPSession` instances are used to talk raw Chrome Devtools Protocol:

--- a/nodejs/docs/api/class-clock.mdx
+++ b/nodejs/docs/api/class-clock.mdx
@@ -5,7 +5,6 @@ title: "Clock"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Accurately simulating time-dependent behavior is essential for verifying the correctness of applications. Learn more about [clock emulation](../clock.mdx).

--- a/nodejs/docs/api/class-consolemessage.mdx
+++ b/nodejs/docs/api/class-consolemessage.mdx
@@ -5,7 +5,6 @@ title: "ConsoleMessage"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [ConsoleMessage] objects are dispatched by page via the [page.on('console')](/api/class-page.mdx#page-event-console) event. For each console message logged in the page there will be corresponding event in the Playwright context.

--- a/nodejs/docs/api/class-coverage.mdx
+++ b/nodejs/docs/api/class-coverage.mdx
@@ -5,7 +5,6 @@ title: "Coverage"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Coverage gathers information about parts of JavaScript and CSS that were used by the page.

--- a/nodejs/docs/api/class-dialog.mdx
+++ b/nodejs/docs/api/class-dialog.mdx
@@ -5,7 +5,6 @@ title: "Dialog"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Dialog] objects are dispatched by page via the [page.on('dialog')](/api/class-page.mdx#page-event-dialog) event.

--- a/nodejs/docs/api/class-download.mdx
+++ b/nodejs/docs/api/class-download.mdx
@@ -5,7 +5,6 @@ title: "Download"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Download] objects are dispatched by page via the [page.on('download')](/api/class-page.mdx#page-event-download) event.

--- a/nodejs/docs/api/class-electron.mdx
+++ b/nodejs/docs/api/class-electron.mdx
@@ -5,7 +5,6 @@ title: "Electron"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright has **experimental** support for Electron automation. You can access electron namespace via:

--- a/nodejs/docs/api/class-electronapplication.mdx
+++ b/nodejs/docs/api/class-electronapplication.mdx
@@ -5,7 +5,6 @@ title: "ElectronApplication"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Electron application representation. You can use [electron.launch()](/api/class-electron.mdx#electron-launch) to obtain the application instance. This instance you can control main electron process as well as work with Electron windows:

--- a/nodejs/docs/api/class-elementhandle.mdx
+++ b/nodejs/docs/api/class-elementhandle.mdx
@@ -5,7 +5,6 @@ title: "ElementHandle"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 * extends: [JSHandle]
 

--- a/nodejs/docs/api/class-filechooser.mdx
+++ b/nodejs/docs/api/class-filechooser.mdx
@@ -5,7 +5,6 @@ title: "FileChooser"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [FileChooser] objects are dispatched by the page in the [page.on('filechooser')](/api/class-page.mdx#page-event-file-chooser) event.

--- a/nodejs/docs/api/class-fixtures.mdx
+++ b/nodejs/docs/api/class-fixtures.mdx
@@ -5,7 +5,6 @@ title: "Fixtures"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright Test is based on the concept of the [test fixtures](../test-fixtures.mdx). Test fixtures are used to establish environment for each test, giving the test everything it needs and nothing else.

--- a/nodejs/docs/api/class-frame.mdx
+++ b/nodejs/docs/api/class-frame.mdx
@@ -5,7 +5,6 @@ title: "Frame"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 At every point of time, page exposes its current frame tree via the [page.mainFrame()](/api/class-page.mdx#page-main-frame) and [frame.childFrames()](/api/class-frame.mdx#frame-child-frames) methods.

--- a/nodejs/docs/api/class-framelocator.mdx
+++ b/nodejs/docs/api/class-framelocator.mdx
@@ -5,7 +5,6 @@ title: "FrameLocator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 FrameLocator represents a view to the `iframe` on the page. It captures the logic sufficient to retrieve the `iframe` and locate elements in that iframe. FrameLocator can be created with either [locator.contentFrame()](/api/class-locator.mdx#locator-content-frame), [page.frameLocator()](/api/class-page.mdx#page-frame-locator) or [locator.frameLocator()](/api/class-locator.mdx#locator-frame-locator) method.

--- a/nodejs/docs/api/class-fullconfig.mdx
+++ b/nodejs/docs/api/class-fullconfig.mdx
@@ -5,7 +5,6 @@ title: "FullConfig"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Resolved configuration which is accessible via [testInfo.config](/api/class-testinfo.mdx#test-info-config) and is passed to the test reporters. To see the format of Playwright configuration file, please see [TestConfig] instead.

--- a/nodejs/docs/api/class-fullproject.mdx
+++ b/nodejs/docs/api/class-fullproject.mdx
@@ -5,7 +5,6 @@ title: "FullProject"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Runtime representation of the test project configuration. It is accessible in the tests via [testInfo.project](/api/class-testinfo.mdx#test-info-project) and [workerInfo.project](/api/class-workerinfo.mdx#worker-info-project) and is passed to the test reporters. To see the format of the project in the Playwright configuration file please see [TestProject] instead.

--- a/nodejs/docs/api/class-genericassertions.mdx
+++ b/nodejs/docs/api/class-genericassertions.mdx
@@ -5,7 +5,6 @@ title: "GenericAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [GenericAssertions] class provides assertion methods that can be used to make assertions about any values in the tests. A new instance of [GenericAssertions] is created by calling [expect()](/api/class-playwrightassertions.mdx#playwright-assertions-expect-generic):

--- a/nodejs/docs/api/class-jshandle.mdx
+++ b/nodejs/docs/api/class-jshandle.mdx
@@ -5,7 +5,6 @@ title: "JSHandle"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 JSHandle represents an in-page JavaScript object. JSHandles can be created with the [page.evaluateHandle()](/api/class-page.mdx#page-evaluate-handle) method.

--- a/nodejs/docs/api/class-keyboard.mdx
+++ b/nodejs/docs/api/class-keyboard.mdx
@@ -5,7 +5,6 @@ title: "Keyboard"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Keyboard provides an api for managing a virtual keyboard. The high level api is [keyboard.type()](/api/class-keyboard.mdx#keyboard-type), which takes raw characters and generates proper `keydown`, `keypress`/`input`, and `keyup` events on your page.

--- a/nodejs/docs/api/class-location.mdx
+++ b/nodejs/docs/api/class-location.mdx
@@ -5,7 +5,6 @@ title: "Location"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Represents a location in the source code where [TestCase] or [Suite] is defined.

--- a/nodejs/docs/api/class-locator.mdx
+++ b/nodejs/docs/api/class-locator.mdx
@@ -5,7 +5,6 @@ title: "Locator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Locators are the central piece of Playwright's auto-waiting and retry-ability. In a nutshell, locators represent a way to find element(s) on the page at any moment. A locator can be created with the [page.locator()](/api/class-page.mdx#page-locator) method.

--- a/nodejs/docs/api/class-locatorassertions.mdx
+++ b/nodejs/docs/api/class-locatorassertions.mdx
@@ -5,7 +5,6 @@ title: "LocatorAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [LocatorAssertions] class provides assertion methods that can be used to make assertions about the [Locator] state in the tests.

--- a/nodejs/docs/api/class-logger.mdx
+++ b/nodejs/docs/api/class-logger.mdx
@@ -5,7 +5,6 @@ title: "Logger"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 :::warning[Deprecated]

--- a/nodejs/docs/api/class-mouse.mdx
+++ b/nodejs/docs/api/class-mouse.mdx
@@ -5,7 +5,6 @@ title: "Mouse"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.

--- a/nodejs/docs/api/class-page.mdx
+++ b/nodejs/docs/api/class-page.mdx
@@ -5,7 +5,6 @@ title: "Page"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Page provides methods to interact with a single tab in a [Browser], or an [extension background page](https://developer.chrome.com/extensions/background_pages) in Chromium. One [Browser] instance might have multiple [Page] instances.

--- a/nodejs/docs/api/class-pageassertions.mdx
+++ b/nodejs/docs/api/class-pageassertions.mdx
@@ -5,7 +5,6 @@ title: "PageAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [PageAssertions] class provides assertion methods that can be used to make assertions about the [Page] state in the tests.

--- a/nodejs/docs/api/class-playwright.mdx
+++ b/nodejs/docs/api/class-playwright.mdx
@@ -5,7 +5,6 @@ title: "Playwright Library"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright module provides a method to launch a browser instance. The following is a typical example of using Playwright to drive automation:

--- a/nodejs/docs/api/class-playwrightassertions.mdx
+++ b/nodejs/docs/api/class-playwrightassertions.mdx
@@ -5,7 +5,6 @@ title: "PlaywrightAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright gives you Web-First Assertions with convenience methods for creating assertions that will wait and retry until the expected condition is met.

--- a/nodejs/docs/api/class-reporter.mdx
+++ b/nodejs/docs/api/class-reporter.mdx
@@ -5,7 +5,6 @@ title: "Reporter"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Test runner notifies the reporter about various events during test execution. All methods of the reporter are optional.

--- a/nodejs/docs/api/class-request.mdx
+++ b/nodejs/docs/api/class-request.mdx
@@ -5,7 +5,6 @@ title: "Request"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever the page sends a request for a network resource the following sequence of events are emitted by [Page]:

--- a/nodejs/docs/api/class-response.mdx
+++ b/nodejs/docs/api/class-response.mdx
@@ -5,7 +5,6 @@ title: "Response"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Response] class represents responses which are received by page.

--- a/nodejs/docs/api/class-route.mdx
+++ b/nodejs/docs/api/class-route.mdx
@@ -5,7 +5,6 @@ title: "Route"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever a network route is set up with [page.route()](/api/class-page.mdx#page-route) or [browserContext.route()](/api/class-browsercontext.mdx#browser-context-route), the `Route` object allows to handle the route.

--- a/nodejs/docs/api/class-selectors.mdx
+++ b/nodejs/docs/api/class-selectors.mdx
@@ -5,7 +5,6 @@ title: "Selectors"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Selectors can be used to install custom selector engines. See [extensibility](../extensibility.mdx) for more information.

--- a/nodejs/docs/api/class-snapshotassertions.mdx
+++ b/nodejs/docs/api/class-snapshotassertions.mdx
@@ -5,7 +5,6 @@ title: "SnapshotAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright provides methods for comparing page and element screenshots with expected values stored in files.

--- a/nodejs/docs/api/class-suite.mdx
+++ b/nodejs/docs/api/class-suite.mdx
@@ -5,7 +5,6 @@ title: "Suite"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 `Suite` is a group of tests. All tests in Playwright Test form the following hierarchy:

--- a/nodejs/docs/api/class-test.mdx
+++ b/nodejs/docs/api/class-test.mdx
@@ -5,7 +5,6 @@ title: "Playwright Test"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright Test provides a `test` function to declare tests and `expect` function to write assertions.

--- a/nodejs/docs/api/class-testcase.mdx
+++ b/nodejs/docs/api/class-testcase.mdx
@@ -5,7 +5,6 @@ title: "TestCase"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 `TestCase` corresponds to every [test()](/api/class-test.mdx#test-call) call in a test file. When a single [test()](/api/class-test.mdx#test-call) is running in multiple projects or repeated multiple times, it will have multiple `TestCase` objects in corresponding projects' suites.

--- a/nodejs/docs/api/class-testconfig.mdx
+++ b/nodejs/docs/api/class-testconfig.mdx
@@ -5,7 +5,6 @@ title: "TestConfig"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright Test provides many options to configure how your tests are collected and executed, for example `timeout` or `testDir`. These options are described in the [TestConfig] object in the [configuration file](../test-configuration.mdx). This type describes format of the configuration file, to access resolved configuration parameters at run time use [FullConfig].

--- a/nodejs/docs/api/class-testerror.mdx
+++ b/nodejs/docs/api/class-testerror.mdx
@@ -5,7 +5,6 @@ title: "TestError"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Information about an error thrown during test execution.

--- a/nodejs/docs/api/class-testinfo.mdx
+++ b/nodejs/docs/api/class-testinfo.mdx
@@ -5,7 +5,6 @@ title: "TestInfo"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 `TestInfo` contains information about currently running test. It is available to test functions, [test.beforeEach()](/api/class-test.mdx#test-before-each), [test.afterEach()](/api/class-test.mdx#test-after-each), [test.beforeAll()](/api/class-test.mdx#test-before-all) and [test.afterAll()](/api/class-test.mdx#test-after-all) hooks, and test-scoped fixtures. `TestInfo` provides utilities to control test execution: attach files, update test timeout, determine which test is currently running and whether it was retried, etc.

--- a/nodejs/docs/api/class-testinfoerror.mdx
+++ b/nodejs/docs/api/class-testinfoerror.mdx
@@ -5,7 +5,6 @@ title: "TestInfoError"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Information about an error thrown during test execution.

--- a/nodejs/docs/api/class-testoptions.mdx
+++ b/nodejs/docs/api/class-testoptions.mdx
@@ -5,7 +5,6 @@ title: "TestOptions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright Test provides many options to configure test environment, [Browser], [BrowserContext] and more.

--- a/nodejs/docs/api/class-testproject.mdx
+++ b/nodejs/docs/api/class-testproject.mdx
@@ -5,7 +5,6 @@ title: "TestProject"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright Test supports running multiple test projects at the same time. This is useful for running tests in multiple configurations. For example, consider running tests against multiple browsers. This type describes format of a project in the configuration file, to access resolved configuration parameters at run time use [FullProject].

--- a/nodejs/docs/api/class-testresult.mdx
+++ b/nodejs/docs/api/class-testresult.mdx
@@ -5,7 +5,6 @@ title: "TestResult"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 A result of a single [TestCase] run.

--- a/nodejs/docs/api/class-teststep.mdx
+++ b/nodejs/docs/api/class-teststep.mdx
@@ -5,7 +5,6 @@ title: "TestStep"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Represents a step in the [TestRun].

--- a/nodejs/docs/api/class-teststepinfo.mdx
+++ b/nodejs/docs/api/class-teststepinfo.mdx
@@ -5,7 +5,6 @@ title: "TestStepInfo"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 `TestStepInfo` contains information about currently running test step. It is passed as an argument to the step function. `TestStepInfo` provides utilities to control test step execution.

--- a/nodejs/docs/api/class-timeouterror.mdx
+++ b/nodejs/docs/api/class-timeouterror.mdx
@@ -5,7 +5,6 @@ title: "TimeoutError"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 * extends: [Error]
 

--- a/nodejs/docs/api/class-touchscreen.mdx
+++ b/nodejs/docs/api/class-touchscreen.mdx
@@ -5,7 +5,6 @@ title: "Touchscreen"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Touchscreen class operates in main-frame CSS pixels relative to the top-left corner of the viewport. Methods on the touchscreen can only be used in browser contexts that have been initialized with `hasTouch` set to true.

--- a/nodejs/docs/api/class-tracing.mdx
+++ b/nodejs/docs/api/class-tracing.mdx
@@ -5,7 +5,6 @@ title: "Tracing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 API for collecting and saving Playwright traces. Playwright traces can be opened in [Trace Viewer](../trace-viewer.mdx) after Playwright script runs.

--- a/nodejs/docs/api/class-video.mdx
+++ b/nodejs/docs/api/class-video.mdx
@@ -5,7 +5,6 @@ title: "Video"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 When browser context is created with the `recordVideo` option, each page has a video object associated with it.

--- a/nodejs/docs/api/class-weberror.mdx
+++ b/nodejs/docs/api/class-weberror.mdx
@@ -5,7 +5,6 @@ title: "WebError"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [WebError] class represents an unhandled exception thrown in the page. It is dispatched via the [browserContext.on('weberror')](/api/class-browsercontext.mdx#browser-context-event-web-error) event.

--- a/nodejs/docs/api/class-websocket.mdx
+++ b/nodejs/docs/api/class-websocket.mdx
@@ -5,7 +5,6 @@ title: "WebSocket"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [WebSocket] class represents WebSocket connections within a page. It provides the ability to inspect and manipulate the data being transmitted and received.

--- a/nodejs/docs/api/class-websocketroute.mdx
+++ b/nodejs/docs/api/class-websocketroute.mdx
@@ -5,7 +5,6 @@ title: "WebSocketRoute"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever a [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) route is set up with [page.routeWebSocket()](/api/class-page.mdx#page-route-web-socket) or [browserContext.routeWebSocket()](/api/class-browsercontext.mdx#browser-context-route-web-socket), the `WebSocketRoute` object allows to handle the WebSocket, like an actual server would do.

--- a/nodejs/docs/api/class-worker.mdx
+++ b/nodejs/docs/api/class-worker.mdx
@@ -5,7 +5,6 @@ title: "Worker"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Worker class represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). `worker` event is emitted on the page object to signal a worker creation. `close` event is emitted on the worker object when the worker is gone.

--- a/nodejs/docs/api/class-workerinfo.mdx
+++ b/nodejs/docs/api/class-workerinfo.mdx
@@ -5,7 +5,6 @@ title: "WorkerInfo"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 `WorkerInfo` contains information about the worker that is running tests and is available to worker-scoped fixtures. `WorkerInfo` is a subset of [TestInfo] that is available in many other places.

--- a/nodejs/docs/aria-snapshots.mdx
+++ b/nodejs/docs/aria-snapshots.mdx
@@ -5,7 +5,6 @@ title: "Snapshot testing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/nodejs/docs/auth.mdx
+++ b/nodejs/docs/auth.mdx
@@ -5,7 +5,6 @@ title: "Authentication"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/best-practices.mdx
+++ b/nodejs/docs/best-practices.mdx
@@ -5,7 +5,6 @@ title: "Best Practices"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/browser-contexts.mdx
+++ b/nodejs/docs/browser-contexts.mdx
@@ -5,7 +5,6 @@ title: "Isolation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/browsers.mdx
+++ b/nodejs/docs/browsers.mdx
@@ -5,7 +5,6 @@ title: "Browsers"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 
@@ -150,7 +149,7 @@ Running 1 test using 1 worker
 
 With the VS Code extension you can run your tests on different browsers by checking the checkbox next to the browser name in the Playwright sidebar. These names are defined in your Playwright config file under the projects section. The default config when installing Playwright gives you 3 projects, Chromium, Firefox and WebKit. The first project is selected by default.
 
-<ProgressiveImage image={require("../images/vscode-projects-section.png")} alt="Projects section in VS Code extension" />
+![Projects section in VS Code extension](../images/vscode-projects-section.png)
 
 To run tests on multiple projects(browsers), select each project by checking the checkboxes next to the project name.
 

--- a/nodejs/docs/canary-releases.mdx
+++ b/nodejs/docs/canary-releases.mdx
@@ -5,7 +5,6 @@ title: "Canary releases"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/chrome-extensions.mdx
+++ b/nodejs/docs/chrome-extensions.mdx
@@ -5,7 +5,6 @@ title: "Chrome extensions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/ci-intro.mdx
+++ b/nodejs/docs/ci-intro.mdx
@@ -5,7 +5,6 @@ title: "Setting up CI"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/ci.mdx
+++ b/nodejs/docs/ci.mdx
@@ -5,7 +5,6 @@ title: "Continuous Integration"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/clock.mdx
+++ b/nodejs/docs/clock.mdx
@@ -5,7 +5,6 @@ title: "Clock"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/nodejs/docs/codegen-intro.mdx
+++ b/nodejs/docs/codegen-intro.mdx
@@ -5,7 +5,6 @@ title: "Generating tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 
@@ -35,7 +34,7 @@ With the test generator you can record:
   * `'assert value'` to assert that an element has a specific value
 
 ###### 
-<ProgressiveImage image={require("../images/getting-started/record-test-js.png")} alt="Recording a test" />
+![Recording a test](../images/getting-started/record-test-js.png)
 
 ###### 
 When you finish interacting with the page, press the `'record'` button to stop recording and use the `'copy'` button to copy the generated code to your editor.
@@ -54,7 +53,7 @@ You can generate [locators](/locators.mdx) with the test generator.
 * Use the copy button to copy the locator and paste it into your code
 
 ###### 
-<ProgressiveImage image={require("../images/getting-started/pick-locator-js.png")} alt="picking a locator" />
+![picking a locator](../images/getting-started/pick-locator-js.png)
 
 ### Emulation
 

--- a/nodejs/docs/codegen.mdx
+++ b/nodejs/docs/codegen.mdx
@@ -5,7 +5,6 @@ title: "Test generator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/nodejs/docs/debug.mdx
+++ b/nodejs/docs/debug.mdx
@@ -5,7 +5,6 @@ title: "Debugging Tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## VS Code debugger
 

--- a/nodejs/docs/dialogs.mdx
+++ b/nodejs/docs/dialogs.mdx
@@ -5,7 +5,6 @@ title: "Dialogs"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/docker.mdx
+++ b/nodejs/docs/docker.mdx
@@ -5,7 +5,6 @@ title: "Docker"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/downloads.mdx
+++ b/nodejs/docs/downloads.mdx
@@ -5,7 +5,6 @@ title: "Downloads"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/emulation.mdx
+++ b/nodejs/docs/emulation.mdx
@@ -5,7 +5,6 @@ title: "Emulation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/evaluating.mdx
+++ b/nodejs/docs/evaluating.mdx
@@ -5,7 +5,6 @@ title: "Evaluating JavaScript"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/events.mdx
+++ b/nodejs/docs/events.mdx
@@ -5,7 +5,6 @@ title: "Events"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/extensibility.mdx
+++ b/nodejs/docs/extensibility.mdx
@@ -5,7 +5,6 @@ title: "Extensibility"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Custom selector engines
 

--- a/nodejs/docs/frames.mdx
+++ b/nodejs/docs/frames.mdx
@@ -5,7 +5,6 @@ title: "Frames"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/getting-started-vscode.mdx
+++ b/nodejs/docs/getting-started-vscode.mdx
@@ -5,7 +5,6 @@ title: "Getting started - VS Code"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 
@@ -26,20 +25,20 @@ Before you begin, make sure you have the following installed:
 ### Installation & Setup
 1.  **Install the Extension**: Open the Extensions view in VS Code (`Ctrl+Shift+X` or `Cmd+Shift+X`) and search for "Playwright". [Install the official extension from Microsoft](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright).
 
-<ProgressiveImage image={require("../images/getting-started/vscode-extension.png")} alt="install playwright extension" />
+![install playwright extension](../images/getting-started/vscode-extension.png)
 1.  **Install Playwright**: Once the extension is installed, open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) and run the **Test: Install Playwright** command.
 
-<ProgressiveImage image={require("../images/getting-started/install-playwright.png")} alt="install playwright" />
+![install playwright](../images/getting-started/install-playwright.png)
 
 3.  **Select Browsers**: Choose the browsers you want for your tests (e.g., Chromium, Firefox, WebKit). You can also add a GitHub Actions workflow to run tests in CI. These settings can be changed later in your `playwright.config.ts` file.
 
-<ProgressiveImage image={require("../images/getting-started/install-browsers.png")} alt="install browsers" />
+![install browsers](../images/getting-started/install-browsers.png)
 
 ### Opening the Testing Sidebar
 
 Click the **Testing icon** in the VS Code Activity Bar to open the Test Explorer. Here, you'll find your tests, as well as the Playwright sidebar for managing projects, tools, and settings.
 
-<ProgressiveImage image={require("../images/getting-started/testing-sidebar.png")} alt="Testing Sidebar" />
+![Testing Sidebar](../images/getting-started/testing-sidebar.png)
 
 ## Core Features
 
@@ -48,16 +47,16 @@ Click the **Testing icon** in the VS Code Activity Bar to open the Test Explorer
 <LiteYouTube id="mQmcIBMsc38" title="Running Playwright Tests in VS Code" />
 -   **Run a Single Test**: Click the green "play" icon next to any test to run it. The play button will change to a green checkmark if the test passes or a red X if the test fails. You'll be able to see how long the test took to run displayed next to the test name. Additionally, the Test Results panel will automatically open at the bottom of VS Code, showing a summary of the test execution including how many tests ran, how many passed, failed, or were skipped, along with the total execution time.
 
-<ProgressiveImage image={require("../images/getting-started/run-single-test.png")} alt="run a single test" />
+![run a single test](../images/getting-started/run-single-test.png)
 -   **Run All Tests**: You can run all tests at different levels. Click the play icon next to a specific test file to run all tests within that file, or click the play icon at the very top of the Test Explorer to run all tests across your entire project.
 
-<ProgressiveImage image={require("../images/getting-started/run-all-tests.png")} alt="run all tests" />
+![run all tests](../images/getting-started/run-all-tests.png)
 -   **Run on Multiple Browsers**: In the Playwright sidebar, check the boxes for the projects (browsers) you want to test against. Projects in Playwright represent different browser configurations - each project typically corresponds to a specific browser (like Chromium, Firefox, or WebKit) with its own settings such as viewport size, device emulation, or other browser-specific options. When you run a test, it will execute across all selected projects, allowing you to verify your application works consistently across different browsers and configurations.
 
-<ProgressiveImage image={require("../images/getting-started/select-projects.png")} alt="Selecting projects to run tests on" />
+![Selecting projects to run tests on](../images/getting-started/select-projects.png)
 -   **Show Browser**: To watch your tests execute in a live browser window, enable the **Show Browser** option in the sidebar. Disable it to run in headless mode (where tests run in the background without opening a visible browser window).
 
-<ProgressiveImage image={require("../images/getting-started/show-browser.png")} alt="show browsers while running tests" />
+![show browsers while running tests](../images/getting-started/show-browser.png)
 
 ### Debugging Your Tests
 
@@ -66,16 +65,16 @@ Click the **Testing icon** in the VS Code Activity Bar to open the Test Explorer
 The VS Code extension provides powerful debugging tools to help you identify and fix issues in your tests. You can set breakpoints, inspect variables, view detailed error messages, get AI-powered suggestions to resolve test failures, and use the comprehensive trace viewer to analyze test execution step-by-step.
 -   **Using Breakpoints**: Set a breakpoint by clicking in the gutter next to a line number. Right-click the test and select **Debug Test**. The test will pause at your breakpoint, allowing you to inspect variables and step through the code.
   
-  <ProgressiveImage image={require("../images/getting-started/debug-mode.png")} alt="setting debug mode" />
+  ![setting debug mode](../images/getting-started/debug-mode.png)
 -   **Live Debugging**: With **Show Browsers** enabled, click on a locator in your code. Playwright will highlight the corresponding element in the browser, making it easy to verify locators.
   
-  <ProgressiveImage image={require("../images/getting-started/live-debugging.png")} alt="live debugging in vs code" />
+  ![live debugging in vs code](../images/getting-started/live-debugging.png)
 -   **Viewing Error Messages**: If a test fails, the extension displays detailed error messages, including the expected vs. received values and a full call log, directly in the editor.
 
-<ProgressiveImage image={require("../images/getting-started/error-messaging.png")} alt="error messaging in vs code" />
+![error messaging in vs code](../images/getting-started/error-messaging.png)
 -   **Fix with AI**: When a test fails, click the sparkle icon next to the error to get an AI-powered fix suggestion from Copilot. Copilot analyzes the error and suggests a code change to resolve the issue.
 
-<ProgressiveImage image={require("../images/getting-started/fix-with-ai.png")} alt="fix with ai in vs code" />
+![fix with ai in vs code](../images/getting-started/fix-with-ai.png)
 -   **Debugging with Trace Viewer**: For comprehensive debugging, enable the **Show Trace Viewer** option in the Playwright sidebar. When your test finishes, a detailed trace will automatically open, providing you with a complete timeline of your test execution. The trace viewer is particularly useful for:
   - **Step-by-step analysis**: Navigate through each action your test performed with precise timestamps
   - **DOM inspection**: View DOM snapshots at any point during test execution to see exactly what the page looked like
@@ -86,7 +85,7 @@ The VS Code extension provides powerful debugging tools to help you identify and
   
   The trace viewer is especially valuable when debugging flaky tests or understanding complex user interactions.
 
-<ProgressiveImage image={require("../images/getting-started/trace-viewer-debug.png")} alt="trace viewer debugging" />
+![trace viewer debugging](../images/getting-started/trace-viewer-debug.png)
 
 To learn more, see our [Trace Viewer guide](./trace-viewer.mdx).
 
@@ -97,13 +96,11 @@ CodeGen is Playwright's powerful test generation tool that automatically creates
 <LiteYouTube id="5XIZPqKkdBA" title="Generating Playwright tests in VS Code" />
 -   **Record a New Test**: Click **Record new** in the sidebar. A browser window will open. As you interact with the page, Playwright will automatically generate the test code. You can also generate assertions from the recording toolbar.
 
-<ProgressiveImage image={require("../images/getting-started/record-new-test.png")} alt="record a new test" />
--   **Record at Cursor**: Place your cursor inside an existing test and click **Record at cursor** to add new actions at that specific point.
-
-<ProgressiveImage image={require("../images/getting-started/record-at-cursor.png")} alt="record at cursor" />
+![record a new test](../images/getting-started/record-new-test.png)
+-   **Record at Cursor**: Place your cursor inside an existing test and click **Record at cursor** to add new actions at that specific point. ![record at cursor](../images/getting-started/record-at-cursor.png)
 -   **Pick a Locator**: Use the **Pick locator** tool to click on any element in the opened browser. Playwright will determine the best locator and copy it to your clipboard, ready to be pasted into your code.
 
-<ProgressiveImage image={require("../images/getting-started/pick-locator.png")} alt="pick locators" />
+![pick locators](../images/getting-started/pick-locator.png)
 
 To learn more, see our [CodeGen guide](./codegen.mdx).
 
@@ -113,7 +110,7 @@ To learn more, see our [CodeGen guide](./codegen.mdx).
 
 Use [project dependencies](./test-projects.mdx) to define setup tests that run before other tests. For example, you can create a login test that runs first, then reuse that authenticated state across multiple tests without having to log in again for each test. In VS Code, you can see these setup tests in the Test Explorer and run them independently when needed.
 
-<ProgressiveImage image={require("../images/getting-started/setup-tests.png")} alt="setup tests in vscode" />
+![setup tests in vscode](../images/getting-started/setup-tests.png)
 
 To learn more, see our [Project Dependencies guide](./test-projects.mdx).
 
@@ -121,13 +118,13 @@ To learn more, see our [Project Dependencies guide](./test-projects.mdx).
 
 For tasks that need to run only once before all tests (like seeding a database), use **Global Setup**. You can trigger the global setup and teardown manually from the Playwright sidebar.
 
-<ProgressiveImage image={require("../images/getting-started/global-setup.png")} alt="running global setup" />
+![running global setup](../images/getting-started/global-setup.png)
 
 ### Multiple Configurations
 
 If you have multiple `playwright.config.ts` files, you can switch between them using the gear icon in the Playwright sidebar. This allows you to easily work with different test suites or environments.
 
-<ProgressiveImage image={require("../images/getting-started/selecting-configuration.png")} alt="Selecting a configuration file" />
+![Selecting a configuration file](../images/getting-started/selecting-configuration.png)
 
 ## Quick Reference
 

--- a/nodejs/docs/handles.mdx
+++ b/nodejs/docs/handles.mdx
@@ -5,7 +5,6 @@ title: "Handles"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/input.mdx
+++ b/nodejs/docs/input.mdx
@@ -5,7 +5,6 @@ title: "Actions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/intro.mdx
+++ b/nodejs/docs/intro.mdx
@@ -5,7 +5,6 @@ title: "Installation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 
@@ -115,7 +114,7 @@ pnpm exec playwright test
 
 </Tabs>
 
-<ProgressiveImage image={require("../images/getting-started/run-tests-cli.png")} alt="tests running in command line" />
+![tests running in command line](../images/getting-started/run-tests-cli.png)
 
 Tips:
 - See the browser window: add `--headed`.
@@ -157,7 +156,7 @@ pnpm exec playwright show-report
 
 </Tabs>
 
-<ProgressiveImage image={require("../images/getting-started/html-report-basic.png")} alt="HTML Report" />
+![HTML Report](../images/getting-started/html-report-basic.png)
 
 ## Running the Example Test in UI Mode
 
@@ -191,7 +190,7 @@ pnpm exec playwright test --ui
 
 </Tabs>
 
-<ProgressiveImage image={require("../images/getting-started/ui-mode.png")} alt="UI Mode" />
+![UI Mode](../images/getting-started/ui-mode.png)
 
 See the [detailed guide on UI Mode](./test-ui-mode.mdx) for watch filters, step details and trace integration.
 

--- a/nodejs/docs/languages.mdx
+++ b/nodejs/docs/languages.mdx
@@ -5,7 +5,6 @@ title: "Supported languages"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/library.mdx
+++ b/nodejs/docs/library.mdx
@@ -5,7 +5,6 @@ title: "Library"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/locators.mdx
+++ b/nodejs/docs/locators.mdx
@@ -5,7 +5,6 @@ title: "Locators"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/mock-browser.mdx
+++ b/nodejs/docs/mock-browser.mdx
@@ -5,7 +5,6 @@ title: "Mock browser APIs"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/mock.mdx
+++ b/nodejs/docs/mock.mdx
@@ -5,7 +5,6 @@ title: "Mock APIs"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/navigations.mdx
+++ b/nodejs/docs/navigations.mdx
@@ -5,7 +5,6 @@ title: "Navigations"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/network.mdx
+++ b/nodejs/docs/network.mdx
@@ -5,7 +5,6 @@ title: "Network"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/other-locators.mdx
+++ b/nodejs/docs/other-locators.mdx
@@ -5,7 +5,6 @@ title: "Other locators"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/pages.mdx
+++ b/nodejs/docs/pages.mdx
@@ -5,7 +5,6 @@ title: "Pages"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Pages
 

--- a/nodejs/docs/pom.mdx
+++ b/nodejs/docs/pom.mdx
@@ -5,7 +5,6 @@ title: "Page object models"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/protractor.mdx
+++ b/nodejs/docs/protractor.mdx
@@ -5,7 +5,6 @@ title: "Migrating from Protractor"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Migration Principles
 - No need for "webdriver-manager" / Selenium.

--- a/nodejs/docs/puppeteer.mdx
+++ b/nodejs/docs/puppeteer.mdx
@@ -5,7 +5,6 @@ title: "Migrating from Puppeteer"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Migration Principles
 

--- a/nodejs/docs/release-notes.mdx
+++ b/nodejs/docs/release-notes.mdx
@@ -6,7 +6,6 @@ toc_max_heading_level: 2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/nodejs/docs/running-tests.mdx
+++ b/nodejs/docs/running-tests.mdx
@@ -5,7 +5,6 @@ title: "Running and debugging tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 
@@ -26,7 +25,7 @@ You can run your tests with the `playwright test` command. This runs your tests 
 npx playwright test
 ```
 
-<ProgressiveImage image={require("../images/getting-started/run-tests-cli.png")} alt="tests running in command line" />
+![tests running in command line](../images/getting-started/run-tests-cli.png)
 
 ### Run tests in UI mode
 
@@ -36,7 +35,7 @@ We highly recommend running your tests with [UI Mode](./test-ui-mode.mdx) for a 
 npx playwright test --ui
 ```
 
-<ProgressiveImage image={require("../images/getting-started/ui-mode.png")} alt="UI Mode" />
+![UI Mode](../images/getting-started/ui-mode.png)
 
 Check out our [detailed guide on UI Mode](./test-ui-mode.mdx) to learn more about its features.
 
@@ -100,7 +99,7 @@ npx playwright test --last-failed
 
 Tests can be run right from VS Code using the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright). Once installed you can simply click the green triangle next to the test you want to run or run all tests from the testing sidebar. Check out our [Getting Started with VS Code](./getting-started-vscode.mdx) guide for more details.
 
-<ProgressiveImage image={require("../images/getting-started/vscode-extension.png")} alt="install playwright extension" />
+![install playwright extension](../images/getting-started/vscode-extension.png)
 
 ## Debugging tests
 
@@ -114,11 +113,11 @@ We highly recommend debugging your tests with [UI Mode](./test-ui-mode.mdx) for 
 npx playwright test --ui
 ```
 
-<ProgressiveImage image={require("../images/getting-started/ui-mode-error.png")} alt="showing errors in ui mode" />
+![showing errors in ui mode](../images/getting-started/ui-mode-error.png)
 
 While debugging you can use the Pick Locator button to select an element on the page and see the locator that Playwright would use to find that element. You can also edit the locator in the locator playground and see it highlighting live in the browser window. Use the Copy Locator button to copy the locator to your clipboard and then paste it into your test.
 
-<ProgressiveImage image={require("../images/getting-started/ui-mode-pick-locator.png")} alt="pick locator in ui mode" />
+![pick locator in ui mode](../images/getting-started/ui-mode-pick-locator.png)
 
 Check out our [detailed guide on UI Mode](./test-ui-mode.mdx) to learn more about its features.
 
@@ -130,7 +129,7 @@ To debug all tests, run the Playwright test command followed by the `--debug` fl
 npx playwright test --debug
 ```
 
-<ProgressiveImage image={require("../images/getting-started/run-tests-debug.png")} alt="Debugging Tests with the Playwright inspector" />
+![Debugging Tests with the Playwright inspector](../images/getting-started/run-tests-debug.png)
 
 This command opens a browser window as well as the Playwright Inspector. You can use the step over button at the top of the inspector to step through your test. Or, press the play button to run your test from start to finish. Once the test finishes, the browser window closes.
 
@@ -148,7 +147,7 @@ npx playwright test example.spec.ts:10 --debug
 
 While debugging you can use the Pick Locator button to select an element on the page and see the locator that Playwright would use to find that element. You can also edit the locator and see it highlighting live in the browser window. Use the Copy Locator button to copy the locator to your clipboard and then paste it into your test.
 
-<ProgressiveImage image={require("../images/getting-started/run-tests-pick-locator.png")} alt="Locator picker in the Playwright Inspector" />
+![Locator picker in the Playwright Inspector](../images/getting-started/run-tests-pick-locator.png)
 
 Check out our [debugging guide](./debug.mdx) to learn more about debugging with the [VS Code debugger](./debug.mdx#vs-code-debugger), UI Mode, and the [Playwright Inspector](./debug.mdx#playwright-inspector) as well as debugging with [Browser Developer tools](./debug.mdx#browser-developer-tools).
 
@@ -160,11 +159,11 @@ The [HTML Reporter](./test-reporters.mdx#html-reporter) shows you a full report 
 npx playwright show-report
 ```
 
-<ProgressiveImage image={require("../images/getting-started/html-report.png")} alt="HTML Report" />
+![HTML Report](../images/getting-started/html-report.png)
 
 You can filter and search for tests as well as click on each test to see the test errors and explore each step of the test.
 
-<ProgressiveImage image={require("../images/getting-started/html-report-detail.png")} alt="HTML Reporter detail view" />
+![HTML Reporter detail view](../images/getting-started/html-report-detail.png)
 
 ## What's next
 - [Generate tests with Codegen](./codegen-intro.mdx)

--- a/nodejs/docs/screenshots.mdx
+++ b/nodejs/docs/screenshots.mdx
@@ -5,7 +5,6 @@ title: "Screenshots"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/selenium-grid.mdx
+++ b/nodejs/docs/selenium-grid.mdx
@@ -5,7 +5,6 @@ title: "Selenium Grid (experimental)"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/service-workers-experimental-network-events.mdx
+++ b/nodejs/docs/service-workers-experimental-network-events.mdx
@@ -5,7 +5,6 @@ title: "(Experimental) Service Worker Network Events"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-agents.mdx
+++ b/nodejs/docs/test-agents.mdx
@@ -5,7 +5,6 @@ title: "Agents"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 # Playwright Agents
 

--- a/nodejs/docs/test-annotations.mdx
+++ b/nodejs/docs/test-annotations.mdx
@@ -5,7 +5,6 @@ title: "Annotations"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-assertions.mdx
+++ b/nodejs/docs/test-assertions.mdx
@@ -5,7 +5,6 @@ title: "Assertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-cli.mdx
+++ b/nodejs/docs/test-cli.mdx
@@ -5,7 +5,6 @@ title: "Command line"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 Playwright provides a powerful command line interface for running tests, generating code, debugging, and more. The most up to date list of commands and arguments available on the CLI can always be retrieved via `npx playwright --help`.
 

--- a/nodejs/docs/test-components.mdx
+++ b/nodejs/docs/test-components.mdx
@@ -5,7 +5,6 @@ title: "Components (experimental)"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/nodejs/docs/test-configuration.mdx
+++ b/nodejs/docs/test-configuration.mdx
@@ -5,7 +5,6 @@ title: "Configuration"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-fixtures.mdx
+++ b/nodejs/docs/test-fixtures.mdx
@@ -5,7 +5,6 @@ title: "Fixtures"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-global-setup-teardown.mdx
+++ b/nodejs/docs/test-global-setup-teardown.mdx
@@ -5,7 +5,6 @@ title: "Global setup and teardown"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-parallel.mdx
+++ b/nodejs/docs/test-parallel.mdx
@@ -5,7 +5,6 @@ title: "Parallelism"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-parameterize.mdx
+++ b/nodejs/docs/test-parameterize.mdx
@@ -5,7 +5,6 @@ title: "Parameterize tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-projects.mdx
+++ b/nodejs/docs/test-projects.mdx
@@ -5,7 +5,6 @@ title: "Projects"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-reporters.mdx
+++ b/nodejs/docs/test-reporters.mdx
@@ -5,7 +5,6 @@ title: "Reporters"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-retries.mdx
+++ b/nodejs/docs/test-retries.mdx
@@ -5,7 +5,6 @@ title: "Retries"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-sharding.mdx
+++ b/nodejs/docs/test-sharding.mdx
@@ -5,7 +5,6 @@ title: "Sharding"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-snapshots.mdx
+++ b/nodejs/docs/test-snapshots.mdx
@@ -5,7 +5,6 @@ title: "Visual comparisons"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-timeouts.mdx
+++ b/nodejs/docs/test-timeouts.mdx
@@ -5,7 +5,6 @@ title: "Timeouts"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 Playwright Test has multiple configurable timeouts for various tasks.
 

--- a/nodejs/docs/test-typescript.mdx
+++ b/nodejs/docs/test-typescript.mdx
@@ -5,7 +5,6 @@ title: "TypeScript"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-ui-mode.mdx
+++ b/nodejs/docs/test-ui-mode.mdx
@@ -5,7 +5,6 @@ title: "UI Mode"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/nodejs/docs/test-use-options.mdx
+++ b/nodejs/docs/test-use-options.mdx
@@ -5,7 +5,6 @@ title: "Configuration (use)"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/test-webserver.mdx
+++ b/nodejs/docs/test-webserver.mdx
@@ -5,7 +5,6 @@ title: "Web server"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/testing-library.mdx
+++ b/nodejs/docs/testing-library.mdx
@@ -5,7 +5,6 @@ title: "Migrating from Testing Library"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Migration principles
 

--- a/nodejs/docs/touch-events.mdx
+++ b/nodejs/docs/touch-events.mdx
@@ -5,7 +5,6 @@ title: "Touch events (legacy)"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/trace-viewer-intro.mdx
+++ b/nodejs/docs/trace-viewer-intro.mdx
@@ -5,7 +5,6 @@ title: "Trace viewer"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 
@@ -55,11 +54,11 @@ npx playwright show-report
 
 In the HTML report, click on the trace icon next to the test file name to directly open the trace for the required test.
 
-<ProgressiveImage image={require("../images/getting-started/html-report-failed-tests.png")} alt="playwright html report" />
+![playwright html report](../images/getting-started/html-report-failed-tests.png)
 
 You can also click to open the detailed view of the test and scroll down to the `'Traces'` tab and open the trace by clicking on the trace screenshot.
 
-<ProgressiveImage image={require("../images/getting-started/html-report-trace.png")} alt="playwright html report detailed view" />
+![playwright html report detailed view](../images/getting-started/html-report-trace.png)
 
 To learn more about reporters, check out our detailed guide on reporters including the [HTML Reporter](/test-reporters.mdx#html-reporter).
 
@@ -67,7 +66,7 @@ To learn more about reporters, check out our detailed guide on reporters includi
 
 View traces of your test by clicking through each action or hovering using the timeline and see the state of the page before and after the action. Inspect the log, source and network, errors, and console during each step of the test. The trace viewer creates a DOM snapshot so you can fully interact with it and open the browser DevTools to inspect the HTML, CSS, etc.
 
-<ProgressiveImage image={require("../images/getting-started/trace-viewer-failed-test.png")} alt="playwright trace viewer" />
+![playwright trace viewer](../images/getting-started/trace-viewer-failed-test.png)
 
 To learn more about traces, check out our detailed guide on [Trace Viewer](/trace-viewer.mdx).
 

--- a/nodejs/docs/trace-viewer.mdx
+++ b/nodejs/docs/trace-viewer.mdx
@@ -5,7 +5,6 @@ title: "Trace viewer"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/nodejs/docs/videos.mdx
+++ b/nodejs/docs/videos.mdx
@@ -5,7 +5,6 @@ title: "Videos"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/webview2.mdx
+++ b/nodejs/docs/webview2.mdx
@@ -5,7 +5,6 @@ title: "WebView2"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/nodejs/docs/writing-tests.mdx
+++ b/nodejs/docs/writing-tests.mdx
@@ -5,7 +5,6 @@ title: "Writing tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/actionability.mdx
+++ b/python/docs/actionability.mdx
@@ -5,7 +5,6 @@ title: "Auto-waiting"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/api-testing.mdx
+++ b/python/docs/api-testing.mdx
@@ -5,7 +5,6 @@ title: "API testing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/api/class-accessibility.mdx
+++ b/python/docs/api/class-accessibility.mdx
@@ -5,7 +5,6 @@ title: "Accessibility"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 :::warning[Deprecated]

--- a/python/docs/api/class-apirequest.mdx
+++ b/python/docs/api/class-apirequest.mdx
@@ -5,7 +5,6 @@ title: "APIRequest"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Exposes API that can be used for the Web API testing. This class is used for creating [APIRequestContext] instance which in turn can be used for sending web requests. An instance of this class can be obtained via [playwright.request](/api/class-playwright.mdx#playwright-request). For more information see [APIRequestContext].

--- a/python/docs/api/class-apirequestcontext.mdx
+++ b/python/docs/api/class-apirequestcontext.mdx
@@ -5,7 +5,6 @@ title: "APIRequestContext"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 This API is used for the Web API testing. You can use it to trigger API endpoints, configure micro-services, prepare environment or the service to your e2e test.

--- a/python/docs/api/class-apiresponse.mdx
+++ b/python/docs/api/class-apiresponse.mdx
@@ -5,7 +5,6 @@ title: "APIResponse"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [APIResponse] class represents responses returned by [api_request_context.get()](/api/class-apirequestcontext.mdx#api-request-context-get) and similar methods.

--- a/python/docs/api/class-apiresponseassertions.mdx
+++ b/python/docs/api/class-apiresponseassertions.mdx
@@ -5,7 +5,6 @@ title: "APIResponseAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [APIResponseAssertions] class provides assertion methods that can be used to make assertions about the [APIResponse] in the tests.

--- a/python/docs/api/class-browser.mdx
+++ b/python/docs/api/class-browser.mdx
@@ -5,7 +5,6 @@ title: "Browser"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 A Browser is created via [browser_type.launch()](/api/class-browsertype.mdx#browser-type-launch). An example of using a [Browser] to create a [Page]:

--- a/python/docs/api/class-browsercontext.mdx
+++ b/python/docs/api/class-browsercontext.mdx
@@ -5,7 +5,6 @@ title: "BrowserContext"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 BrowserContexts provide a way to operate multiple independent browser sessions.

--- a/python/docs/api/class-browsertype.mdx
+++ b/python/docs/api/class-browsertype.mdx
@@ -5,7 +5,6 @@ title: "BrowserType"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 BrowserType provides methods to launch a specific browser instance or connect to an existing one. The following is a typical example of using Playwright to drive automation:

--- a/python/docs/api/class-cdpsession.mdx
+++ b/python/docs/api/class-cdpsession.mdx
@@ -5,7 +5,6 @@ title: "CDPSession"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The `CDPSession` instances are used to talk raw Chrome Devtools Protocol:

--- a/python/docs/api/class-clock.mdx
+++ b/python/docs/api/class-clock.mdx
@@ -5,7 +5,6 @@ title: "Clock"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Accurately simulating time-dependent behavior is essential for verifying the correctness of applications. Learn more about [clock emulation](../clock.mdx).

--- a/python/docs/api/class-consolemessage.mdx
+++ b/python/docs/api/class-consolemessage.mdx
@@ -5,7 +5,6 @@ title: "ConsoleMessage"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [ConsoleMessage] objects are dispatched by page via the [page.on("console")](/api/class-page.mdx#page-event-console) event. For each console message logged in the page there will be corresponding event in the Playwright context.

--- a/python/docs/api/class-dialog.mdx
+++ b/python/docs/api/class-dialog.mdx
@@ -5,7 +5,6 @@ title: "Dialog"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Dialog] objects are dispatched by page via the [page.on("dialog")](/api/class-page.mdx#page-event-dialog) event.

--- a/python/docs/api/class-download.mdx
+++ b/python/docs/api/class-download.mdx
@@ -5,7 +5,6 @@ title: "Download"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Download] objects are dispatched by page via the [page.on("download")](/api/class-page.mdx#page-event-download) event.

--- a/python/docs/api/class-elementhandle.mdx
+++ b/python/docs/api/class-elementhandle.mdx
@@ -5,7 +5,6 @@ title: "ElementHandle"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 * extends: [JSHandle]
 

--- a/python/docs/api/class-error.mdx
+++ b/python/docs/api/class-error.mdx
@@ -5,7 +5,6 @@ title: "Error"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 * extends: [Exception]
 

--- a/python/docs/api/class-filechooser.mdx
+++ b/python/docs/api/class-filechooser.mdx
@@ -5,7 +5,6 @@ title: "FileChooser"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [FileChooser] objects are dispatched by the page in the [page.on("filechooser")](/api/class-page.mdx#page-event-file-chooser) event.

--- a/python/docs/api/class-frame.mdx
+++ b/python/docs/api/class-frame.mdx
@@ -5,7 +5,6 @@ title: "Frame"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 At every point of time, page exposes its current frame tree via the [page.main_frame](/api/class-page.mdx#page-main-frame) and [frame.child_frames](/api/class-frame.mdx#frame-child-frames) methods.

--- a/python/docs/api/class-framelocator.mdx
+++ b/python/docs/api/class-framelocator.mdx
@@ -5,7 +5,6 @@ title: "FrameLocator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 FrameLocator represents a view to the `iframe` on the page. It captures the logic sufficient to retrieve the `iframe` and locate elements in that iframe. FrameLocator can be created with either [locator.content_frame](/api/class-locator.mdx#locator-content-frame), [page.frame_locator()](/api/class-page.mdx#page-frame-locator) or [locator.frame_locator()](/api/class-locator.mdx#locator-frame-locator) method.

--- a/python/docs/api/class-jshandle.mdx
+++ b/python/docs/api/class-jshandle.mdx
@@ -5,7 +5,6 @@ title: "JSHandle"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 JSHandle represents an in-page JavaScript object. JSHandles can be created with the [page.evaluate_handle()](/api/class-page.mdx#page-evaluate-handle) method.

--- a/python/docs/api/class-keyboard.mdx
+++ b/python/docs/api/class-keyboard.mdx
@@ -5,7 +5,6 @@ title: "Keyboard"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Keyboard provides an api for managing a virtual keyboard. The high level api is [keyboard.type()](/api/class-keyboard.mdx#keyboard-type), which takes raw characters and generates proper `keydown`, `keypress`/`input`, and `keyup` events on your page.

--- a/python/docs/api/class-locator.mdx
+++ b/python/docs/api/class-locator.mdx
@@ -5,7 +5,6 @@ title: "Locator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Locators are the central piece of Playwright's auto-waiting and retry-ability. In a nutshell, locators represent a way to find element(s) on the page at any moment. A locator can be created with the [page.locator()](/api/class-page.mdx#page-locator) method.

--- a/python/docs/api/class-locatorassertions.mdx
+++ b/python/docs/api/class-locatorassertions.mdx
@@ -5,7 +5,6 @@ title: "LocatorAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [LocatorAssertions] class provides assertion methods that can be used to make assertions about the [Locator] state in the tests.

--- a/python/docs/api/class-mouse.mdx
+++ b/python/docs/api/class-mouse.mdx
@@ -5,7 +5,6 @@ title: "Mouse"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Mouse class operates in main-frame CSS pixels relative to the top-left corner of the viewport.

--- a/python/docs/api/class-page.mdx
+++ b/python/docs/api/class-page.mdx
@@ -5,7 +5,6 @@ title: "Page"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Page provides methods to interact with a single tab in a [Browser], or an [extension background page](https://developer.chrome.com/extensions/background_pages) in Chromium. One [Browser] instance might have multiple [Page] instances.

--- a/python/docs/api/class-pageassertions.mdx
+++ b/python/docs/api/class-pageassertions.mdx
@@ -5,7 +5,6 @@ title: "PageAssertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [PageAssertions] class provides assertion methods that can be used to make assertions about the [Page] state in the tests.

--- a/python/docs/api/class-playwright.mdx
+++ b/python/docs/api/class-playwright.mdx
@@ -5,7 +5,6 @@ title: "Playwright"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Playwright module provides a method to launch a browser instance. The following is a typical example of using Playwright to drive automation:

--- a/python/docs/api/class-request.mdx
+++ b/python/docs/api/class-request.mdx
@@ -5,7 +5,6 @@ title: "Request"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever the page sends a request for a network resource the following sequence of events are emitted by [Page]:

--- a/python/docs/api/class-response.mdx
+++ b/python/docs/api/class-response.mdx
@@ -5,7 +5,6 @@ title: "Response"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [Response] class represents responses which are received by page.

--- a/python/docs/api/class-route.mdx
+++ b/python/docs/api/class-route.mdx
@@ -5,7 +5,6 @@ title: "Route"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever a network route is set up with [page.route()](/api/class-page.mdx#page-route) or [browser_context.route()](/api/class-browsercontext.mdx#browser-context-route), the `Route` object allows to handle the route.

--- a/python/docs/api/class-selectors.mdx
+++ b/python/docs/api/class-selectors.mdx
@@ -5,7 +5,6 @@ title: "Selectors"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Selectors can be used to install custom selector engines. See [extensibility](../extensibility.mdx) for more information.

--- a/python/docs/api/class-timeouterror.mdx
+++ b/python/docs/api/class-timeouterror.mdx
@@ -5,7 +5,6 @@ title: "TimeoutError"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 * extends: [Error]
 

--- a/python/docs/api/class-touchscreen.mdx
+++ b/python/docs/api/class-touchscreen.mdx
@@ -5,7 +5,6 @@ title: "Touchscreen"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Touchscreen class operates in main-frame CSS pixels relative to the top-left corner of the viewport. Methods on the touchscreen can only be used in browser contexts that have been initialized with `hasTouch` set to true.

--- a/python/docs/api/class-tracing.mdx
+++ b/python/docs/api/class-tracing.mdx
@@ -5,7 +5,6 @@ title: "Tracing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 API for collecting and saving Playwright traces. Playwright traces can be opened in [Trace Viewer](../trace-viewer.mdx) after Playwright script runs.

--- a/python/docs/api/class-video.mdx
+++ b/python/docs/api/class-video.mdx
@@ -5,7 +5,6 @@ title: "Video"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 When browser context is created with the `recordVideo` option, each page has a video object associated with it.

--- a/python/docs/api/class-weberror.mdx
+++ b/python/docs/api/class-weberror.mdx
@@ -5,7 +5,6 @@ title: "WebError"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 [WebError] class represents an unhandled exception thrown in the page. It is dispatched via the [browser_context.on("weberror")](/api/class-browsercontext.mdx#browser-context-event-web-error) event.

--- a/python/docs/api/class-websocket.mdx
+++ b/python/docs/api/class-websocket.mdx
@@ -5,7 +5,6 @@ title: "WebSocket"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The [WebSocket] class represents WebSocket connections within a page. It provides the ability to inspect and manipulate the data being transmitted and received.

--- a/python/docs/api/class-websocketroute.mdx
+++ b/python/docs/api/class-websocketroute.mdx
@@ -5,7 +5,6 @@ title: "WebSocketRoute"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 Whenever a [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) route is set up with [page.route_web_socket()](/api/class-page.mdx#page-route-web-socket) or [browser_context.route_web_socket()](/api/class-browsercontext.mdx#browser-context-route-web-socket), the `WebSocketRoute` object allows to handle the WebSocket, like an actual server would do.

--- a/python/docs/api/class-worker.mdx
+++ b/python/docs/api/class-worker.mdx
@@ -5,7 +5,6 @@ title: "Worker"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 
 The Worker class represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). `worker` event is emitted on the page object to signal a worker creation. `close` event is emitted on the worker object when the worker is gone.

--- a/python/docs/aria-snapshots.mdx
+++ b/python/docs/aria-snapshots.mdx
@@ -5,7 +5,6 @@ title: "Snapshot testing"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/python/docs/auth.mdx
+++ b/python/docs/auth.mdx
@@ -5,7 +5,6 @@ title: "Authentication"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/browser-contexts.mdx
+++ b/python/docs/browser-contexts.mdx
@@ -5,7 +5,6 @@ title: "Isolation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/browsers.mdx
+++ b/python/docs/browsers.mdx
@@ -5,7 +5,6 @@ title: "Browsers"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/chrome-extensions.mdx
+++ b/python/docs/chrome-extensions.mdx
@@ -5,7 +5,6 @@ title: "Chrome extensions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/ci-intro.mdx
+++ b/python/docs/ci-intro.mdx
@@ -5,7 +5,6 @@ title: "Setting up CI"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 
@@ -86,7 +85,7 @@ Clicking on the workflow run shows you all the actions that GitHub performed and
 
 [trace.playwright.dev](https://trace.playwright.dev) is a statically hosted variant of the Trace Viewer. You can upload trace files using drag and drop.
 
-<ProgressiveImage image={require("../images/getting-started/trace-viewer-failed-test.png")} alt="playwright trace viewer" />
+![playwright trace viewer](../images/getting-started/trace-viewer-failed-test.png)
 
 ## Properly handling Secrets
 

--- a/python/docs/ci.mdx
+++ b/python/docs/ci.mdx
@@ -5,7 +5,6 @@ title: "Continuous Integration"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/clock.mdx
+++ b/python/docs/clock.mdx
@@ -5,7 +5,6 @@ title: "Clock"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/python/docs/codegen-intro.mdx
+++ b/python/docs/codegen-intro.mdx
@@ -5,7 +5,6 @@ title: "Generating tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 
@@ -35,7 +34,7 @@ With the test generator you can record:
   * `'assert value'` to assert that an element has a specific value
 
 ###### 
-<ProgressiveImage image={require("../images/getting-started/record-test-python.png")} alt="recording a test" />
+![recording a test](../images/getting-started/record-test-python.png)
 
 ###### 
 When you finish interacting with the page, press the `'record'` button to stop recording and use the `'copy'` button to copy the generated code to your editor.
@@ -54,7 +53,7 @@ You can generate [locators](/locators.mdx) with the test generator.
 * Use the copy button to copy the locator and paste it into your code
 
 ###### 
-<ProgressiveImage image={require("../images/getting-started/pick-locator-python.png")} alt="picking a locator" />
+![picking a locator](../images/getting-started/pick-locator-python.png)
 
 ### Emulation
 

--- a/python/docs/codegen.mdx
+++ b/python/docs/codegen.mdx
@@ -5,7 +5,6 @@ title: "Test generator"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/python/docs/debug.mdx
+++ b/python/docs/debug.mdx
@@ -5,7 +5,6 @@ title: "Debugging Tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Playwright Inspector
 

--- a/python/docs/dialogs.mdx
+++ b/python/docs/dialogs.mdx
@@ -5,7 +5,6 @@ title: "Dialogs"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/docker.mdx
+++ b/python/docs/docker.mdx
@@ -5,7 +5,6 @@ title: "Docker"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/downloads.mdx
+++ b/python/docs/downloads.mdx
@@ -5,7 +5,6 @@ title: "Downloads"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/emulation.mdx
+++ b/python/docs/emulation.mdx
@@ -5,7 +5,6 @@ title: "Emulation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/evaluating.mdx
+++ b/python/docs/evaluating.mdx
@@ -5,7 +5,6 @@ title: "Evaluating JavaScript"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/events.mdx
+++ b/python/docs/events.mdx
@@ -5,7 +5,6 @@ title: "Events"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/extensibility.mdx
+++ b/python/docs/extensibility.mdx
@@ -5,7 +5,6 @@ title: "Extensibility"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Custom selector engines
 

--- a/python/docs/frames.mdx
+++ b/python/docs/frames.mdx
@@ -5,7 +5,6 @@ title: "Frames"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/handles.mdx
+++ b/python/docs/handles.mdx
@@ -5,7 +5,6 @@ title: "Handles"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/input.mdx
+++ b/python/docs/input.mdx
@@ -5,7 +5,6 @@ title: "Actions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/intro.mdx
+++ b/python/docs/intro.mdx
@@ -5,7 +5,6 @@ title: "Installation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/languages.mdx
+++ b/python/docs/languages.mdx
@@ -5,7 +5,6 @@ title: "Supported languages"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/library.mdx
+++ b/python/docs/library.mdx
@@ -5,7 +5,6 @@ title: "Getting started - Library"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Installation
 

--- a/python/docs/locators.mdx
+++ b/python/docs/locators.mdx
@@ -5,7 +5,6 @@ title: "Locators"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/mock.mdx
+++ b/python/docs/mock.mdx
@@ -5,7 +5,6 @@ title: "Mock APIs"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/navigations.mdx
+++ b/python/docs/navigations.mdx
@@ -5,7 +5,6 @@ title: "Navigations"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/network.mdx
+++ b/python/docs/network.mdx
@@ -5,7 +5,6 @@ title: "Network"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/other-locators.mdx
+++ b/python/docs/other-locators.mdx
@@ -5,7 +5,6 @@ title: "Other locators"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/pages.mdx
+++ b/python/docs/pages.mdx
@@ -5,7 +5,6 @@ title: "Pages"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Pages
 

--- a/python/docs/pom.mdx
+++ b/python/docs/pom.mdx
@@ -5,7 +5,6 @@ title: "Page object models"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/release-notes.mdx
+++ b/python/docs/release-notes.mdx
@@ -6,7 +6,6 @@ toc_max_heading_level: 2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Version 1.55
 

--- a/python/docs/running-tests.mdx
+++ b/python/docs/running-tests.mdx
@@ -5,7 +5,6 @@ title: "Running and debugging tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/screenshots.mdx
+++ b/python/docs/screenshots.mdx
@@ -5,7 +5,6 @@ title: "Screenshots"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/selenium-grid.mdx
+++ b/python/docs/selenium-grid.mdx
@@ -5,7 +5,6 @@ title: "Selenium Grid (experimental)"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/test-assertions.mdx
+++ b/python/docs/test-assertions.mdx
@@ -5,7 +5,6 @@ title: "Assertions"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## List of assertions
 

--- a/python/docs/test-runners.mdx
+++ b/python/docs/test-runners.mdx
@@ -5,7 +5,6 @@ title: "Pytest Plugin Reference"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/touch-events.mdx
+++ b/python/docs/touch-events.mdx
@@ -5,7 +5,6 @@ title: "Touch events (legacy)"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/trace-viewer-intro.mdx
+++ b/python/docs/trace-viewer-intro.mdx
@@ -5,7 +5,6 @@ title: "Trace viewer"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/trace-viewer.mdx
+++ b/python/docs/trace-viewer.mdx
@@ -5,7 +5,6 @@ title: "Trace viewer"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 import LiteYouTube from '@site/src/components/LiteYouTube';
 

--- a/python/docs/videos.mdx
+++ b/python/docs/videos.mdx
@@ -5,7 +5,6 @@ title: "Videos"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/webview2.mdx
+++ b/python/docs/webview2.mdx
@@ -5,7 +5,6 @@ title: "WebView2"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/python/docs/writing-tests.mdx
+++ b/python/docs/writing-tests.mdx
@@ -5,7 +5,6 @@ title: "Writing tests"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 
 ## Introduction
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -146,7 +146,6 @@ title: "${this.formatter.rewriteClassTitle?.(clazz.name) || clazz.name}"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';
 `});
     if (clazz.deprecated) {
       result.push({
@@ -433,7 +432,7 @@ ${this.documentation.renderLinksInText(member.discouraged)}
    */
   rewriteImageLinks(content) {
     return content.replaceAll(/!\[(.*)\]\((\.\/images\/.*)\)/g, (match, alt, link) => {
-      return `<ProgressiveImage image={require("${path.join('..', link)}")} alt="${alt}" />`;
+      return `![${alt}](${path.join('..', link)})`;
     });
   }
 
@@ -450,8 +449,7 @@ ${this.documentation.renderLinksInText(member.discouraged)}
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import HTMLCard from '@site/src/components/HTMLCard';
-import ProgressiveImage from '@theme/ProgressiveImage';`);
+import HTMLCard from '@site/src/components/HTMLCard';`);
   writeFileSyncCached(path.join(this.outDir, outName), this.rewriteVersion(this.mdxLinks(output)));
   }
 


### PR DESCRIPTION
Remove the actual usage of `ProgressiveImage` from `@docusaurus/plugin-ideal-image` in our `next` docs. Once `next` has rolled to be the primary docs, we can remove all references to `@docusaurus/plugin-ideal-image`.

The only human changes are in `src/generator.js`. The vast majority of docs have no changes, and the ones with images will have:

```diff
- <ProgressiveImage image={require("../images/vscode-projects-section.png")} alt="Projects section in VS Code extension" />
+ ![Projects section in VS Code extension](../images/vscode-projects-section.png)
```