### PR TITLE
docs(cli): clarify what pause-at does

### DIFF
--- a/agent-cli/commands/test-debugging.mdx
+++ b/agent-cli/commands/test-debugging.mdx
@@ -34,7 +34,7 @@ And control execution:
 ```bash
 playwright-cli resume                   # continue
 playwright-cli step-over                # step to next action
-playwright-cli pause-at test.ts:42      # set a breakpoint
+playwright-cli pause-at test.ts:42      # run up to test.ts:42 and pause there
 ```
 
 ## Workflow: investigating a flaky test

--- a/agent-cli/commands/test-debugging.mdx
+++ b/agent-cli/commands/test-debugging.mdx
@@ -34,7 +34,7 @@ And control execution:
 ```bash
 playwright-cli resume                   # continue
 playwright-cli step-over                # step to next action
-playwright-cli pause-at test.ts:42      # run up to test.ts:42 and pause there
+playwright-cli pause-at test.ts:42      # run to that line and pause
 ```
 
 ## Workflow: investigating a flaky test


### PR DESCRIPTION
## Summary
- The Test Debugging page annotated `playwright-cli pause-at test.ts:42` as "set a breakpoint", but the command does not just arm a breakpoint: it resumes the paused test and runs it up to that location before pausing again (`browser_resume` with a `location` calls `debugger.runTo`).
- Reworded the comment to match, in line with the command's own description ("Run the test up to a specific location and pause there").

Fixes https://github.com/microsoft/playwright/issues/42389