### PR TITLE
docs: rebrand "Playwright MCP Bridge extension" to "Playwright Extension"

### DIFF
--- a/agent-cli/commands/attach.mdx
+++ b/agent-cli/commands/attach.mdx
@@ -13,7 +13,7 @@ Connect to an existing browser instead of launching a new one.
 | `attach --cdp=<channel>` | Connect to a running browser by channel name |
 | `attach --cdp=<url>` | Connect via Chrome DevTools Protocol endpoint |
 | `attach --endpoint=<url>` | Connect to a Playwright server endpoint |
-| `attach --extension` | Connect via Playwright MCP Bridge extension |
+| `attach --extension` | Connect via Playwright Extension |
 
 ## Attach by channel name
 
@@ -70,9 +70,9 @@ playwright-cli snapshot
 
 ## Browser extension
 
-Connect to your existing browser tabs using the [Playwright MCP Bridge extension](https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md). This lets you reuse your logged-in sessions, cookies, and installed extensions.
+Connect to your existing browser tabs using the [Playwright Extension](https://chromewebstore.google.com/detail/playwright-mcp-bridge/mmlmfjhmonkocbjadbfplnigmagldckm). This lets you reuse your logged-in sessions, cookies, and installed extensions.
 
-<img src="/img/mcp/chrome-bridge-extension.png" width="662" height="427" alt="Playwright MCP Bridge extension in Chrome Web Store" />
+<img src="/img/mcp/chrome-bridge-extension.png" width="662" height="427" alt="Playwright Extension in Chrome Web Store" />
 
 ```bash
 playwright-cli attach --extension

--- a/agent-cli/commands/attach.mdx
+++ b/agent-cli/commands/attach.mdx
@@ -13,7 +13,8 @@ Connect to an existing browser instead of launching a new one.
 | `attach --cdp=<channel>` | Connect to a running browser by channel name |
 | `attach --cdp=<url>` | Connect via Chrome DevTools Protocol endpoint |
 | `attach --endpoint=<url>` | Connect to a Playwright server endpoint |
-| `attach --extension` | Connect via Playwright Extension |
+| `attach --extension` | Connect via Playwright Extension (defaults to Chrome) |
+| `attach --extension=<channel>` | Connect via Playwright Extension to a specific channel |
 
 ## Attach by channel name
 
@@ -75,8 +76,16 @@ Connect to your existing browser tabs using the [Playwright Extension](https://c
 <img src="/img/mcp/chrome-bridge-extension.png" width="662" height="427" alt="Playwright Extension in Chrome Web Store" />
 
 ```bash
+# Attach to Chrome (default)
 playwright-cli attach --extension
+
+# Attach to a specific channel
+playwright-cli attach --extension=chrome-canary
+playwright-cli attach --extension=msedge
+playwright-cli attach --extension=msedge-dev
 ```
+
+If no channel is specified, the extension attaches to Chrome by default.
 
 ### When to use extension mode
 

--- a/mcp/configuration/browser-extension.mdx
+++ b/mcp/configuration/browser-extension.mdx
@@ -56,9 +56,9 @@ Works with Chrome/Chromium with `--remote-debugging-port`, Edge, Electron apps, 
 
 ## Connect via browser extension
 
-The [Playwright MCP Bridge extension](https://github.com/microsoft/playwright-mcp/blob/main/packages/extension/README.md) connects to your existing browser tabs, reusing your logged-in sessions, cookies, and installed extensions.
+The [Playwright Extension](https://chromewebstore.google.com/detail/playwright-mcp-bridge/mmlmfjhmonkocbjadbfplnigmagldckm) connects to your existing browser tabs, reusing your logged-in sessions, cookies, and installed extensions.
 
-<img src="/img/mcp/chrome-bridge-extension.png" width="662" height="427" alt="Playwright MCP Bridge extension in Chrome Web Store" />
+<img src="/img/mcp/chrome-bridge-extension.png" width="662" height="427" alt="Playwright Extension in Chrome Web Store" />
 
 1. Install the extension in Chrome or Edge
 2. Configure the MCP server:


### PR DESCRIPTION
## Summary
- Rename references to the browser extension in MCP and agent-cli docs from "Playwright MCP Bridge extension" to "Playwright Extension".
- Link directly to the Chrome Web Store listing instead of the package README.