### PR TITLE
docs: fix web server reuse wording

### DIFF
--- a/nodejs/docs/test-webserver.mdx
+++ b/nodejs/docs/test-webserver.mdx
@@ -39,7 +39,7 @@ export default defineConfig({
 | `ignoreHTTPSErrors` | Whether to ignore HTTPS errors when fetching the `url`. Defaults to `false`. |
 | `name` | Specifies a custom name for the web server. This name will be prefixed to log messages. Defaults to `[WebServer]`. |
 | `port` | **Deprecated**. Use `url` instead. The port that your http server is expected to appear on. It does wait until it accepts connections. Either `port` or `url` should be specified. |
-| `reuseExistingServer`| If `true`, it will re-use an existing server on the `port` or `url` when available. If no server is running on that `port` or `url`, it will run the command to start a new server. If `false`, it will throw if an existing process is listening on the `port` or `url`. This should be commonly set to `!process.env.CI` to allow the local dev server when running tests locally. |
+| `reuseExistingServer`| If `true`, it will reuse an existing server on the `port` or `url` when available. If no server is running on that `port` or `url`, it will run the command to start a new server. If `false`, it will throw if an existing process is listening on the `port` or `url`. This should be commonly set to `!process.env.CI` to allow the local dev server when running tests locally. |
 | `stderr` | Whether to pipe the stderr of the command to the process stderr or ignore it. Defaults to `"pipe"`. |
 | `stdout` | If `"pipe"`, it will pipe the stdout of the command to the process stdout. If `"ignore"`, it will ignore the stdout of the command. Default to `"ignore"`. |
 | `timeout` | How long to wait for the process to start up and be available in milliseconds. Defaults to 60000. |


### PR DESCRIPTION
## Summary
- fix reuse wording in the web server docs

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- reviewed the repository guidance in `README.md`
- kept the change to one docs file with no behavior impact

## Validation
- `git diff --check`
