### PR TITLE
docs: fix component testing reuse wording

### DIFF
--- a/nodejs/docs/test-components.mdx
+++ b/nodejs/docs/test-components.mdx
@@ -658,7 +658,7 @@ test('should work', async ({ mount }) => {
 
 Additionally, it adds some config options you can use in your `playwright-ct.config.{ts,js}`.
 
-Finally, under the hood, each test re-uses the `context` and `page` fixture as a speed optimization for Component Testing. It resets them in between each test so it should be functionally equivalent to `@playwright/test`'s guarantee that you get a new, isolated `context` and `page` fixture per-test.
+Finally, under the hood, each test reuses the `context` and `page` fixture as a speed optimization for Component Testing. It resets them in between each test so it should be functionally equivalent to `@playwright/test`'s guarantee that you get a new, isolated `context` and `page` fixture per-test.
 
 ### I have a project that already uses Vite. Can I reuse the config?
 


### PR DESCRIPTION
## Summary
- fix reuse wording in the component testing docs

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- reviewed the repository guidance in `README.md`
- kept the change to one docs file with no behavior impact

## Validation
- `git diff --check`
