### PR TITLE
fix(docs): change ref to target in browser_take_screenshot

### DIFF
--- a/mcp/tools/screenshots.mdx
+++ b/mcp/tools/screenshots.mdx
@@ -11,7 +11,7 @@ Capture the current page, a specific element, or the full scrollable page.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `type` | string | no | `png` (default) or `jpeg` |
-| `ref` | string | no | Element ref to screenshot a specific element |
+| `target` | string | no | Exact target element reference from page snapshot |
 | `fullPage` | boolean | no | Capture full scrollable page |
 
 ### Page screenshot
@@ -26,7 +26,7 @@ You: Take a screenshot of the current page.
 
 ```txt
 You: Take a screenshot of just the login form.
-→ browser_take_screenshot { ref: "e12" }
+→ browser_take_screenshot { target: "e12" }
 → Returns: PNG image cropped to the element
 ```
 


### PR DESCRIPTION
## Summary

Fixes #42517

The documentation for browser_take_screenshot incorrectly listed `ref` as the parameter for element screenshots. The actual parameter is `target`, as used in the implementation.

## Changes

- Changed parameter name from `ref` to `target` in the parameters table
- Updated the example from `{ ref: "e12" }` to `{ target: "e12" }`

## Verification

The `target` parameter is confirmed in the implementation at `packages/playwright-core/src/tools/backend/screenshot.ts`.