### PR TITLE
fix(docs): use target for browser_take_screenshot element param

### DIFF
--- a/mcp/tools/screenshots.mdx
+++ b/mcp/tools/screenshots.mdx
@@ -11,7 +11,7 @@ Capture the current page, a specific element, or the full scrollable page.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `type` | string | no | `png` (default) or `jpeg` |
-| `ref` | string | no | Element ref to screenshot a specific element |
+| `target` | string | no | Exact target element reference (`ref`) from page snapshot or unique element selector |
 | `fullPage` | boolean | no | Capture full scrollable page |
 
 ### Page screenshot
@@ -26,7 +26,7 @@ You: Take a screenshot of the current page.
 
 ```txt
 You: Take a screenshot of just the login form.
-→ browser_take_screenshot { ref: "e12" }
+→ browser_take_screenshot { target: "e12" }
 → Returns: PNG image cropped to the element
 ```
 


### PR DESCRIPTION
## Summary
- Update `browser_take_screenshot` docs to use `target` instead of `ref`
- Matches the `@playwright/mcp` tool schema so element screenshots are cropped correctly

Fixes https://github.com/microsoft/playwright/issues/42517

## Test plan
- [ ] Confirm parameter table on `/mcp/tools/screenshots` shows `target`
- [ ] Confirm Element screenshot example uses `{ target: "e12" }`


Made with [Cursor](https://cursor.com)