### PR TITLE
fix(stars): always link star button to microsoft/playwright

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -105,7 +105,7 @@ const Home: React.FC = () => {
             <Link className={styles.getStarted} to="docs/intro">
               Get started
             </Link>
-            <GitHubStarButton owner="microsoft" repo={siteConfig.customFields.repositoryName as string} />
+            <GitHubStarButton owner="microsoft" repo="playwright" />
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- The star count shown on the home page comes from `microsoft/playwright` (~86k+), but the button on the Python/Java/.NET sites linked to the language-specific repo, whose count is much lower. Always link to `microsoft/playwright` so the link matches the displayed count.

Fixes https://github.com/microsoft/playwright.dev/issues/1239