### PR TITLE
chore: auto-discover *-api doc directories

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -76,6 +76,7 @@ class Generator {
 
     this.documentation = parseApi(path.join(srcDir, 'api'))
       .mergeWith(parseApi(path.join(srcDir, 'electron-api'), path.join(srcDir, 'api', 'params.md')))
+      .mergeWith(parseApi(path.join(srcDir, 'mobile-api'), path.join(srcDir, 'api', 'params.md')))
       .mergeWith(parseApi(path.join(srcDir, 'test-api'), path.join(srcDir, 'api', 'params.md')))
       .mergeWith(parseApi(path.join(srcDir, 'test-reporter-api')));
     this.documentation.filterForLanguage(lang, { csharpOptionOverloadsShortNotation: true });

--- a/src/generator.js
+++ b/src/generator.js
@@ -74,11 +74,11 @@ class Generator {
     this.generatedFiles = new Set();
     this.formatter = formatter;
 
-    this.documentation = parseApi(path.join(srcDir, 'api'))
-      .mergeWith(parseApi(path.join(srcDir, 'electron-api'), path.join(srcDir, 'api', 'params.md')))
-      .mergeWith(parseApi(path.join(srcDir, 'mobile-api'), path.join(srcDir, 'api', 'params.md')))
-      .mergeWith(parseApi(path.join(srcDir, 'test-api'), path.join(srcDir, 'api', 'params.md')))
-      .mergeWith(parseApi(path.join(srcDir, 'test-reporter-api')));
+    const paramsPath = path.join(srcDir, 'api', 'params.md');
+    const apiDirs = fs.readdirSync(srcDir).filter(name => name === 'api' || name.endsWith('-api'));
+    this.documentation = apiDirs
+      .map(dir => parseApi(path.join(srcDir, dir), dir === 'api' ? undefined : paramsPath))
+      .reduce((acc, doc) => acc.mergeWith(doc));
     this.documentation.filterForLanguage(lang, { csharpOptionOverloadsShortNotation: true });
     this.documentation.setLinkRenderer(item => {
       const { clazz, member, param, option, href } = item;


### PR DESCRIPTION
## Summary
- Replace the hardcoded list (`api`, `electron-api`, `mobile-api`, `test-api`, `test-reporter-api`) with a glob over `srcDir` for `api` and `*-api`. New sibling dirs are picked up automatically.
- Unblocks the v1.60 roll: microsoft/playwright#40644 moved the Android classes into `docs/src/mobile-api/`, which made `[method: AndroidDevice.launchBrowser]` references in release notes unresolvable for `Roll Stable`.