### PR TITLE
feat: register codex tab label for docs

### DIFF
--- a/src/format_utils.js
+++ b/src/format_utils.js
@@ -110,6 +110,8 @@ function tabLabel(groupId, value) {
     return 'VS Code';
   if (value === 'claude')
     return 'Claude Code';
+  if (value === 'codex')
+    return 'Codex';
   if (value === 'opencode')
     return 'OpenCode';
   throw new Error(`Unknown label type: ${value}`)


### PR DESCRIPTION
## Summary
- Add `codex` to `format_utils.js` tab-label whitelist so `bash tab=bash-codex` blocks (microsoft/playwright#40817) roll cleanly