### PR TITLE
fix(docs): migrate broken markdown links hook

### DIFF
--- a/dotnet/docusaurus.config.ts
+++ b/dotnet/docusaurus.config.ts
@@ -60,7 +60,11 @@ export default {
   organizationName: "microsoft",
   projectName: "playwright.dev",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: "throw",
+    },
+  },
   scripts: ["/dotnet/js/redirection.js"],
   favicon: "img/playwright-logo.ico",
   themeConfig: {

--- a/java/docusaurus.config.ts
+++ b/java/docusaurus.config.ts
@@ -60,7 +60,11 @@ module.exports = {
   organizationName: "microsoft",
   projectName: "playwright.dev",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: "throw",
+    },
+  },
   scripts: ["/java/js/redirection.js"],
   favicon: "img/playwright-logo.ico",
   themeConfig: {

--- a/nodejs/docusaurus.config.ts
+++ b/nodejs/docusaurus.config.ts
@@ -80,7 +80,11 @@ export default {
   organizationName: "microsoft",
   projectName: "playwright.dev",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: "throw",
+    },
+  },
   scripts: ["/js/redirection.js"],
   favicon: "img/playwright-logo.ico",
   themeConfig: {

--- a/python/docusaurus.config.ts
+++ b/python/docusaurus.config.ts
@@ -60,7 +60,11 @@ export default {
   organizationName: "microsoft",
   projectName: "playwright.dev",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: "throw",
+    },
+  },
   scripts: ["/python/js/redirection.js"],
   favicon: "img/playwright-logo.ico",
   themeConfig: {


### PR DESCRIPTION
Migrate deprecated `onBrokenMarkdownLinks` to `markdown.hooks.onBrokenMarkdownLinks` in nodejs/python/java/dotnet configs to remove Docusaurus warning.

See warning: https://github.com/microsoft/playwright.dev/actions/runs/29505500426/job/87645069266#step:6:19
See docs: https://docusaurus.io/docs/api/docusaurus-config#onBrokenMarkdownLinks