### PR TITLE
chore(ci): bump actions to versions running on Node.js 24

### DIFF
--- a/.github/workflows/roll-next.yml
+++ b/.github/workflows/roll-next.yml
@@ -47,13 +47,13 @@ jobs:
           git add .
           git commit -m "feat(roll): roll to ToT Playwright ($(date +"%d-%m-%y"))"
           git push origin $BRANCH_NAME --force
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.PLAYWRIGHT_APP_ID }}
           private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
       - name: Create Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: ${{ steps.prepare-branch.outputs.HAS_CHANGES == '1' }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/roll-stable.yml
+++ b/.github/workflows/roll-stable.yml
@@ -69,14 +69,14 @@ jobs:
           git add "**/versions.json"
           git commit -m "feat(roll): roll to $VERSION Playwright"
           git push origin $BRANCH_NAME --force
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.PLAYWRIGHT_APP_ID }}
           private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
       - name: Check for existing Pull Request
         id: check-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -89,7 +89,7 @@ jobs:
             return pullRequests.length > 0 ? 'true' : 'false';
           result-encoding: string
       - name: Create Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: ${{ steps.prepare-branch.outputs.HAS_CHANGES == '1' && steps.check-pr.outputs.result == 'false' }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Bump `actions/create-github-app-token` from `@v1` to `@v3` and `actions/github-script` from `@v7` to `@v8` in the roll workflows so they run on Node.js 24.
- GitHub is forcing JavaScript actions to Node 24 by default on 2026-06-02 and removing Node 20 from runners on 2026-09-16.
