### PR TITLE
Adjust `exec:java` examples to use test classpath scope

### DIFF
--- a/java/docs/codegen.mdx
+++ b/java/docs/codegen.mdx
@@ -21,7 +21,7 @@ When running the `codegen` command two windows will be opened, a browser window 
 Use the `codegen` command to run the test generator followed by the URL of the website you want to generate tests for. The URL is optional and you can always run the command without it and then add the URL directly into the browser window instead.
 
 ```bash
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen demo.playwright.dev/todomvc"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen demo.playwright.dev/todomvc"
 ```
 
 ### Recording a test
@@ -63,7 +63,7 @@ You can use the test generator to generate tests using emulation so as to genera
 Playwright opens a browser window with its viewport set to a specific width and height and is not responsive as tests need to be run under the same conditions. Use the `--viewport` option to generate tests with a different viewport size.
 
 ```bash
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen --viewport-size='800,600' playwright.dev"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen --viewport-size='800,600' playwright.dev"
 ```
 
 ###### 
@@ -74,7 +74,7 @@ mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="co
 Record scripts and tests while emulating a mobile device using the `--device` option which sets the viewport size and user agent among others.
 
 ```bash
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args='codegen --device="iPhone 13" playwright.dev'
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args='codegen --device="iPhone 13" playwright.dev'
 ```
 
 ###### 
@@ -85,7 +85,7 @@ mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args='co
 Record scripts and tests while emulating the color scheme with the `--color-scheme` option.
 
 ```bash
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen --color-scheme=dark playwright.dev"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen --color-scheme=dark playwright.dev"
 ```
 
 ###### 
@@ -98,7 +98,7 @@ Record scripts and tests while emulating timezone, language & location using the
 1. On the top right, click on the locate me button to see geolocation in action.
 
 ```bash
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args='codegen --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" bing.com/maps'
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args='codegen --timezone="Europe/Rome" --geolocation="41.890221,12.492348" --lang="it-IT" bing.com/maps'
 ```
 
 ###### 
@@ -109,7 +109,7 @@ mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args='co
 Run `codegen` with `--save-storage` to save [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies), [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) and [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) data at the end of the session. This is useful to separately record an authentication step and reuse it later when recording more tests.
 
 ```bash
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen github.com/microsoft/playwright  --save-storage=auth.json"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen github.com/microsoft/playwright  --save-storage=auth.json"
 ```
 
 ###### 
@@ -128,7 +128,7 @@ Make sure you only use the `auth.json` locally as it contains sensitive informat
 Run with `--load-storage` to consume the previously loaded storage from the `auth.json`. This way, all [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies), [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) and [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) data will be restored, bringing most web apps to the authenticated state without the need to login again. This means you can continue generating tests from the logged in state.
 
 ```bash
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen --load-storage=auth.json github.com/microsoft/playwright"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen --load-storage=auth.json github.com/microsoft/playwright"
 ```
 
 ###### 
@@ -144,7 +144,7 @@ Run `codegen` with `--user-data-dir` to set a fixed [user data directory](https:
 :::
 
 ```bash
-mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="codegen --user-data-dir=/path/to/your/browser/data/ github.com/microsoft/playwright"
+mvn exec:java -e -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="codegen --user-data-dir=/path/to/your/browser/data/ github.com/microsoft/playwright"
 ```
 
 ## Record using custom setup


### PR DESCRIPTION
For whatever reason https://playwright.dev/java/docs/intro proposes adding Playwright to compile scope. I guess that could make sense for a module which solely consists of Playwright tests, but I think a more typical setup would specify

```xml
<scope>test</scope>
```

In that environment, running `exec:java` commands as shown fails:

```
…
java.lang.ClassNotFoundException: com.microsoft.playwright.CLI
    at org.codehaus.mojo.exec.URLClassLoaderBuilder$ExecJavaClassLoader.loadClass (URLClassLoaderBuilder.java:211)
…
```

https://www.mojohaus.org/exec-maven-plugin/java-mojo.html#classpathScope is normally what you want (and this should work even for a project which _does_ have Playwright at `compile` scope).

I have also taken the liberty of conjoining the `key=value` with the `-D` in Maven options, which is more typical (when not using `--define`) although either format is accepted.