### PR TITLE
docs: Update GitHub issue template links

### DIFF
--- a/community/0-welcome.mdx
+++ b/community/0-welcome.mdx
@@ -12,9 +12,10 @@ We love stars so make sure you [star us on GitHub](https://github.com/microsoft/
 
 Please create an issue for the following:
 
-- [Bug Reports](https://github.com/microsoft/playwright/issues/new?assignees=&labels=&template=bug.md&title=%5BBUG%5D)
-- [Feature Requests](https://github.com/microsoft/playwright/issues/new?assignees=&labels=&template=feature_request.md&title=%5BFeature%5D)
-- [Report Regression](https://github.com/microsoft/playwright/issues/new?assignees=&labels=&template=regression.md&title=%5BREGRESSION%5D%3A+)
+- [Bug Reports](https://github.com/microsoft/playwright/issues/new?template=bug.yml)
+- [Documentation Issues](https://github.com/microsoft/playwright/issues/new?template=documentation.yml)
+- [Feature Requests](https://github.com/microsoft/playwright/issues/new?template=feature.yml)
+- [Report Regression](https://github.com/microsoft/playwright/issues/new?template=regression.yml)
 - [Report a security vulnerability](https://github.com/microsoft/playwright/security/policy)
 
 ## Contributing


### PR DESCRIPTION
Use the 'new' templates links, and add link for 'Documentation Issues'.