### PR TITLE
fix: hide duplicate navbar logo during hydration

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -104,11 +104,14 @@ x-search {
   visibility: hidden;
 }
 
-/* Navbar logo uses ThemedComponent which sets display:none as base,
-   relying on [data-theme] selectors to show. This causes flicker
-   during navigation. Force it always visible since we use one logo. */
+/* Keep the shared light/dark logo visible during navigation, but hide the
+   duplicate image rendered before Docusaurus hydrates. */
 .navbar__brand img {
   display: initial !important;
+}
+
+.navbar__brand img + img {
+  display: none !important;
 }
 
 


### PR DESCRIPTION
https://github.com/microsoft/playwright.dev/pull/2014 introduced a bug with two logos being shown briefly on slow connections:

<img width="433" height="399" alt="Screenshot 2026-07-14 at 10 00 38" src="https://github.com/user-attachments/assets/c97319d4-5aec-46f1-901f-a1d8edf43fc5" />


This patch keeps the navigation-flicker workaround from https://github.com/microsoft/playwright.dev/pull/2014, but hides the second logo image rendered by Docusaurus before hydration.