### PR TITLE
docs(cli): drop unsupported open flags from agent-cli configuration

### DIFF
--- a/agent-cli/configuration.mdx
+++ b/agent-cli/configuration.mdx
@@ -21,24 +21,6 @@ playwright-cli open --browser=webkit     # WebKit (Safari engine)
 playwright-cli open --browser=msedge     # Microsoft Edge
 ```
 
-## Device emulation
-
-```bash
-playwright-cli open --device="iPhone 15" https://example.com
-```
-
-## Viewport size
-
-```bash
-playwright-cli open --viewport-size=1280x720 https://example.com
-```
-
-## Proxy
-
-```bash
-playwright-cli open --proxy-server=http://myproxy:3128 --proxy-bypass=localhost,*.internal.com https://example.com
-```
-
 ## Profile modes
 
 ### In-memory (default)
@@ -263,14 +245,8 @@ See [Attach](./commands/attach.mdx) for details.
 playwright-cli open [url]                          # open browser
 playwright-cli open --headed                       # show browser window
 playwright-cli open --browser=firefox              # specific browser
-playwright-cli open --device="iPhone 15"           # device emulation
-playwright-cli open --viewport-size=1280x720       # viewport size
 playwright-cli open --persistent                   # persist profile to disk
 playwright-cli open --profile=<path>               # custom profile directory
-playwright-cli open --proxy-server=<url>           # proxy server
-playwright-cli open --proxy-bypass=<hosts>         # bypass proxy
-playwright-cli open --user-agent=<ua>              # custom user agent
-playwright-cli open --ignore-https-errors          # ignore HTTPS errors
 playwright-cli open --config=file.json             # use config file
 playwright-cli attach --extension                  # connect via extension
 playwright-cli attach --cdp <url>                  # connect via CDP


### PR DESCRIPTION
## Summary
- The Configuration page listed `--device`, `--viewport-size`, `--proxy-server`, `--proxy-bypass`, `--user-agent`, and `--ignore-https-errors` as `playwright-cli open` flags, but the command rejects them.
- Removed the misleading sections and matching lines in the "All open parameters" block. The `PLAYWRIGHT_MCP_*` env-var equivalents and the `contextOptions` config-file workaround still work and remain documented.

Fixes https://github.com/microsoft/playwright-cli/issues/405