### PR TITLE
docs: update Twitter links to X

### DIFF
--- a/community/0-welcome.mdx
+++ b/community/0-welcome.mdx
@@ -44,7 +44,7 @@ Follow our [Blog](https://dev.to/playwright) on dev.to for official posts on Pla
 
 ## News {/* #news */}
 
-For the latest news about Playwright, [follow **@playwrightweb** on Twitter](https://twitter.com/playwrightweb).
+For the latest news about Playwright, [follow **@playwrightweb** on X](https://x.com/playwrightweb).
 
 ## Playwright Training {/* #training */}
 

--- a/dotnet/docusaurus.config.ts
+++ b/dotnet/docusaurus.config.ts
@@ -174,8 +174,8 @@ export default {
               href: "https://aka.ms/playwright/discord",
             },
             {
-              label: "Twitter",
-              href: "https://twitter.com/playwrightweb",
+              label: "X",
+              href: "https://x.com/playwrightweb",
             },
             {
               label: "LinkedIn",

--- a/java/docusaurus.config.ts
+++ b/java/docusaurus.config.ts
@@ -174,8 +174,8 @@ module.exports = {
               href: "https://aka.ms/playwright/discord",
             },
             {
-              label: "Twitter",
-              href: "https://twitter.com/playwrightweb",
+              label: "X",
+              href: "https://x.com/playwrightweb",
             },
             {
               label: "LinkedIn",

--- a/nodejs/docusaurus.config.ts
+++ b/nodejs/docusaurus.config.ts
@@ -200,8 +200,8 @@ export default {
               href: "https://aka.ms/playwright/discord",
             },
             {
-              label: "Twitter",
-              href: "https://twitter.com/playwrightweb",
+              label: "X",
+              href: "https://x.com/playwrightweb",
             },
             {
               label: "LinkedIn",

--- a/python/docusaurus.config.ts
+++ b/python/docusaurus.config.ts
@@ -175,8 +175,8 @@ export default {
               href: "https://aka.ms/playwright/discord",
             },
             {
-              label: "Twitter",
-              href: "https://twitter.com/playwrightweb",
+              label: "X",
+              href: "https://x.com/playwrightweb",
             },
             {
               label: "LinkedIn",


### PR DESCRIPTION
  - Update Playwright social link labels from `Twitter` to `X`
  - Replace `twitter.com/playwrightweb` links with `x.com/playwrightweb`
  - Apply the change across Node.js, Python, Java, .NET docs configs and the community page