### PR TITLE
chore(ci): modernize workflow actions and use client-id

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - name: Setup Pages

--- a/.github/workflows/roll-next.yml
+++ b/.github/workflows/roll-next.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.PLAYWRIGHT_APP_ID }}
+          client-id: ${{ vars.PLAYWRIGHT_CLIENT_ID }}
           private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
       - name: Create Pull Request
         uses: actions/github-script@v8

--- a/.github/workflows/roll-next.yml
+++ b/.github/workflows/roll-next.yml
@@ -11,12 +11,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           repository: 'microsoft/playwright'
           path: playwright
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - name: Install dependencies

--- a/.github/workflows/roll-stable.yml
+++ b/.github/workflows/roll-stable.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.PLAYWRIGHT_APP_ID }}
+          client-id: ${{ vars.PLAYWRIGHT_CLIENT_ID }}
           private-key: ${{ secrets.PLAYWRIGHT_PRIVATE_KEY }}
       - name: Check for existing Pull Request
         id: check-pr

--- a/.github/workflows/roll-stable.yml
+++ b/.github/workflows/roll-stable.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         id: determine-version
         with:
           script: |

--- a/.github/workflows/roll-stable.yml
+++ b/.github/workflows/roll-stable.yml
@@ -25,13 +25,13 @@ jobs:
             });
             return relevantBranches.pop().name.replace(/^release-/, '');
           result-encoding: string
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           repository: 'microsoft/playwright'
           path: playwright
           ref: 'release-${{ steps.determine-version.outputs.result }}'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.59.0-noble
       options: --user 1001
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install dependencies
       run: npm ci
     - name: Build site


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` and `actions/setup-node` to `@v5` (Node.js 24) across all workflows, clearing the Node.js 20 deprecation warning ahead of the June 16 / Sept 16 2026 runner deadlines.
- Bump the `determine-version` step in roll-stable to `actions/github-script@v8` (it was still on `@v7`/Node 20).
- Replace the deprecated `app-id` input of `actions/create-github-app-token` with `client-id`, sourced from the new `PLAYWRIGHT_CLIENT_ID` repo variable, in both roll workflows.

Clears the deprecation annotations from https://github.com/microsoft/playwright.dev/actions/runs/26882695531

Note: the old `PLAYWRIGHT_APP_ID` repo variable is no longer referenced and can be removed after merge.