### PR TITLE
fix(search): align DocSearch v4 modal colors with the Playwright brand

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -112,6 +112,46 @@ x-search {
 }
 
 
-:root {
-  --docsearch-muted-color: #666c77 !important;
+/* ----------------------------------------------------------------------------
+   Algolia DocSearch — brand colour alignment
+   DocSearch v4 ships Algolia-blue/indigo accents and navy dark-mode surfaces
+   that clash with the Playwright palette. Docusaurus maps
+   --docsearch-primary-color to --ifm-color-primary (green), but the v4 accent
+   variables below are NOT mapped and keep their defaults, so we override them.
+   `:root:root` raises specificity above DocSearch's own later-injected `:root`
+   without needing !important. The Algolia logo stays blue on purpose: its SVG
+   uses hardcoded fills and the free tier requires the mark to stay unmodified.
+---------------------------------------------------------------------------- */
+:root:root {
+  /* Blue -> Playwright green: magnifier, search/back icons, links, hit marks */
+  --docsearch-highlight-color: var(--ifm-color-primary);
+  /* Selected result row + action hover: blue tint -> green tint */
+  --docsearch-hit-highlight-color: rgba(26, 126, 31, 0.1);
+  --docsearch-soft-primary-color: rgba(26, 126, 31, 0.1);
+  /* Indigo-tinted greys -> neutral */
+  --docsearch-muted-color: #666c77;
+  --docsearch-secondary-text-color: #5e6a75;
+  --docsearch-icon-color: #5e6a75;
+  --docsearch-subtle-color: #e3e3e7;
+}
+
+:root[data-theme='dark'] {
+  /* Navy/indigo surfaces -> neutral Playwright dark */
+  --docsearch-modal-background: #242526;
+  --docsearch-hit-background: #1b1b1d;
+  --docsearch-background-color: #1b1b1d;
+  --docsearch-text-color: #e3e3e3;
+  --docsearch-secondary-text-color: #a0a6ad;
+  --docsearch-icon-color: #a0a6ad;
+  --docsearch-subtle-color: #2a2a2c;
+  /* Brighter green tint for the selected row on dark backgrounds */
+  --docsearch-hit-highlight-color: rgba(69, 186, 75, 0.12);
+  --docsearch-soft-primary-color: rgba(69, 186, 75, 0.12);
+}
+
+/* The "no results" magnifier icon ships with a hardcoded indigo stroke
+   attribute (stroke="#5a5e9a") instead of reading a variable, so it ignores
+   the palette above. Neutralise it to match the other DocSearch icons. */
+.DocSearch-NoResults svg {
+  stroke: var(--docsearch-icon-color);
 }


### PR DESCRIPTION
## Summary

After the Docusaurus migration bumped Algolia DocSearch from v3 to v4, the search modal stopped picking up our brand color. DocSearch v4 moved its accent onto new CSS variables (`--docsearch-highlight-color` and friends) that Docusaurus's `theme-search-algolia` doesn't map to Infima — so on our green-branded site they fall back to Algolia blue/indigo, and dark mode renders navy surfaces.

This overrides the unmapped DocSearch v4 variables in `custom.css` so the search modal uses the Playwright green accent and neutral surfaces in both light and dark themes. Per DocSearch's styling docs, overriding these variables is the intended customization path for brand-colored sites.

### What changed
- **Accent:** magnifier, search/back icons, match highlights, links, and the selected-result row now use Playwright green instead of Algolia blue.
- **Dark surfaces:** modal / result / background surfaces go from navy-indigo to neutral Playwright dark (`#242526` / `#1b1b1d`).
- **Neutral greys:** indigo-tinted secondary text / icon / subtle colors neutralized.
- **"No results" icon:** its inline SVG hardcodes `stroke="#5a5e9a"` and ignores the variable palette, so it's neutralized with an explicit CSS rule.
- **Algolia logo intentionally left blue** — its SVG uses hardcoded fills and the free tier requires the mark to stay unmodified.

## Before / After

### Light mode
| Before | After |
| --- | --- |
| <img width="1100" height="820" alt="v4-light-before" src="https://github.com/user-attachments/assets/36e184bc-49bb-464c-9d88-e9a9e55899c9" /> | <img width="1100" height="820" alt="v4-light-after" src="https://github.com/user-attachments/assets/d7865649-f21c-4d6a-9963-93ff828beaf6" /> |

### Dark mode
| Before | After |
| --- | --- |
| <img width="1100" height="820" alt="v4-dark-before" src="https://github.com/user-attachments/assets/934d9b8d-93c2-4053-bfa3-3319c98604e7" /> | <img width="1100" height="820" alt="v4-dark-after" src="https://github.com/user-attachments/assets/9dfb92a2-d5b8-47fb-b487-684e970d306f" /> |

### "No results" icon
| Before | After |
| --- | --- |
| <img width="1100" height="820" alt="noresults-light" src="https://github.com/user-attachments/assets/16d6769b-b52f-42f1-914e-73d9cce99116" /> | <img width="1100" height="820" alt="noresults-light-after" src="https://github.com/user-attachments/assets/42221a3f-fc5f-4fc0-b54a-9d022a8c25b0" /> |

## Notes
- Scoped to `src/css/custom.css`; no config or dependency changes.
- Verified by inspecting the live computed `--docsearch-*` values in both themes on the running dev server.
