### PR TITLE
devops(pipeline): disable automatic publish runs

### DIFF
--- a/.azure-pipelines/publish.yml
+++ b/.azure-pipelines/publish.yml
@@ -1,3 +1,5 @@
+trigger: none
+
 resources:
   repositories:
   - repository: 1esPipelines


### PR DESCRIPTION
This PR disables automatic runs of the publish pipeline by setting `trigger: none`.