### PR TITLE
Refactor: rename parameter 'ref' to 'target' in screenshots.mdx

### DIFF
--- a/mcp/tools/screenshots.mdx
+++ b/mcp/tools/screenshots.mdx
@@ -11,7 +11,7 @@ Capture the current page, a specific element, or the full scrollable page.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `type` | string | no | `png` (default) or `jpeg` |
-| `ref` | string | no | Element ref to screenshot a specific element |
+| `target` | string | no | Element ref to screenshot a specific element |
 | `fullPage` | boolean | no | Capture full scrollable page |
 
 ### Page screenshot
@@ -26,7 +26,7 @@ You: Take a screenshot of the current page.
 
 ```txt
 You: Take a screenshot of just the login form.
-→ browser_take_screenshot { ref: "e12" }
+→ browser_take_screenshot { target: "e12" }
 → Returns: PNG image cropped to the element
 ```
 


### PR DESCRIPTION
The documentation for browser_take_screenshot incorrectly lists ref as the parameter to capture a screenshot of a specific element. However, the actual JSON schema and implementation of @playwright/mcp expect the parameter name target.

When passing { ref: "e12" } as shown in the documentation, @playwright/mcp does not recognize ref, causing it to ignore the argument and default to capturing the full viewport instead of cropping to the specified element.

<!-- 
  Hey, thank you for your contribution!
  The actual source of the file which you are probably editing lives in this repository
  https://github.com/microsoft/playwright/blob/main/docs
  Thank you for doing the Pull Request there!
-->
